### PR TITLE
Simplify JavaScript template literal token handling

### DIFF
--- a/interpreters/src/javascript/parser.ts
+++ b/interpreters/src/javascript/parser.ts
@@ -887,7 +887,7 @@ export class Parser {
     while (!this.check("BACKTICK") && !this.isAtEnd()) {
       if (this.match("TEMPLATE_LITERAL_TEXT")) {
         parts.push(this.previous().literal as string);
-      } else if (this.match("DOLLAR_LEFT_BRACE")) {
+      } else if (this.match("LEFT_BRACE")) {
         // Parse the interpolated expression
         const expr = this.expression();
         this.consume("RIGHT_BRACE", "MissingRightBraceInTemplateLiteral");

--- a/interpreters/src/javascript/scanner.ts
+++ b/interpreters/src/javascript/scanner.ts
@@ -421,7 +421,7 @@ export class Scanner {
 
         this.advance(); // Consume the $
         this.advance(); // Consume the {
-        this.addToken("DOLLAR_LEFT_BRACE");
+        this.addToken("LEFT_BRACE");
         this.start = this.current;
 
         let braceCount = 1;


### PR DESCRIPTION
## Summary

Simplifies JavaScript template literal implementation by removing the unnecessary `DOLLAR_LEFT_BRACE` token type in favor of using the standard `LEFT_BRACE` token.

## Rationale

The parser already knows it's in template literal context when parsing interpolated expressions, so a distinct token type is not needed. The scanner still handles brace counting correctly to track nested structures (object literals, nested template literals, etc.) within interpolated expressions.

## Changes

- **Scanner** (`src/javascript/scanner.ts`): Changed from emitting `DOLLAR_LEFT_BRACE` to `LEFT_BRACE`
- **Parser** (`src/javascript/parser.ts`): Changed from checking for `DOLLAR_LEFT_BRACE` to `LEFT_BRACE`

## Testing

✅ All 1,112 JavaScript tests pass (33 skipped)

## Benefits

- Cleaner code with fewer special-case tokens
- Consistent with how other languages handle similar constructs
- Serves as the pattern for Python f-string implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)