### PR TITLE
Remove redundant pnpm-workspace.yaml files

### DIFF
--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,4 +1,0 @@
-packages:
-  - "."
-  - "../interpreters"
-  - "../curriculum"

--- a/curriculum/pnpm-workspace.yaml
+++ b/curriculum/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-packages:
-  - "."
-  - "../interpreters"


### PR DESCRIPTION
## Summary

- Remove `pnpm-workspace.yaml` files from `app/` and `curriculum/` subdirectories
- The root-level `pnpm-workspace.yaml` is sufficient for the entire monorepo

Having multiple workspace files is not supported by pnpm and can cause conflicts. The single root workspace configuration properly manages all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)