### PR TITLE
Add break and continue statements to JavaScript interpreter

### DIFF
--- a/interpreters/TODO.md
+++ b/interpreters/TODO.md
@@ -67,7 +67,7 @@ For everything in here, base your work in the JikiScript interpreter.
 - [x] Add the ability to call external functions. Look at the JikiScript implementation of this. We'll use a standard CallExpression but we'll check to see if the function is external and use it if so. We need to keep the format the same in terms of using ExecutionContext etc. The same external functions contract needs to apply to all three languages and should be made generic.
 - [x] Add the ability to create functions using the function keyword. Keep things very minimal for now. Only have normal args (not spread etc). Confirm exactly which options to support. Add return with or without a value. Don't worry about bindings (this etc) at this stage. Keep things close to JikiScript functions. Check that code.
 - [x] Look at all JS stdlib methods on existing data types and implement a stub for each that raises a NotYetAvailable error, that says that this method isn't available to students yet in this exercise. Have a list of method names in an array that does this, rather than writing a stub for every one.
-- [ ] Add break and continue. Look at JikiScript for inspiration.
+- [x] Add break and continue. Look at JikiScript for inspiration.
 - [ ] Add for ... of ... loop.
 - [ ] Add tests for `else if`
 - [ ] Add const.

--- a/interpreters/src/javascript/describers/describeBreakStatement.ts
+++ b/interpreters/src/javascript/describers/describeBreakStatement.ts
@@ -1,0 +1,7 @@
+import type { Description, DescriptionContext, FrameWithResult } from "../../shared/frames";
+
+export function describeBreakStatement(_fr: FrameWithResult, _dc: DescriptionContext): Description {
+  const result = `<p>This line immediately exited the loop.</p>`;
+  const steps = [`<li>JavaScript saw this and decided to move on to after this loop.</li>`];
+  return { result, steps };
+}

--- a/interpreters/src/javascript/describers/describeContinueStatement.ts
+++ b/interpreters/src/javascript/describers/describeContinueStatement.ts
@@ -1,0 +1,7 @@
+import type { Description, DescriptionContext, FrameWithResult } from "../../shared/frames";
+
+export function describeContinueStatement(_fr: FrameWithResult, _dc: DescriptionContext): Description {
+  const result = `<p>This line stopped running any more code in this iteration.</p>`;
+  const steps = [`<li>JavaScript saw this and decided to move on to the next iteration.</li>`];
+  return { result, steps };
+}

--- a/interpreters/src/javascript/error.ts
+++ b/interpreters/src/javascript/error.ts
@@ -48,6 +48,8 @@ export type SyntaxErrorType =
   | "IfStatementNotAllowed"
   | "ForStatementNotAllowed"
   | "WhileStatementNotAllowed"
+  | "BreakStatementNotAllowed"
+  | "ContinueStatementNotAllowed"
   | "MissingRightParenthesisAfterArguments"
   // Function-related errors
   | "NestedFunctionDeclaration"

--- a/interpreters/src/javascript/evaluation-result.ts
+++ b/interpreters/src/javascript/evaluation-result.ts
@@ -115,3 +115,11 @@ export interface EvaluationResultReturnStatement {
   jikiObject: JikiObject;
   immutableJikiObject: JikiObject;
 }
+
+export interface EvaluationResultBreakStatement {
+  type: "BreakStatement";
+}
+
+export interface EvaluationResultContinueStatement {
+  type: "ContinueStatement";
+}

--- a/interpreters/src/javascript/executor/executeBreakStatement.ts
+++ b/interpreters/src/javascript/executor/executeBreakStatement.ts
@@ -1,0 +1,20 @@
+import type { Executor } from "../executor";
+import type { BreakStatement } from "../statement";
+import type { EvaluationResultBreakStatement } from "../evaluation-result";
+import type { Location } from "../../shared/location";
+
+export class BreakFlowControlError extends Error {
+  constructor(public location: Location) {
+    super();
+  }
+}
+
+export function executeBreakStatement(executor: Executor, statement: BreakStatement): void {
+  const result: EvaluationResultBreakStatement = {
+    type: "BreakStatement",
+  };
+
+  executor.addSuccessFrame(statement.location, result as any, statement);
+
+  throw new BreakFlowControlError(statement.location);
+}

