### PR TITLE
Consolidate Husky pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+echo "🔍 Detecting changed packages..."
+
+# Get all staged files
+STAGED_FILES=$(git diff --cached --name-only)
+
+# Detect which packages have changes
+APP_CHANGED=false
+CURRICULUM_CHANGED=false
+INTERPRETERS_CHANGED=false
+
+for file in $STAGED_FILES; do
+  if echo "$file" | grep -q "^app/"; then
+    APP_CHANGED=true
+  elif echo "$file" | grep -q "^curriculum/"; then
+    CURRICULUM_CHANGED=true
+  elif echo "$file" | grep -q "^interpreters/"; then
+    INTERPRETERS_CHANGED=true
+  fi
+done
+
+# Run pre-commit hooks for changed packages
+FAILED=false
+
+if [ "$APP_CHANGED" = true ]; then
+  echo "\n📦 Running app pre-commit checks..."
+  cd app && ./scripts/pre-commit
+  if [ $? -ne 0 ]; then
+    FAILED=true
+  fi
+  cd ..
+fi
+
+if [ "$CURRICULUM_CHANGED" = true ]; then
+  echo "\n📦 Running curriculum pre-commit checks..."
+  cd curriculum && ./scripts/pre-commit
+  if [ $? -ne 0 ]; then
+    FAILED=true
+  fi
+  cd ..
+fi
+
+if [ "$INTERPRETERS_CHANGED" = true ]; then
+  echo "\n📦 Running interpreters pre-commit checks..."
+  cd interpreters && ./scripts/pre-commit
+  if [ $? -ne 0 ]; then
+    FAILED=true
+  fi
+  cd ..
+fi
+
+if [ "$FAILED" = true ]; then
+  echo "\n❌ Pre-commit checks failed in one or more packages"
+  exit 1
+fi
+
+if [ "$APP_CHANGED" = false ] && [ "$CURRICULUM_CHANGED" = false ] && [ "$INTERPRETERS_CHANGED" = false ]; then
+  echo "✅ No package files changed, skipping pre-commit checks"
+else
+  echo "\n✅ All pre-commit checks passed!"
+fi

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,6 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky",
     "knip": "knip"
   },
   "dependencies": {
@@ -71,7 +70,6 @@
     "babel-plugin-react-compiler": "19.1.0-rc.3",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "husky": "^9.1.7",
     "jest": "^30.1.3",
     "jest-environment-jsdom": "^30.1.2",
     "jest-puppeteer": "^11.0.0",

--- a/app/scripts/pre-commit
+++ b/app/scripts/pre-commit
@@ -11,7 +11,7 @@ fi
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' || true)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^app/||' || true)
 if [ -n "$STAGED_FILES" ]; then
     echo "Formatting: $STAGED_FILES"
     npx prettier --write $STAGED_FILES
@@ -22,7 +22,7 @@ fi
 
 # Run lint check on staged files only (treating warnings as errors)
 echo "🔍 Running lint check on staged files..."
-STAGED_TS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx|mjs)$' || true)
+STAGED_TS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs)$' | sed 's|^app/||' || true)
 if [ -n "$STAGED_TS_FILES" ]; then
     echo "Linting: $STAGED_TS_FILES"
     npx eslint $STAGED_TS_FILES --max-warnings=0

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky && pnpm run build"
+    "prepare": "pnpm run build"
   },
   "keywords": [
     "jiki",
@@ -46,7 +46,6 @@
     "@typescript-eslint/parser": "^8.44.0",
     "@vitest/ui": "^3.2.4",
     "eslint": "^9",
-    "husky": "^9.1.7",
     "jsdom": "^27.0.0",
     "onchange": "^7.1.0",
     "prettier": "^3.6.2",

--- a/curriculum/scripts/pre-commit
+++ b/curriculum/scripts/pre-commit
@@ -11,7 +11,7 @@ fi
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' || true)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^curriculum/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^curriculum/||' || true)
 if [ -n "$STAGED_FILES" ]; then
     echo "Formatting: $STAGED_FILES"
     npx prettier --write $STAGED_FILES
@@ -25,6 +25,14 @@ echo "🔍 Running lint check..."
 pnpm run lint --max-warnings=0
 if [ $? -ne 0 ]; then
     echo "❌ Lint check failed (errors or warnings found). Commit aborted."
