### PR TITLE
Add array mutating methods: push, pop, shift, unshift

### DIFF
--- a/interpreters/.context/javascript/architecture.md
+++ b/interpreters/.context/javascript/architecture.md
@@ -139,6 +139,10 @@ Provides built-in properties and methods for JavaScript types with feature flag 
   - `length`: Returns the number of elements in the array
 - Implemented Methods:
   - `at(index)`: Returns element at index (supports negative indices)
+  - `push(...elements)`: Adds one or more elements to the end, returns new length
+  - `pop()`: Removes and returns the last element
+  - `shift()`: Removes and returns the first element
+  - `unshift(...elements)`: Adds one or more elements to the beginning, returns new length
 
 **Strings** (`src/javascript/stdlib/string/`):
 
@@ -148,8 +152,8 @@ Provides built-in properties and methods for JavaScript types with feature flag 
   - `toUpperCase()`: Returns uppercase version of the string
   - `toLowerCase()`: Returns lowercase version of the string
 - Stubbed Methods (throw MethodNotYetImplemented when called):
-  - All standard JS array methods: `push`, `pop`, `shift`, `unshift`, `indexOf`, `includes`, `slice`, `concat`, `join`, `forEach`, `map`, `filter`, `reduce`, etc.
-  - Stub methods still return function objects for correct semantics (e.g., `arr.push` returns a function)
+  - All standard JS array methods not yet implemented: `indexOf`, `includes`, `slice`, `concat`, `join`, `forEach`, `map`, `filter`, `reduce`, etc.
+  - Stub methods still return function objects for correct semantics
 
 **Access Patterns**:
 

--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -1,5 +1,91 @@
 # JavaScript Interpreter Evolution
 
+## 2025-10-07: Added Array Mutating Methods (push, pop, shift, unshift)
+
+### Overview
+
+Implemented four essential array mutating methods (`push`, `pop`, `shift`, `unshift`) that modify arrays in place. Refactored JSArray to use native JavaScript array methods for improved maintainability and 100% compatibility with native behavior.
+
+### Changes Applied
+
+**1. JSArray Refactoring** (`src/javascript/jsObjects/JSArray.ts`):
+
+- Changed `elements` field from `private readonly` to `public readonly`
+- This allows stdlib methods to directly access and use native JavaScript array methods
+- The array reference is readonly but contents remain mutable, enabling proper method behavior
+
+**2. Refactored at() Method** (`src/javascript/stdlib/array/at.ts`):
+
+- Updated to use native `array.elements.at(index)` instead of custom logic
+- Simplified implementation while maintaining all existing behavior
+- Ensures 100% compatibility with JavaScript's native `at()` method
+
+**3. Implemented Mutating Methods**:
+
+- **push()** (`src/javascript/stdlib/array/push.ts`):
+  - Accepts variable arguments (arity: `[1, Infinity]`)
+  - Uses native `array.elements.push(...args)`
+  - Returns JSNumber with new array length
+
+- **pop()** (`src/javascript/stdlib/array/pop.ts`):
+  - Accepts no arguments (arity: `0`)
+  - Uses native `array.elements.pop()`
+  - Returns removed element or JSUndefined if array is empty
+
+- **shift()** (`src/javascript/stdlib/array/shift.ts`):
+  - Accepts no arguments (arity: `0`)
+  - Uses native `array.elements.shift()`
+  - Returns removed first element or JSUndefined if array is empty
+
+- **unshift()** (`src/javascript/stdlib/array/unshift.ts`):
+  - Accepts variable arguments (arity: `[1, Infinity]`)
+  - Uses native `array.elements.unshift(...args)`
+  - Returns JSNumber with new array length
+
+**4. Stdlib Registry Updates** (`src/javascript/stdlib/array/index.ts`):
+
+- Removed `push`, `pop`, `shift`, `unshift` from `notYetImplementedMethods` list
+- Added imports and exports for all four new methods
+
+**5. Test Infrastructure Improvements**:
+
+- Moved `TestAugmentedFrame` type from inline definitions to `src/shared/frames.ts` for reuse
+- Updated all test files (JavaScript and Python) to import from shared location
+- Ensures type consistency across the entire test suite
+
+**6. Comprehensive Test Coverage**:
+
+- **Unit tests** (`tests/javascript/array-properties-methods.test.ts`):
+  - Added 14 new tests covering all four methods
+  - Tests for basic functionality, edge cases, return values, mutations
+  - Tests for argument validation (too many/few arguments)
+
+- **Cross-validation tests** (`tests/cross-validation/javascript/stdlib/array-methods.test.ts`):
+  - Added 17 new tests verifying implementation matches native JavaScript
+  - Tests for push/pop/shift/unshift with various scenarios
+  - Verifies mutations, return values, and array state changes
+
+- **Error tests** (`tests/javascript/stdlib-errors.test.ts`):
+  - Updated to reflect that push/pop/shift/unshift are now implemented
+  - Changed test cases to use other unimplemented methods (indexOf, etc.)
+
+### Benefits of Native Method Approach
+
+- **Simpler code**: No need to reimplement JavaScript's array logic
+- **100% compatibility**: Native methods guarantee matching behavior
+- **Easier maintenance**: Less custom code to maintain and debug
+- **Future-proof**: Easy to add more array methods using the same pattern
+
+### Supported Syntax
+
+```javascript
+let arr = [1, 2, 3];
+arr.push(4); // Returns 4 (new length)
+arr.pop(); // Returns 4 (removed element)
+arr.shift(); // Returns 1 (first element)
+arr.unshift(0); // Returns 3 (new length)
+```
+
 ## 2025-10-07: Added Exponentiation Operator (`**`)
 
 ### Overview

