### PR TITLE
Add success modal on all tests passing

### DIFF
--- a/app/components/complex-exercise/lib/types.ts
+++ b/app/components/complex-exercise/lib/types.ts
@@ -24,6 +24,7 @@ export interface OrchestratorState {
   currentTest: TestResult | null;
   hasCodeBeenEdited: boolean;
   isSpotlightActive: boolean;
+  wasSuccessModalShown: boolean;
   foldedLines: number[]; // Line numbers that are currently folded in the editor
   language: "javascript" | "python" | "jikiscript";
 
@@ -81,6 +82,7 @@ export interface OrchestratorActions {
   setCurrentTestTime: (time: number, nearestOrExactFrame?: "nearest" | "exact", force?: boolean) => void;
   setHasCodeBeenEdited: (value: boolean) => void;
   setIsSpotlightActive: (value: boolean) => void;
+  setWasSuccessModalShown: (value: boolean) => void;
   setFoldedLines: (lines: number[]) => void;
   setLanguage: (language: OrchestratorState["language"]) => void;
 

--- a/app/components/complex-exercise/ui/test-results-view/InspectedTestResultView.tsx
+++ b/app/components/complex-exercise/ui/test-results-view/InspectedTestResultView.tsx
@@ -8,7 +8,7 @@ import { TestResultInfo } from "./TestResultInfo";
 
 export function InspectedTestResultView() {
   const orchestrator = useOrchestrator();
-  const { currentTest } = useOrchestratorStore(orchestrator);
+  const { currentTest, isSpotlightActive } = useOrchestratorStore(orchestrator);
 
   const result = currentTest ? (currentTest as unknown as TestResult) : null;
   const viewContainerRef = useRef<HTMLDivElement | null>(null);
@@ -55,7 +55,10 @@ export function InspectedTestResultView() {
       />
 
       <div
-        className="spotlight flex-grow relative p-2.5 bg-white [container-type:size] min-w-[300px] aspect-square flex-shrink"
+        className={assembleClassNames(
+          "flex-grow relative p-2.5 bg-white [container-type:size] min-w-[300px] aspect-square flex-shrink",
+          isSpotlightActive && "spotlight"
+        )}
         ref={viewContainerRef}
       />
     </div>

--- a/app/lib/modal/modals/ExerciseSuccessModal.tsx
+++ b/app/lib/modal/modals/ExerciseSuccessModal.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { hideModal } from "../store";
+
+interface ExerciseSuccessModalProps {
+  title?: string;
+  message?: string;
+  buttonText?: string;
+}
+
+export function ExerciseSuccessModal({
+  title = "Congratulations!",
+  message = "All tests passed! You've successfully completed this exercise.",
+  buttonText = "Continue"
+}: ExerciseSuccessModalProps) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-green-700">{title}</h2>
+      <div className="text-gray-600">
+        <p>{message}</p>
+      </div>
+      <div className="flex justify-center mt-6">
+        <button
+          onClick={hideModal}
+          className="px-6 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
+        >
+          {buttonText}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/lib/modal/modals/index.ts
+++ b/app/lib/modal/modals/index.ts
@@ -1,13 +1,15 @@
 import { ConfirmationModal } from "./ConfirmationModal";
 import { ExampleModal } from "./ExampleModal";
+import { ExerciseSuccessModal } from "./ExerciseSuccessModal";
 import { InfoModal } from "./InfoModal";
 
 // Export all modals
-export { ConfirmationModal, ExampleModal, InfoModal };
+export { ConfirmationModal, ExampleModal, ExerciseSuccessModal, InfoModal };
 
 // Available modals registry
 export const availableModals = {
   "example-modal": ExampleModal,
   "confirmation-modal": ConfirmationModal,
-  "info-modal": InfoModal
+  "info-modal": InfoModal,
+  "exercise-success-modal": ExerciseSuccessModal
 };

--- a/app/tests/mocks/orchestrator-store.ts
+++ b/app/tests/mocks/orchestrator-store.ts
@@ -17,6 +17,7 @@ export function mockStore(overrides: Partial<OrchestratorStore> = {}) {
       currentTest: null,
       hasCodeBeenEdited: false,
       isSpotlightActive: false,
+      wasSuccessModalShown: false,
       foldedLines: [],
       language: "jikiscript" as const,
 
@@ -88,6 +89,7 @@ export function mockStore(overrides: Partial<OrchestratorStore> = {}) {
         }),
       setHasCodeBeenEdited: jest.fn(),
       setIsSpotlightActive: jest.fn(),
+      setWasSuccessModalShown: jest.fn(),
       setFoldedLines: jest.fn(),
       setLanguage: jest.fn(),
 

--- a/app/tests/unit/components/complex-exercise/ui/CodeEditor.test.tsx
+++ b/app/tests/unit/components/complex-exercise/ui/CodeEditor.test.tsx
@@ -46,6 +46,7 @@ describe("CodeEditor", () => {
       currentTest: null,
       hasCodeBeenEdited: false,
       isSpotlightActive: false,
+      wasSuccessModalShown: false,
       foldedLines: [],
       language: "jikiscript" as const,
       defaultCode: "const x = 1;",


### PR DESCRIPTION
## Summary

Implements a celebration flow when all tests pass:
- Shows test running with **spotlight class** during animation
- Displays **success modal** when animation completes
- Tracks modal state to prevent showing it multiple times

## Implementation Details

### State Management
- Added `wasSuccessModalShown` to orchestrator state
- Added `setWasSuccessModalShown()` action
- Reset flag on new test runs to allow multiple celebrations

### Spotlight Behavior
- `isSpotlightActive` is set to `true` when all tests pass (in `setTestSuiteResult()`)
- Spotlight class is applied to the test result view container
- Spotlight is disabled when modal appears

### Modal Flow
1. Tests run and all pass → `isSpotlightActive = true`
2. Test animation plays with spotlight active
3. Animation completes → check if all tests passed and modal not shown
4. Show success modal and set `wasSuccessModalShown = true`, `isSpotlightActive = false`
5. Modal only shows once per test run

### Files Changed
- `components/complex-exercise/lib/types.ts` - Added state and action types
- `components/complex-exercise/lib/orchestrator/store.ts` - Implemented spotlight and modal logic
- `components/complex-exercise/ui/test-results-view/InspectedTestResultView.tsx` - Conditional spotlight class
- `lib/modal/modals/ExerciseSuccessModal.tsx` - New modal component
- `lib/modal/modals/index.ts` - Register new modal
- `tests/mocks/orchestrator-store.ts` - Updated mocks
- `tests/unit/components/complex-exercise/ui/CodeEditor.test.tsx` - Updated test mock

## Testing
- ✅ TypeScript compilation passes
- ✅ All 753 tests pass
- ✅ Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)