### PR TITLE
Fix flaky timeline completion E2E test

### DIFF
--- a/app/tests/e2e/complex-exercise/timeline-completion.test.ts
+++ b/app/tests/e2e/complex-exercise/timeline-completion.test.ts
@@ -152,8 +152,11 @@ describe("Timeline Completion and Restart E2E", () => {
     // Click play again
     await page.click('[data-ci="play-button"]');
 
-    // Wait just a moment
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Wait for isPlaying to become true
+    await page.waitForFunction(() => {
+      const orchestrator = (window as any).testOrchestrator;
+      return orchestrator.getStore().getState().isPlaying === true;
+    });
 
     // Verify time was NOT reset to 0 (should resume)
     const timeAfterResume = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- Fix race condition in timeline completion E2E test that caused intermittent failures
- Replace fixed 100ms timeout with `page.waitForFunction()` to poll for `isPlaying` state

## Details
The test "should resume from current position when clicking play after manual pause" was failing intermittently because it used a fixed 100ms timeout after clicking the play button, which wasn't always enough time for the state to update.

The fix uses `page.waitForFunction()` to actively wait for `isPlaying === true`, which is the same pattern used throughout other E2E tests in the codebase.

## Test plan
- [x] Run the specific test multiple times to verify it passes consistently
- [x] All unit tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)