### PR TITLE
Fix pre-commit hooks to format and lint renamed files

### DIFF
--- a/app/scripts/pre-commit
+++ b/app/scripts/pre-commit
@@ -11,7 +11,7 @@ fi
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^app/||' || true)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^app/||' || true)
 if [ -n "$STAGED_FILES" ]; then
     echo "Formatting: $STAGED_FILES"
     pnpm exec prettier --write $STAGED_FILES
@@ -22,7 +22,7 @@ fi
 
 # Run lint check on staged files only (treating warnings as errors)
 echo "🔍 Running lint check on staged files..."
-STAGED_TS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs)$' | sed 's|^app/||' || true)
+STAGED_TS_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs)$' | sed 's|^app/||' || true)
 if [ -n "$STAGED_TS_FILES" ]; then
     echo "Linting: $STAGED_TS_FILES"
     pnpm exec eslint $STAGED_TS_FILES --max-warnings=0

--- a/curriculum/scripts/pre-commit
+++ b/curriculum/scripts/pre-commit
@@ -11,7 +11,7 @@ fi
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^curriculum/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^curriculum/||' || true)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^curriculum/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^curriculum/||' || true)
 if [ -n "$STAGED_FILES" ]; then
     echo "Formatting: $STAGED_FILES"
     pnpm exec prettier --write $STAGED_FILES

--- a/interpreters/scripts/pre-commit
+++ b/interpreters/scripts/pre-commit
@@ -2,7 +2,7 @@ echo "Running pre-commit checks..."
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^interpreters/" | grep -E '\.(ts|tsx|js|jsx|json|md|yml)$' | sed 's|^interpreters/||' || true)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^interpreters/" | grep -E '\.(ts|tsx|js|jsx|json|md|yml)$' | sed 's|^interpreters/||' || true)
 if [ -n "$STAGED_FILES" ]; then
     echo "Formatting: $STAGED_FILES"
     pnpm exec prettier --write $STAGED_FILES


### PR DESCRIPTION
## Summary

Fixed pre-commit hooks across all three packages to properly format and lint renamed/moved files.

## Problem

The pre-commit hooks were using `--diff-filter=ACM` which only processes:
- **A**dded files
- **C**opied files
- **M**odified files

This excluded **R**enamed files, causing formatting and linting to be skipped when files were moved or renamed.

## Solution

Updated `--diff-filter=ACM` to `--diff-filter=ACMR` in all pre-commit scripts to include renamed files.

## Changes

- `app/scripts/pre-commit` - Updated 2 instances (formatter and linter)
- `curriculum/scripts/pre-commit` - Updated 1 instance (formatter)
- `interpreters/scripts/pre-commit` - Updated 1 instance (formatter)

## Testing

All pre-commit checks pass:
- ✅ TypeScript type checking
- ✅ Code formatting
- ✅ Linting
- ✅ All tests (app: 760 tests, curriculum: 65 tests, interpreters: 2228 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)