--- a/interpreters/TODO.md
+++ b/interpreters/TODO.md
@@ -39,7 +39,7 @@ For everything in here, base your work in the JikiScript interpreter.
 - [x] Add template literals.
 - [x] Add a specific error type if someone tries to use a const in a for loop.
 - [x] Add Exponentiation.
-- [ ] Add array mutating methods: `push()`, `pop()`, `shift()`, `unshift()`. These modify the array in place and should follow the stdlib pattern like `.length` and `.at()`. Look at `src/javascript/stdlib/arrays.ts` for the pattern.
+- [x] Add array mutating methods: `push()`, `pop()`, `shift()`, `unshift()`. These modify the array in place and should follow the stdlib pattern like `.length` and `.at()`. Look at `src/javascript/stdlib/arrays.ts` for the pattern.
 - [ ] Add array query methods: `indexOf()`, `includes()`. These search the array and return values without mutating. Follow the same stdlib pattern.
 - [ ] Add array transformation methods: `slice()`, `concat()`, `join()`. These create new values from the array. `slice()` and `concat()` return new arrays, `join()` returns a string.
 - [ ] Add string `.length` property. Follow the same stdlib pattern as array `.length`.

--- a/interpreters/src/javascript/jsObjects/JSArray.ts
+++ b/interpreters/src/javascript/jsObjects/JSArray.ts
@@ -2,7 +2,7 @@ import { JikiObject } from "../../shared/jikiObject";
 import { JSString } from "./JSString";
 
 export class JSArray extends JikiObject {
-  private readonly elements: JikiObject[];
+  public readonly elements: JikiObject[];
 
   constructor(elements: JikiObject[]) {
     super("list");

--- a/interpreters/src/javascript/stdlib/array/at.ts
+++ b/interpreters/src/javascript/stdlib/array/at.ts
@@ -21,16 +21,9 @@ export const at: Method = {
     // We match this behavior for compatibility (e.g., arr.at(1.5) returns arr[1])
     const index = Math.trunc(indexArg.value);
 
-    // Handle negative indices
-    const actualIndex = index < 0 ? array.length + index : index;
-
-    // Check bounds and get element
-    if (actualIndex < 0 || actualIndex >= array.length) {
-      return new JSUndefined();
-    }
-
-    const element = array.getElement(actualIndex);
-    return element || new JSUndefined();
+    // Use native JavaScript at() method
+    const element = array.elements.at(index);
+    return element ?? new JSUndefined();
   },
   description: "returns the element at the specified index, supporting negative indices",
 };

--- a/interpreters/src/javascript/stdlib/array/index.ts
+++ b/interpreters/src/javascript/stdlib/array/index.ts
@@ -4,6 +4,10 @@ import { createNotYetImplementedStub } from "../index";
 // Import implemented properties and methods
 import { length } from "./length";
 import { at } from "./at";
+import { push } from "./push";
+import { pop } from "./pop";
+import { shift } from "./shift";
+import { unshift } from "./unshift";
 
 // Array properties
 export const arrayProperties: Record<string, Property> = {
@@ -13,10 +17,6 @@ export const arrayProperties: Record<string, Property> = {
 // List of array methods that are not yet implemented
 const notYetImplementedMethods = [
   // Mutating methods
-  "push",
-  "pop",
-  "shift",
-  "unshift",
   "splice",
   "sort",
   "reverse",
@@ -60,6 +60,10 @@ const notYetImplementedMethods = [
 // Array methods
 export const arrayMethods: Record<string, Method> = {
   at,
+  push,
+  pop,
+  shift,
+  unshift,
 
   // Generate stub methods for all not-yet-implemented methods
   ...Object.fromEntries(notYetImplementedMethods.map(name => [name, createNotYetImplementedStub(name)])),

--- a/interpreters/src/javascript/stdlib/array/pop.ts
+++ b/interpreters/src/javascript/stdlib/array/pop.ts
@@ -1,0 +1,21 @@
+import type { JSArray, JikiObject } from "../../jsObjects";
+import { JSUndefined } from "../../jsObjects";
+import type { ExecutionContext } from "../../executor";
+import type { Method } from "../index";
+import { guardNoArgs } from "../guards";
+
+export const pop: Method = {
+  arity: 0,
+  call: (_ctx: ExecutionContext, obj: JikiObject, args: JikiObject[]) => {
+    const array = obj as JSArray;
+
+    // Validate no arguments
+    guardNoArgs(args, "pop");
+
+    // Use native JavaScript pop() method
+    const element = array.elements.pop();
+
+    return element ?? new JSUndefined();
+  },
+  description: "removes and returns the last element of the array",
+};

--- a/interpreters/src/javascript/stdlib/array/push.ts
+++ b/interpreters/src/javascript/stdlib/array/push.ts
@@ -1,0 +1,21 @@
+import type { JSArray, JikiObject } from "../../jsObjects";
+import { JSNumber } from "../../jsObjects";
+import type { ExecutionContext } from "../../executor";
+import type { Method } from "../index";
+import { guardArgRange } from "../guards";
+
+export const push: Method = {
+  arity: [1, Infinity],
+  call: (_ctx: ExecutionContext, obj: JikiObject, args: JikiObject[]) => {
+    const array = obj as JSArray;
+
+    // Validate at least one argument
+    guardArgRange(args, 1, Infinity, "push");
+
+    // Use native JavaScript push() method
+    const newLength = array.elements.push(...args);
+
+    return new JSNumber(newLength);
+  },
+  description: "adds one or more elements to the end of the array and returns the new length",
+};

--- a/interpreters/src/javascript/stdlib/array/shift.ts
+++ b/interpreters/src/javascript/stdlib/array/shift.ts
@@ -1,0 +1,21 @@
+import type { JSArray, JikiObject } from "../../jsObjects";
+import { JSUndefined } from "../../jsObjects";
+import type { ExecutionContext } from "../../executor";
+import type { Method } from "../index";
+import { guardNoArgs } from "../guards";
+
+export const shift: Method = {
+  arity: 0,
+  call: (_ctx: ExecutionContext, obj: JikiObject, args: JikiObject[]) => {
+    const array = obj as JSArray;
+
+    // Validate no arguments
+    guardNoArgs(args, "shift");
+
+    // Use native JavaScript shift() method
+    const element = array.elements.shift();
+
+    return element ?? new JSUndefined();
+  },
+  description: "removes and returns the first element of the array",
+};

--- a/interpreters/src/javascript/stdlib/array/unshift.ts
+++ b/interpreters/src/javascript/stdlib/array/unshift.ts
@@ -1,0 +1,21 @@
+import type { JSArray, JikiObject } from "../../jsObjects";
+import { JSNumber } from "../../jsObjects";
+import type { ExecutionContext } from "../../executor";
+import type { Method } from "../index";
+import { guardArgRange } from "../guards";
+
+export const unshift: Method = {
+  arity: [1, Infinity],
+  call: (_ctx: ExecutionContext, obj: JikiObject, args: JikiObject[]) => {
+    const array = obj as JSArray;
+
+    // Validate at least one argument
+    guardArgRange(args, 1, Infinity, "unshift");
+
+    // Use native JavaScript unshift() method
+    const newLength = array.elements.unshift(...args);
+
+    return new JSNumber(newLength);
+  },
+  description: "adds one or more elements to the beginning of the array and returns the new length",
+};

--- a/interpreters/tests/cross-validation/javascript/stdlib/array-methods.test.ts
+++ b/interpreters/tests/cross-validation/javascript/stdlib/array-methods.test.ts
@@ -94,6 +94,173 @@ let result = arr.at(1);
     );
   });
 
+  describe("array.push()", () => {
+    testJavaScript(
+      "push single element",
+      `
+let arr = [1, 2, 3];
+let result = arr.push(4);
+    `,
+      { expectedValue: 4 }
+    );
+
+    testJavaScript(
+      "push multiple elements",
+      `
+let arr = [1, 2];
+let result = arr.push(3, 4, 5);
+    `,
+      { expectedValue: 5 }
+    );
+
+    testJavaScript(
+      "push to empty array",
+      `
+let arr = [];
+let result = arr.push(1);
+    `,
+      { expectedValue: 1 }
+    );
+
+    testJavaScript(
+      "push modifies original array",
+      `
+let arr = [1, 2];
+arr.push(3);
+let result = arr.length;
+    `,
+      { expectedValue: 3 }
+    );
+  });
+
+  describe("array.pop()", () => {
+    testJavaScript(
+      "pop from array with elements",
+      `
+let arr = [1, 2, 3];
+let result = arr.pop();
+    `,
+      { expectedValue: 3 }
+    );
+
+    testJavaScript(
+      "pop from empty array",
+      `
+let arr = [];
+let result = arr.pop();
+    `,
+      { expectedValue: undefined }
+    );
+
+    testJavaScript(
+      "pop modifies original array",
+      `
+let arr = [1, 2, 3];
+arr.pop();
+let result = arr.length;
+    `,
+      { expectedValue: 2 }
+    );
+
+    testJavaScript(
+      "pop single element array",
+      `
+let arr = [42];
+let result = arr.pop();
+    `,
+      { expectedValue: 42 }
+    );
+  });
+
+  describe("array.shift()", () => {
+    testJavaScript(
+      "shift from array with elements",
+      `
+let arr = [1, 2, 3];
+let result = arr.shift();
+    `,
+      { expectedValue: 1 }
+    );
+
+    testJavaScript(
+      "shift from empty array",
+      `
+let arr = [];
+let result = arr.shift();
+    `,
+      { expectedValue: undefined }
+    );
+
+    testJavaScript(
+      "shift modifies original array",
+      `
+let arr = [1, 2, 3];
+arr.shift();
+let result = arr.length;
+    `,
+      { expectedValue: 2 }
+    );
+
+    testJavaScript(
+      "shift updates indices",
+      `
+let arr = [1, 2, 3];
+arr.shift();
+let result = arr[0];
+    `,
+      { expectedValue: 2 }
+    );
+  });
+
+  describe("array.unshift()", () => {
+    testJavaScript(
+      "unshift single element",
+      `
+let arr = [2, 3, 4];
+let result = arr.unshift(1);
+    `,
+      { expectedValue: 4 }
+    );
+
+    testJavaScript(
+      "unshift multiple elements",
+      `
+let arr = [4, 5];
+let result = arr.unshift(1, 2, 3);
+    `,
+      { expectedValue: 5 }
+    );
+
+    testJavaScript(
+      "unshift to empty array",
+      `
+let arr = [];
+let result = arr.unshift(1);
+    `,
+      { expectedValue: 1 }
+    );
+
+    testJavaScript(
+      "unshift updates indices",
+      `
+let arr = [2, 3];
+arr.unshift(1);
+let result = arr[0];
+    `,
+      { expectedValue: 1 }
+    );
+
+    testJavaScript(
+      "unshift preserves order",
+      `
+let arr = [4];
+arr.unshift(1, 2, 3);
+let result = arr[2];
+    `,
+      { expectedValue: 3 }
+    );
+  });
+
   describe("array.length", () => {
     testJavaScript(
       "empty array",

--- a/interpreters/tests/javascript/array-properties-methods.test.ts
+++ b/interpreters/tests/javascript/array-properties-methods.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, describe } from "vitest";
 import { interpret } from "../../src/javascript/interpreter";
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("Array properties", () => {
   describe("length property", () => {
@@ -91,8 +92,7 @@ describe("Array properties", () => {
   });
 });
 
-// Note: Method tests will be added when CallExpression is implemented
-describe("Array methods (placeholder)", () => {
+describe("Array methods", () => {
   test("gives runtime error when using computed access for methods", () => {
     const result = interpret(`
       let arr = [1, 2, 3];
@@ -149,5 +149,182 @@ describe("Array methods (placeholder)", () => {
     const lastFrame = result.frames[result.frames.length - 1];
     expect(lastFrame.status).toBe("SUCCESS");
     expect(lastFrame.result?.jikiObject?.value).toBeUndefined();
+  });
+
+  describe("push() method", () => {
+    test("adds single element and returns new length", () => {
+      const result = interpret(`
+        let arr = [1, 2, 3];
+        let len = arr.push(4);
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(4);
+      expect(lastFrame.variables?.arr.value.length).toBe(4);
+      expect(lastFrame.variables?.arr.value[3].value).toBe(4);
+    });
+
+    test("adds multiple elements", () => {
+      const result = interpret(`
+        let arr = [1, 2];
+        let len = arr.push(3, 4, 5);
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(5);
+      expect(lastFrame.variables?.arr.value.length).toBe(5);
+    });
+
+    test("works on empty array", () => {
+      const result = interpret(`
+        let arr = [];
+        let len = arr.push(1);
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(1);
+      expect(lastFrame.variables?.arr.value.length).toBe(1);
+    });
+
+    test("requires at least one argument", () => {
+      const result = interpret(`
+        let arr = [1, 2, 3];
+        arr.push();
+      `);
+      expect(result.error).toBeNull();
+      const errorFrame = result.frames.find(f => f.status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect(errorFrame?.error?.type).toBe("InvalidNumberOfArguments");
+    });
+  });
+
+  describe("pop() method", () => {
+    test("removes and returns last element", () => {
+      const result = interpret(`
+        let arr = [1, 2, 3];
+        let last = arr.pop();
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(3);
+      expect(lastFrame.variables?.arr.value.length).toBe(2);
+    });
+
+    test("returns undefined for empty array", () => {
+      const result = interpret(`
+        let arr = [];
+        let last = arr.pop();
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBeUndefined();
+      expect(lastFrame.variables?.arr.value.length).toBe(0);
+    });
+
+    test("requires no arguments", () => {
+      const result = interpret(`
+        let arr = [1, 2, 3];
+        arr.pop(1);
+      `);
+      expect(result.error).toBeNull();
+      const errorFrame = result.frames.find(f => f.status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect(errorFrame?.error?.type).toBe("InvalidNumberOfArguments");
+    });
+  });
+
+  describe("shift() method", () => {
+    test("removes and returns first element", () => {
+      const result = interpret(`
+        let arr = [1, 2, 3];
+        let first = arr.shift();
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(1);
+      expect(lastFrame.variables?.arr.value.length).toBe(2);
+      expect(lastFrame.variables?.arr.value[0].value).toBe(2);
+    });
+
+    test("returns undefined for empty array", () => {
+      const result = interpret(`
+        let arr = [];
+        let first = arr.shift();
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBeUndefined();
+      expect(lastFrame.variables?.arr.value.length).toBe(0);
+    });
+
+    test("requires no arguments", () => {
+      const result = interpret(`
+        let arr = [1, 2, 3];
+        arr.shift(1);
+      `);
+      expect(result.error).toBeNull();
+      const errorFrame = result.frames.find(f => f.status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect(errorFrame?.error?.type).toBe("InvalidNumberOfArguments");
+    });
+  });
+
+  describe("unshift() method", () => {
+    test("adds single element to beginning and returns new length", () => {
+      const result = interpret(`
+        let arr = [2, 3, 4];
+        let len = arr.unshift(1);
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(4);
+      expect(lastFrame.variables?.arr.value.length).toBe(4);
+      expect(lastFrame.variables?.arr.value[0].value).toBe(1);
+    });
+
+    test("adds multiple elements to beginning", () => {
+      const result = interpret(`
+        let arr = [4, 5];
+        let len = arr.unshift(1, 2, 3);
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(5);
+      expect(lastFrame.variables?.arr.value.length).toBe(5);
+      expect(lastFrame.variables?.arr.value[0].value).toBe(1);
+      expect(lastFrame.variables?.arr.value[1].value).toBe(2);
+    });
+
+    test("works on empty array", () => {
+      const result = interpret(`
+        let arr = [];
+        let len = arr.unshift(1);
+      `);
+      expect(result.success).toBe(true);
+      const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(lastFrame.status).toBe("SUCCESS");
+      expect(lastFrame.result?.jikiObject?.value).toBe(1);
+      expect(lastFrame.variables?.arr.value.length).toBe(1);
+    });
+
+    test("requires at least one argument", () => {
+      const result = interpret(`
+        let arr = [1, 2, 3];
+        arr.unshift();
+      `);
+      expect(result.error).toBeNull();
+      const errorFrame = result.frames.find(f => f.status === "ERROR");
+      expect(errorFrame).toBeDefined();
+      expect(errorFrame?.error?.type).toBe("InvalidNumberOfArguments");
+    });
   });
 });

--- a/interpreters/tests/javascript/stdlib-errors.test.ts
+++ b/interpreters/tests/javascript/stdlib-errors.test.ts
@@ -1,25 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { interpret } from "../../src/javascript/interpreter";
-
-// Type for frames augmented in test environment
-interface TestAugmentedFrame {
-  status: "SUCCESS" | "ERROR";
-  result?: any;
-  variables?: Record<string, any>;
-  description?: string;
-  error?: {
-    type: string;
-    message?: string;
-    context?: any;
-  };
-}
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("JavaScript stdlib errors", () => {
   describe("MethodNotYetImplemented errors", () => {
     it("should throw MethodNotYetImplemented for unimplemented array methods", () => {
       const code = `
         let arr = [1, 2, 3];
-        arr.push(4);
+        arr.indexOf(2);
       `;
       const result = interpret(code);
       expect(result.success).toBe(false);
@@ -28,14 +16,14 @@ describe("JavaScript stdlib errors", () => {
       const lastFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
       expect(lastFrame.status).toBe("ERROR");
       expect(lastFrame.error?.type).toBe("MethodNotYetImplemented");
-      expect(lastFrame.error?.context?.method).toBe("push");
+      expect(lastFrame.error?.context?.method).toBe("indexOf");
     });
 
     it("should return a function for stub methods but throw when called", () => {
       const code = `
         let arr = [1, 2, 3];
-        let pushFn = arr.push;
-        pushFn(4);
+        let indexOfFn = arr.indexOf;
+        indexOfFn(2);
       `;
       const result = interpret(code);
       expect(result.success).toBe(false);
@@ -53,10 +41,6 @@ describe("JavaScript stdlib errors", () => {
 
     it("should list all unimplemented array methods", () => {
       const unimplementedMethods = [
-        "push",
-        "pop",
-        "shift",
-        "unshift",
         "indexOf",
         "includes",
         "slice",

--- a/interpreters/tests/javascript/string-methods-implemented.test.ts
+++ b/interpreters/tests/javascript/string-methods-implemented.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { interpret } from "../../src/javascript/interpreter";
-
-// Type for frames augmented in test environment
-interface TestAugmentedFrame {
-  status: "SUCCESS" | "ERROR";
-  result?: any;
-  variables?: Record<string, any>;
-  description?: string;
-  error?: {
-    type: string;
-    message?: string;
-    context?: any;
-  };
-}
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("JavaScript string methods", () => {
   describe("toUpperCase() method", () => {

--- a/interpreters/tests/javascript/string-properties-methods.test.ts
+++ b/interpreters/tests/javascript/string-properties-methods.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { interpret } from "../../src/javascript/interpreter";
-
-// Type for frames augmented in test environment
-interface TestAugmentedFrame {
-  status: "SUCCESS" | "ERROR";
-  result?: any;
-  variables?: Record<string, any>;
-  description?: string;
-  error?: {
-    type: string;
-    message?: string;
-    context?: any;
-  };
-}
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("String properties", () => {
   describe("length property", () => {

--- a/interpreters/tests/python/list-attributes.test.ts
+++ b/interpreters/tests/python/list-attributes.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { interpret } from "../../src/python/interpreter";
-
-// Type for frames augmented in test environment
-interface TestAugmentedFrame {
-  status: "SUCCESS" | "ERROR";
-  result?: any;
-  variables?: Record<string, any>;
-  description?: string;
-  error?: {
-    type: string;
-    message?: string;
-    context?: any;
-  };
-}
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("Python list attributes", () => {
   describe("list properties", () => {

--- a/interpreters/tests/python/list-index.test.ts
+++ b/interpreters/tests/python/list-index.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { interpret } from "../../src/python/interpreter";
-
-// Type for frames augmented in test environment
-interface TestAugmentedFrame {
-  status: "SUCCESS" | "ERROR";
-  result?: any;
-  variables?: Record<string, any>;
-  description?: string;
-  error?: {
-    type: string;
-    message?: string;
-    context?: any;
-  };
-}
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("Python list index() method", () => {
   describe("basic functionality", () => {

--- a/interpreters/tests/python/stdlib-errors.test.ts
+++ b/interpreters/tests/python/stdlib-errors.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { interpret } from "../../src/python/interpreter";
-
-// Type for frames augmented in test environment
-interface TestAugmentedFrame {
-  status: "SUCCESS" | "ERROR";
-  result?: any;
-  variables?: Record<string, any>;
-  description?: string;
-  error?: {
-    type: string;
-    message?: string;
-    context?: any;
-  };
-}
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("Python stdlib errors", () => {
   describe("MethodNotYetImplemented errors", () => {

--- a/interpreters/tests/python/string-methods.test.ts
+++ b/interpreters/tests/python/string-methods.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { interpret } from "../../src/python/interpreter";
-
-// Type for frames augmented in test environment
-interface TestAugmentedFrame {
-  status: "SUCCESS" | "ERROR";
-  result?: any;
-  variables?: Record<string, any>;
-  description?: string;
-  error?: {
-    type: string;
-    message?: string;
-    context?: any;
-  };
-}
+import type { TestAugmentedFrame } from "../../src/shared/frames";
 
 describe("Python string methods", () => {
   describe("upper() method", () => {


### PR DESCRIPTION
## Summary

Implemented four essential array mutating methods (`push`, `pop`, `shift`, `unshift`) that modify arrays in place. Refactored JSArray to use native JavaScript array methods for improved maintainability and 100% compatibility with native behavior.

### Key Changes

**JSArray Refactoring**:
- Changed `elements` field from `private readonly` to `public readonly`
- This allows stdlib methods to directly access and use native JavaScript array methods
- The array reference is readonly but contents remain mutable, enabling proper method behavior

**New Methods**:
- `push(...elements)`: Adds one or more elements to the end, returns new length
- `pop()`: Removes and returns the last element  
- `shift()`: Removes and returns the first element
- `unshift(...elements)`: Adds one or more elements to the beginning, returns new length

**Refactored `at()` Method**:
- Updated to use native `array.elements.at(index)` instead of custom logic
- Simpler implementation while maintaining all existing behavior
- Ensures 100% compatibility with JavaScript's native `at()` method

**Test Infrastructure Improvements**:
- Moved `TestAugmentedFrame` type from inline definitions to `src/shared/frames.ts` for reuse
- Updated all test files (JavaScript and Python) to import from shared location
- Ensures type consistency across the entire test suite

### Testing

- **14 new unit tests** covering all four methods and edge cases
- **17 new cross-validation tests** verifying implementation matches native JavaScript
- Updated stdlib error tests to reflect new implementations
- All tests passing ✅

### Benefits

- **Simpler code**: No need to reimplement JavaScript's array logic
- **100% compatibility**: Native methods guarantee matching behavior
- **Easier maintenance**: Less custom code to maintain and debug
- **Future-proof**: Easy to add more array methods using the same pattern

## Test plan
- [x] All unit tests pass
- [x] All cross-validation tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)