### PR TITLE
Fix animation not playing after second test run

### DIFF
--- a/app/components/coding-exercise/lib/orchestrator/store.ts
+++ b/app/components/coding-exercise/lib/orchestrator/store.ts
@@ -299,7 +299,9 @@ export function createOrchestratorStore(exerciseUuid: string, initialCode: strin
           // Reset success modal tracking for new test runs
           wasSuccessModalShown: false,
           // Enable spotlight if all tests passed
-          isSpotlightActive: allTestsPassed
+          isSpotlightActive: allTestsPassed,
+          // Reset playing state to allow animations to play on new test suite
+          isPlaying: false
         });
 
         // Also set the first test as current by default

--- a/app/tests/unit/components/coding-exercise/orchestrator/store-animation-replay.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/store-animation-replay.test.ts
@@ -1,0 +1,155 @@
+import { createOrchestratorStore } from "@/components/coding-exercise/lib/orchestrator/store";
+import type { TestResult } from "@/components/coding-exercise/lib/test-results-types";
+
+// Mock modal system
+jest.mock("@/lib/modal", () => ({
+  showModal: jest.fn()
+}));
+
+// Mock TimelineManager
+jest.mock("@/components/coding-exercise/lib/orchestrator/TimelineManager", () => ({
+  TimelineManager: {
+    findNearestFrame: jest.fn((frames) => frames[0]),
+    findPrevFrame: jest.fn(),
+    findNextFrame: jest.fn()
+  }
+}));
+
+// Mock BreakpointManager
+jest.mock("@/components/coding-exercise/lib/orchestrator/BreakpointManager", () => ({
+  BreakpointManager: {
+    findPrevBreakpointFrame: jest.fn(),
+    findNextBreakpointFrame: jest.fn()
+  }
+}));
+
+describe("Store Animation Replay Bug", () => {
+  const createMockTest = (slug: string, frames: any[] = []): TestResult => ({
+    slug,
+    name: slug,
+    status: "pass" as const,
+    expects: [],
+    view: document.createElement("div"),
+    frames,
+    animationTimeline: {
+      play: jest.fn(),
+      pause: jest.fn(),
+      seek: jest.fn(),
+      onUpdate: jest.fn(),
+      onComplete: jest.fn(),
+      clearUpdateCallbacks: jest.fn(),
+      clearCompleteCallbacks: jest.fn(),
+      completed: false,
+      currentTime: 0
+    } as any
+  });
+
+  it("should reset isPlaying when setting new test suite results", () => {
+    const store = createOrchestratorStore("test-uuid", "");
+
+    // First test run - with frames (will auto-play)
+    const firstTest = createMockTest("test-1", [
+      {
+        time: 0,
+        timeInMs: 0,
+        line: 1,
+        code: "move()",
+        status: "SUCCESS" as const,
+        generateDescription: () => "Frame 1"
+      }
+    ]);
+
+    const firstResults = {
+      tests: [firstTest],
+      status: "pass" as const
+    };
+
+    store.getState().setTestSuiteResult(firstResults);
+
+    // Verify animation started playing
+    expect(store.getState().isPlaying).toBe(true);
+    expect(firstTest.animationTimeline.play).toHaveBeenCalledTimes(1);
+
+    // Second test run - with different frames
+    const secondTest = createMockTest("test-2", [
+      {
+        time: 0,
+        timeInMs: 0,
+        line: 1,
+        code: "move()",
+        status: "SUCCESS" as const,
+        generateDescription: () => "Frame 1"
+      },
+      {
+        time: 100,
+        timeInMs: 0.1,
+        line: 2,
+        code: "turn_left()",
+        status: "SUCCESS" as const,
+        generateDescription: () => "Frame 2"
+      }
+    ]);
+
+    const secondResults = {
+      tests: [secondTest],
+      status: "pass" as const
+    };
+
+    store.getState().setTestSuiteResult(secondResults);
+
+    // BUG: Without resetting isPlaying, the second animation won't play
+    // because setIsPlaying(true) will return early if isPlaying is already true
+    expect(store.getState().isPlaying).toBe(true);
+    expect(secondTest.animationTimeline.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("should allow animation to play after empty/failed first run", () => {
+    const store = createOrchestratorStore("test-uuid", "");
+
+    // First test run - empty repeat loop (no frames)
+    const firstTest = createMockTest("test-1", []);
+
+    const firstResults = {
+      tests: [firstTest],
+      status: "fail" as const
+    };
+
+    // Manually set isPlaying to true to simulate the bug state
+    // (In reality this might happen if animation completed but state wasn't reset)
+    store.getState().setTestSuiteResult(firstResults);
+
+    // Simulate isPlaying being stuck at true from previous run
+    store.getState().setIsPlaying(true);
+
+    // Second test run - valid movement code with frames
+    const secondTest = createMockTest("test-2", [
+      {
+        time: 0,
+        timeInMs: 0,
+        line: 1,
+        code: "move()",
+        status: "SUCCESS" as const,
+        generateDescription: () => "Frame 1"
+      },
+      {
+        time: 100,
+        timeInMs: 0.1,
+        line: 2,
+        code: "move()",
+        status: "SUCCESS" as const,
+        generateDescription: () => "Frame 2"
+      }
+    ]);
+
+    const secondResults = {
+      tests: [secondTest],
+      status: "pass" as const
+    };
+
+    store.getState().setTestSuiteResult(secondResults);
+
+    // The bug: If isPlaying isn't reset, setIsPlaying(true) will return early
+    // and animationTimeline.play() won't be called
+    expect(secondTest.animationTimeline.play).toHaveBeenCalledTimes(1);
+  });
+});

--- a/interpreters/TODO.md
+++ b/interpreters/TODO.md
@@ -65,7 +65,7 @@ For everything in here, base your work in the JikiScript interpreter.
 
 - [x] Add the ability to call external functions. Look at the JavaScript implementation of this. We'll use a standard CallExpression but we'll check to see if the function is external and use it if so. We need to keep the format the same in terms of using ExecutionContext etc. The same external functions contract needs to apply to all three languages and should be made generic.
 - [x] Add a while loop. Look at the JavaScript implementation.
-- [ ] Add fstrings
+- [ ] Add fstrings. Look at JS template literals for the pattern.
 - [ ] Don't allow statements that don't actually do anything. For example, a statement that is just a variable. Or a grouping expression that doesn't have assignment. Add a TOOD that you will need to modify this for calling functions (which should just be allowed by themselves) later. Look at how this works in JikiScript as there is a specific type for it.
 - [ ] Implement the next Python built-in function from [.context/python/features-and-functions.md](.context/python/features-and-functions.md). Only mark this as complete when all functions in the "Including" list are done. Ensure to move each function from TODO to Implemented in the context document when finished. Remember to confirm the plan with the human before implementing each function.
 - [ ] Implement equivalent tests to the Numbers block in JikiScript's syntaxErrors.test.ts file. Only apply tests where the rules are appropriate for Python. Look at the JikiScript implementation of how this error message is managed.


### PR DESCRIPTION
## Summary

Fixes a bug where animations wouldn't play on the second test run because the `isPlaying` state wasn't reset between test runs.

## Problem

When running code tests multiple times:
1. First run: Empty repeat loop → test fails (or has no animation frames)
2. Second run: Valid movement code → test passes but **animation doesn't play**

The button showed the "playing" state (pause icon) and scrubbing worked, but auto-play didn't work.

## Root Cause

In `setTestSuiteResult()`, the `isPlaying` state was not being reset. This caused:

1. First test run sets `isPlaying: true` when animation starts
2. Second test run calls `setTestSuiteResult()` but doesn't reset `isPlaying`
3. When `setCurrentTest()` tries to call `setIsPlaying(true)`, it returns early because `isPlaying` is already `true` (line 317 in store.ts)
4. This prevents `animationTimeline.play()` from being called

## Solution

Reset `isPlaying: false` in `setTestSuiteResult()` to ensure animations can start fresh on each test run.

## Testing

Added comprehensive tests in `store-animation-replay.test.ts` that:
- Verify the bug by running two test suites sequentially
- Confirm `animationTimeline.play()` is called on both runs
- Test the specific scenario of empty frames followed by valid frames

All existing store tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)