+    exit 1
+fi
+
+# Run tests
+echo "🧪 Running tests..."
+pnpm test
+if [ $? -ne 0 ]; then
+    echo "❌ Tests failed. Commit aborted."
     exit 1
 fi
 

--- a/interpreters/package.json
+++ b/interpreters/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky && pnpm run build"
+    "prepare": "pnpm run build"
   },
   "keywords": [
     "jikiscript",
@@ -49,7 +49,6 @@
     "@typescript-eslint/parser": "^8.44.1",
     "esbuild": "^0.25.10",
     "eslint": "^9.36.0",
-    "husky": "^9.1.7",
     "marked": "^16.2.1",
     "prettier": "^3.6.2",
     "typescript": "^5.0.0",

--- a/interpreters/scripts/pre-commit
+++ b/interpreters/scripts/pre-commit
@@ -2,7 +2,7 @@ echo "Running pre-commit checks..."
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx|json|md|yml)$' || true)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^interpreters/" | grep -E '\.(ts|tsx|js|jsx|json|md|yml)$' | sed 's|^interpreters/||' || true)
 if [ -n "$STAGED_FILES" ]; then
     echo "Formatting: $STAGED_FILES"
     npx prettier --write $STAGED_FILES

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format": "pnpm -r format",
     "format:check": "pnpm -r format:check",
     "dev:app": "pnpm --filter @jiki/app dev",
-    "build:app": "pnpm --filter @jiki/app build"
+    "build:app": "pnpm --filter @jiki/app build",
+    "prepare": "husky"
   },
   "keywords": [
     "jiki",
@@ -25,5 +26,8 @@
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=10.0.0"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,6 @@ importers:
       eslint-config-next:
         specifier: 15.5.2
         version: 15.5.2(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       jest:
         specifier: ^30.1.3
         version: 30.2.0(@types/node@20.19.19)
@@ -226,9 +223,6 @@ importers:
       eslint:
         specifier: ^9
         version: 9.37.0(jiti@2.6.1)
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)
@@ -293,9 +287,6 @@ importers:
       eslint:
         specifier: ^9.36.0
         version: 9.37.0(jiti@2.6.1)
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       marked:
         specifier: ^16.2.1
         version: 16.3.0
@@ -6327,7 +6318,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.7.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
+      vitest: 3.2.4(@types/node@20.19.19)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
 
   '@vitest/utils@3.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
 
   app:
     dependencies:
@@ -6323,7 +6327,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.19)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
+      vitest: 3.2.4(@types/node@24.7.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary

Consolidates git pre-commit hooks from individual packages into a unified monorepo-level Husky setup:

- **Root hook orchestration**: `.husky/pre-commit` detects which packages have staged changes
- **Package-specific scripts**: Each package maintains its own `scripts/pre-commit` with quality checks
- **Smart filtering**: Only runs checks for packages with staged files
- **Path transformation**: Properly filters and transforms file paths for package-relative operations

## Changes

### Root Level
- Added `.husky/pre-commit` - Orchestrates package-specific hooks based on staged files
- Added `husky` to root `package.json` devDependencies
- Added `prepare: "husky"` script to initialize Husky

### Package Changes
- Moved `.husky/pre-commit` → `scripts/pre-commit` for each package
- Fixed path filtering to include package prefix (e.g., `grep "^app/"`)
- Added path transformation to strip package prefix (e.g., `sed 's|^app/||'`)
- Removed `husky` from individual package dependencies
- Removed `husky &&` from package `prepare` scripts

### Quality Checks per Package
Each package runs its own checks when files are staged:

**App**:
- TypeScript type checking
- Prettier formatting on staged files
- ESLint on staged TypeScript/JavaScript files
- Jest unit tests

**Curriculum**:
- TypeScript type checking
- Prettier formatting on staged files
- ESLint (full project)
- Vitest tests

**Interpreters**:
- Prettier formatting on staged files
- ESLint (full project)
- TypeScript type checking
- Vitest tests
- Benchmark tests

## Test Plan

- [x] Verified pre-commit hook runs for each package with staged changes
- [x] Confirmed file paths are correctly filtered and transformed
- [x] All quality checks pass (formatting, linting, type checking, tests)
- [x] Hook properly skips packages without staged changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)