--- a/interpreters/src/javascript/executor/executeContinueStatement.ts
+++ b/interpreters/src/javascript/executor/executeContinueStatement.ts
@@ -1,0 +1,23 @@
+import type { Executor } from "../executor";
+import type { ContinueStatement } from "../statement";
+import type { EvaluationResultContinueStatement } from "../evaluation-result";
+import type { Location } from "../../shared/location";
+
+export class ContinueFlowControlError extends Error {
+  constructor(
+    public location: Location,
+    public lexeme: string
+  ) {
+    super();
+  }
+}
+
+export function executeContinueStatement(executor: Executor, statement: ContinueStatement): void {
+  const result: EvaluationResultContinueStatement = {
+    type: "ContinueStatement",
+  };
+
+  executor.addSuccessFrame(statement.location, result as any, statement);
+
+  throw new ContinueFlowControlError(statement.location, statement.keyword.lexeme);
+}

--- a/interpreters/src/javascript/frameDescribers.ts
+++ b/interpreters/src/javascript/frameDescribers.ts
@@ -8,6 +8,8 @@ import { describeBlockStatement } from "./describers/describeBlockStatement";
 import { describeIfStatement } from "./describers/describeIfStatement";
 import { describeCallExpression } from "./describers/describeCallExpression";
 import { describeReturnStatement } from "./describers/describeReturnStatement";
+import { describeBreakStatement } from "./describers/describeBreakStatement";
+import { describeContinueStatement } from "./describers/describeContinueStatement";
 
 // JavaScript-specific frame extending the shared base
 export interface JavaScriptFrame extends Frame {
@@ -71,6 +73,10 @@ function generateDescription(frame: FrameWithResult, context: DescriptionContext
     }
     case "ReturnStatement":
       return describeReturnStatement(frame, context);
+    case "BreakStatement":
+      return describeBreakStatement(frame, context);
+    case "ContinueStatement":
+      return describeContinueStatement(frame, context);
   }
   return null;
 }

--- a/interpreters/src/javascript/interfaces.ts
+++ b/interpreters/src/javascript/interfaces.ts
@@ -19,7 +19,9 @@ export type NodeType =
   | "BlockStatement"
   | "IfStatement"
   | "ForStatement"
