### PR TITLE
Fix success modal showing on every test run

### DIFF
--- a/app/components/coding-exercise/lib/orchestrator/store.ts
+++ b/app/components/coding-exercise/lib/orchestrator/store.ts
@@ -296,8 +296,7 @@ export function createOrchestratorStore(exerciseUuid: string, initialCode: strin
           hasCodeBeenEdited: false,
           status: "success",
           testCurrentTimes: {},
-          // Reset success modal tracking for new test runs
-          wasSuccessModalShown: false,
+          // wasSuccessModalShown is NOT reset - it's a one-way flag (false -> true)
           // Enable spotlight if all tests passed
           isSpotlightActive: allTestsPassed
         });

--- a/app/tests/unit/components/coding-exercise/orchestrator/store-auto-play.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/store-auto-play.test.ts
@@ -343,7 +343,7 @@ describe("Store Auto-Play Behavior", () => {
         expect(store.getState().isSpotlightActive).toBe(false);
       });
 
-      it("should reset wasSuccessModalShown to false on new test run", () => {
+      it("should NOT reset wasSuccessModalShown when running tests again", () => {
         const store = createOrchestratorStore("test-uuid", "");
 
         // Simulate modal was shown previously
@@ -355,9 +355,11 @@ describe("Store Auto-Play Behavior", () => {
           status: "pass" as const
         };
 
+        // Run tests again (without code changes)
         store.getState().setTestSuiteResult(testResults);
 
-        expect(store.getState().wasSuccessModalShown).toBe(false);
+        // Modal state should persist - it should NOT be reset
+        expect(store.getState().wasSuccessModalShown).toBe(true);
       });
     });
 


### PR DESCRIPTION
## Summary
- Fixed bug where success modal was appearing after every successful test suite run instead of only after the first one
- Made `wasSuccessModalShown` a one-way flag that is never reset except at orchestrator initialization

## Root Cause
The `setTestSuiteResult()` method was resetting `wasSuccessModalShown: false` on every test run. This meant:
1. User clicks "Run" → `setTestSuiteResult()` resets flag to `false`
2. Animation completes → modal shows, flag set to `true`
3. User clicks "Run" again → `setTestSuiteResult()` resets flag to `false` AGAIN
4. Animation completes → modal shows AGAIN (bug)

## Changes
- **`store.ts:300`**: Removed `wasSuccessModalShown: false` from the state reset in `setTestSuiteResult()`
- **`store-auto-play.test.ts:346-363`**: Updated test to verify the flag persists across multiple test runs

## Test Plan
- [x] Test verifies `wasSuccessModalShown` stays `true` after running tests multiple times
- [x] All 771 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)