-  | "WhileStatement";
+  | "WhileStatement"
+  | "BreakStatement"
+  | "ContinueStatement";
 
 export interface LanguageFeatures {
   excludeList?: string[];

--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -34,7 +34,9 @@
       "MissingParameterName": "Missing parameter name in function declaration.",
       "DuplicateParameterName": "Duplicate parameter name '{{name}}' in function declaration.",
       "MissingRightParenthesisAfterParameters": "Missing closing parenthesis ')' after function parameters.",
-      "MissingLeftBraceBeforeFunctionBody": "Missing opening brace '{' before function body."
+      "MissingLeftBraceBeforeFunctionBody": "Missing opening brace '{' before function body.",
+      "BreakStatementNotAllowed": "Break statements are not allowed at your current learning level.",
+      "ContinueStatementNotAllowed": "Continue statements are not allowed at your current learning level."
     },
     "runtime": {
       "ArgumentError": "{{message}}",
@@ -49,6 +51,8 @@
       "UnsupportedOperation": "This operation is not supported.",
       "VariableNotDeclared": "The variable '{{name}}' has not been declared.",
       "ReturnOutsideFunction": "You used the 'return' keyword, but you're not inside a function. Return statements can only be used inside functions.",
+      "BreakOutsideLoop": "You used the 'break' keyword, but you're not inside a loop. Break statements can only be used inside for or while loops.",
+      "ContinueOutsideLoop": "You used the 'continue' keyword, but you're not inside a loop. Continue statements can only be used inside for or while loops.",
       "MethodNotYetImplemented": "The method '{{method}}' exists but has not been implemented yet. It will be available in a future version.",
       "MethodNotYetAvailable": "The method '{{method}}' is not available at your current learning level. Keep progressing to unlock this feature!",
       "NonJikiObjectDetectedInExecution": "Internal error: Expected a JikiObject but received {{receivedType}}: {{receivedValue}}. This is a bug in the interpreter."

--- a/interpreters/src/javascript/locales/system/translation.json
+++ b/interpreters/src/javascript/locales/system/translation.json
@@ -34,7 +34,9 @@
       "MissingParameterName": "MissingParameterName",
       "DuplicateParameterName": "DuplicateParameterName: name: {{name}}",
       "MissingRightParenthesisAfterParameters": "MissingRightParenthesisAfterParameters",
-      "MissingLeftBraceBeforeFunctionBody": "MissingLeftBraceBeforeFunctionBody"
+      "MissingLeftBraceBeforeFunctionBody": "MissingLeftBraceBeforeFunctionBody",
+      "BreakStatementNotAllowed": "BreakStatementNotAllowed",
+      "ContinueStatementNotAllowed": "ContinueStatementNotAllowed"
     },
     "runtime": {
       "ArgumentError": "ArgumentError: {{message}}",
@@ -49,6 +51,8 @@
       "UnsupportedOperation": "UnsupportedOperation",
       "VariableNotDeclared": "VariableNotDeclared: name: {{name}}",
       "ReturnOutsideFunction": "ReturnOutsideFunction",
+      "BreakOutsideLoop": "BreakOutsideLoop",
+      "ContinueOutsideLoop": "ContinueOutsideLoop",
       "MethodNotYetImplemented": "MethodNotYetImplemented: method: {{method}}",
       "MethodNotYetAvailable": "MethodNotYetAvailable: method: {{method}}",
       "NonJikiObjectDetectedInExecution": "NonJikiObjectDetectedInExecution: receivedType: {{receivedType}}: receivedValue: {{receivedValue}}"

--- a/interpreters/src/javascript/parser.ts
+++ b/interpreters/src/javascript/parser.ts
@@ -27,6 +27,8 @@ import {
   FunctionDeclaration,
   FunctionParameter,
   ReturnStatement,
+  BreakStatement,
+  ContinueStatement,
 } from "./statement";
 import { type Token, type TokenType } from "./token";
 import { translate } from "./translator";
@@ -80,6 +82,8 @@ export class Parser {
       IfStatement: "If statements",
       ForStatement: "For loops",
       WhileStatement: "While loops",
+      BreakStatement: "Break statements",
+      ContinueStatement: "Continue statements",
     };
     return friendlyNames[nodeType] || nodeType;
   }
@@ -131,6 +135,16 @@ export class Parser {
       // Handle return statements
       if (this.match("RETURN")) {
         return this.returnStatement(this.previous());
+      }
+
+      // Handle break statements
+      if (this.match("BREAK")) {
+        return this.breakStatement(this.previous());
+      }
+
+      // Handle continue statements
+      if (this.match("CONTINUE")) {
+        return this.continueStatement(this.previous());
       }
 
       // Handle variable declarations
@@ -381,6 +395,22 @@ export class Parser {
 
     const semicolonToken = this.consumeSemicolon();
     return new ReturnStatement(returnToken, expression, Location.between(returnToken, semicolonToken));
+  }
+
+  private breakStatement(breakToken: Token): Statement {
+    // Check if BreakStatement is allowed
+    this.checkNodeAllowed("BreakStatement", "BreakStatementNotAllowed", breakToken.location);
+
+    const semicolonToken = this.consumeSemicolon();
+    return new BreakStatement(breakToken, Location.between(breakToken, semicolonToken));
+  }
+
+  private continueStatement(continueToken: Token): Statement {
+    // Check if ContinueStatement is allowed
+    this.checkNodeAllowed("ContinueStatement", "ContinueStatementNotAllowed", continueToken.location);
+
+    const semicolonToken = this.consumeSemicolon();
+    return new ContinueStatement(continueToken, Location.between(continueToken, semicolonToken));
   }
 
   private expression(): Expression {

--- a/interpreters/src/javascript/scanner.ts
+++ b/interpreters/src/javascript/scanner.ts
@@ -568,12 +568,10 @@ export class Scanner {
     // Check for unimplemented tokens
     const unimplementedTokens: TokenType[] = [
       // Statement keywords
-      "BREAK",
       "CASE",
       "CATCH",
       "CLASS",
       "CONST",
-      "CONTINUE",
       "DEBUGGER",
       "DEFAULT",
       "DELETE",

--- a/interpreters/src/javascript/statement.ts
+++ b/interpreters/src/javascript/statement.ts
@@ -146,3 +146,27 @@ export class ReturnStatement extends Statement {
     return this.expression ? [this.expression] : [];
   }
 }
+
+export class BreakStatement extends Statement {
+  constructor(
+    public keyword: Token,
+    public location: Location
+  ) {
+    super("BreakStatement");
+  }
+  public children() {
+    return [];
+  }
+}
+
+export class ContinueStatement extends Statement {
+  constructor(
+    public keyword: Token,
+    public location: Location
+  ) {
+    super("ContinueStatement");
+  }
+  public children() {
+    return [];
+  }
+}

--- a/interpreters/tests/javascript/concepts/break-continue.test.ts
+++ b/interpreters/tests/javascript/concepts/break-continue.test.ts
@@ -1,0 +1,158 @@
+import { interpret } from "@javascript/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
+
+describe("break", () => {
+  test("break in for loop", () => {
+    const { success, frames } = interpret(
+      `
+      let x = 0;
+      for (let i = 1; i <= 5; i = i + 1) {
+        if (i === 3) {
+          break;
+        }
+        x = x + i;
+      }
+    `,
+      {}
+    );
+    expect(success).toBe(true);
+    // x should be 1 + 2 = 3 (stops before i=3)
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.variables?.x?.value).toBe(3);
+  });
+
+  test("break in while loop", () => {
+    const { success, frames } = interpret(
+      `
+      let x = 0;
+      let i = 1;
+      while (i <= 5) {
+        if (i === 3) {
+          break;
+        }
+        x = x + i;
+        i = i + 1;
+      }
+    `,
+      {}
+    );
+    expect(success).toBe(true);
+    // x should be 1 + 2 = 3 (stops before i=3)
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.variables?.x?.value).toBe(3);
+  });
+
+  test("break outside loop is runtime error", () => {
+    const { frames, success } = interpret(
+      `
+      let x = 5;
+      break;
+    `,
+      {}
+    );
+    expect(success).toBe(false);
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.status).toBe("ERROR");
+    expect(lastFrame.error?.message).toMatch(/BreakOutsideLoop/);
+  });
+});
+
+describe("continue", () => {
+  test("continue in for loop", () => {
+    const { success, frames } = interpret(
+      `
+      let x = 0;
+      for (let i = 1; i <= 5; i = i + 1) {
+        if (i === 3) {
+          continue;
+        }
+        x = x + i;
+      }
+    `,
+      {}
+    );
+    expect(success).toBe(true);
+    // x should be 1 + 2 + 4 + 5 = 12 (skip 3)
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.variables?.x?.value).toBe(12);
+  });
+
+  test("continue in while loop", () => {
+    const { success, frames } = interpret(
+      `
+      let x = 0;
+      let i = 0;
+      while (i < 5) {
+        i = i + 1;
+        if (i === 3) {
+          continue;
+        }
+        x = x + i;
+      }
+    `,
+      {}
+    );
+    expect(success).toBe(true);
+    // x should be 1 + 2 + 4 + 5 = 12 (skip 3)
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.variables?.x?.value).toBe(12);
+  });
+
+  test("continue outside loop is runtime error", () => {
+    const { frames, success } = interpret(
+      `
+      let x = 5;
+      continue;
+    `,
+      {}
+    );
+    expect(success).toBe(false);
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.status).toBe("ERROR");
+    expect(lastFrame.error?.message).toMatch(/ContinueOutsideLoop/);
+  });
+});
+
+describe("nested loops", () => {
+  test("break only exits inner loop", () => {
+    const { success, frames } = interpret(
+      `
+      let x = 0;
+      for (let i = 1; i <= 3; i = i + 1) {
+        for (let j = 1; j <= 3; j = j + 1) {
+          if (j === 2) {
+            break;
+          }
+          x = x + i * 10 + j;
+        }
+      }
+    `,
+      {}
+    );
+    expect(success).toBe(true);
+    // x should be 11 + 21 + 31 = 63 (only first j in each outer loop iteration)
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.variables?.x?.value).toBe(63);
+  });
+
+  test("continue only affects inner loop", () => {
+    const { success, frames } = interpret(
+      `
+      let x = 0;
+      for (let i = 1; i <= 3; i = i + 1) {
+        for (let j = 1; j <= 3; j = j + 1) {
+          if (j === 2) {
+            continue;
+          }
+          x = x + i * 10 + j;
+        }
+      }
+    `,
+      {}
+    );
+    expect(success).toBe(true);
+    // x should be 11 + 13 + 21 + 23 + 31 + 33 = 132 (skip j=2 in each iteration)
+    const lastFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(lastFrame.variables?.x?.value).toBe(132);
+  });
+});

--- a/interpreters/tests/javascript/scanner.test.ts
+++ b/interpreters/tests/javascript/scanner.test.ts
@@ -500,12 +500,10 @@ describe.skip("synthetic", () => {
 describe("JavaScript - Unimplemented Tokens", () => {
   describe("Unimplemented Keywords", () => {
     const unimplementedKeywords = [
-      { token: "break", type: "BREAK" },
       { token: "case", type: "CASE" },
       { token: "catch", type: "CATCH" },
       { token: "class", type: "CLASS" },
       { token: "const", type: "CONST" },
-      { token: "continue", type: "CONTINUE" },
       { token: "debugger", type: "DEBUGGER" },
       { token: "default", type: "DEFAULT" },
       { token: "delete", type: "DELETE" },


### PR DESCRIPTION
## Summary

- Implements `break` and `continue` flow control statements for JavaScript loops (for and while)
- Follows JikiScript pattern of exception-based flow control
- Generates frames before throwing exceptions for proper UI visualization
- All 8 new tests passing, no regressions (2119 tests total)

## Implementation Details

**Flow Control Pattern:**
- Created `BreakFlowControlError` and `ContinueFlowControlError` exception classes
- Added `executeLoop()` helper to catch break exceptions
- Added `executeLoopIteration()` helper to catch continue exceptions
- Both executors generate success frames BEFORE throwing (for frame-by-frame UI)

**AST & Parser:**
- Added `BreakStatement` and `ContinueStatement` AST node classes
- Implemented parser methods with node restriction checks
- Removed BREAK and CONTINUE from scanner's unimplemented tokens

**Error Handling:**
- `BreakOutsideLoop` and `ContinueOutsideLoop` runtime errors for top-level usage
- Flow control errors bubble through execution until caught by loop handlers
- Top-level detection in `withExecutionContext()` generates proper error frames

**Tests:**
- Comprehensive test suite covering all scenarios: for loops, while loops, nested loops
- Tests verify correct variable values to ensure accurate loop behavior
- Removed obsolete scanner tests for unimplemented tokens

## Test Results

```
✓ tests/javascript/concepts/break-continue.test.ts (8 tests)
✓ All 2119 tests passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)