### PR TITLE
Standardize test imports to use TypeScript path aliases

### DIFF
--- a/interpreters/.context/shared/common-issues.md
+++ b/interpreters/.context/shared/common-issues.md
@@ -78,4 +78,37 @@ This document outlines the most common mistakes developers make when working on 
 
 **✅ CORRECT**: Use `string[]` (lowercase) for TypeScript primitive types.
 
+## Import Path Guidelines
+
+### ❌ Using Relative Imports in Tests
+
+**WRONG**: Using relative paths to import from src directories.
+
+```typescript
+import { interpret } from "../../src/javascript/interpreter";
+import type { TestAugmentedFrame } from "../../../src/shared/frames";
+```
+
+**✅ CORRECT**: Always use TypeScript path aliases in test files.
+
+```typescript
+import { interpret } from "@javascript/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
+```
+
+**Available aliases:**
+
+- `@jikiscript/*` → `src/jikiscript/*`
+- `@javascript/*` → `src/javascript/*`
+- `@python/*` → `src/python/*`
+- `@shared/*` → `src/shared/*`
+- `@utils/*` → `src/utils/*`
+
+**Benefits:**
+
+- Cleaner, more readable imports
+- Imports don't break when files are moved
+- Consistent with production code patterns
+- Easier to refactor
+
 **Any deviation from the shared architecture WILL break UI compatibility!**

--- a/interpreters/tests/cross-validation/framework-validation.test.ts
+++ b/interpreters/tests/cross-validation/framework-validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { executeNativePython, executeNativeJS } from "./utils/native-executor";
-import { interpret as interpretPython } from "../../src/python/interpreter";
-import { interpret as interpretJS } from "../../src/javascript/interpreter";
+import { interpret as interpretPython } from "@python/interpreter";
+import { interpret as interpretJS } from "@javascript/interpreter";
 import { extractLastValue } from "./utils/output-helpers";
 
 describe("Cross-validation framework validation", () => {

--- a/interpreters/tests/cross-validation/utils/output-helpers.ts
+++ b/interpreters/tests/cross-validation/utils/output-helpers.ts
@@ -1,4 +1,4 @@
-import type { Frame } from "../../../src/shared/frames";
+import type { Frame } from "@shared/frames";
 
 export interface InterpretResult {
   frames: Frame[];

--- a/interpreters/tests/cross-validation/utils/test-runner.ts
+++ b/interpreters/tests/cross-validation/utils/test-runner.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
-import { interpret as interpretPython } from "../../../src/python/interpreter";
-import { interpret as interpretJS } from "../../../src/javascript/interpreter";
+import { interpret as interpretPython } from "@python/interpreter";
+import { interpret as interpretJS } from "@javascript/interpreter";
 import { executeNativePython, executeNativeJS } from "./native-executor";
 import { extractOutput, normalizeOutput, extractLastValue, hasError, extractError } from "./output-helpers";
 

--- a/interpreters/tests/javascript/array-assignment.test.ts
+++ b/interpreters/tests/javascript/array-assignment.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
+import { interpret } from "@javascript/interpreter";
 
 // Type for frames augmented in test environment
 interface TestFrame {

--- a/interpreters/tests/javascript/array-immutability.test.ts
+++ b/interpreters/tests/javascript/array-immutability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
+import { interpret } from "@javascript/interpreter";
 
 // Type for frames augmented in test environment
 interface TestFrame {

--- a/interpreters/tests/javascript/array-properties-methods.test.ts
+++ b/interpreters/tests/javascript/array-properties-methods.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@javascript/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Array properties", () => {
   describe("length property", () => {

--- a/interpreters/tests/javascript/arrays.test.ts
+++ b/interpreters/tests/javascript/arrays.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
+import { interpret } from "@javascript/interpreter";
 
 // Type for frames augmented in test environment
 interface TestFrame {

--- a/interpreters/tests/javascript/call-descriptions.test.ts
+++ b/interpreters/tests/javascript/call-descriptions.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
-import type { ExternalFunction } from "../../src/shared/interfaces";
-import type { ExecutionContext } from "../../src/javascript/executor";
-import { JSNumber, JSString, JSBoolean, type JikiObject } from "../../src/javascript/jsObjects";
+import { interpret } from "@javascript/interpreter";
+import type { ExternalFunction } from "@shared/interfaces";
+import type { ExecutionContext } from "@javascript/executor";
+import { JSNumber, JSString, JSBoolean, type JikiObject } from "@javascript/jsObjects";
 
 // Helper to extract description text from HTML
 function extractText(html: string): string {

--- a/interpreters/tests/javascript/compile.test.ts
+++ b/interpreters/tests/javascript/compile.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { compile } from "../../src/javascript/interpreter";
+import { compile } from "@javascript/interpreter";
 
 describe("JavaScript compile()", () => {
   describe("successful compilation", () => {

--- a/interpreters/tests/javascript/console.test.ts
+++ b/interpreters/tests/javascript/console.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
+import { interpret } from "@javascript/interpreter";
 
 describe("console.log()", () => {
   it("logs a single string", () => {

--- a/interpreters/tests/javascript/external-functions.test.ts
+++ b/interpreters/tests/javascript/external-functions.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
-import type { ExternalFunction } from "../../src/shared/interfaces";
-import type { ExecutionContext } from "../../src/javascript/executor";
-import { JSNumber, JSString, JSBoolean, type JikiObject } from "../../src/javascript/jsObjects";
+import { interpret } from "@javascript/interpreter";
+import type { ExternalFunction } from "@shared/interfaces";
+import type { ExecutionContext } from "@javascript/executor";
+import { JSNumber, JSString, JSBoolean, type JikiObject } from "@javascript/jsObjects";
 
 describe("JavaScript External Functions", () => {
   it("should call an external function with no arguments", () => {

--- a/interpreters/tests/javascript/functions.test.ts
+++ b/interpreters/tests/javascript/functions.test.ts
@@ -1,4 +1,4 @@
-import { interpret } from "../../src/javascript/interpreter";
+import { interpret } from "@javascript/interpreter";
 import { describe, test, expect } from "vitest";
 import type { TestAugmentedFrame } from "@shared/frames";
 

--- a/interpreters/tests/javascript/interpreter/null-undefined.test.ts
+++ b/interpreters/tests/javascript/interpreter/null-undefined.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { interpret } from "../../../src/javascript/interpreter";
+import { interpret } from "@javascript/interpreter";
 
 describe("JavaScript Interpreter: null and undefined", () => {
   describe("null literal", () => {

--- a/interpreters/tests/javascript/stdlib-errors.test.ts
+++ b/interpreters/tests/javascript/stdlib-errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@javascript/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("JavaScript stdlib errors", () => {
   describe("MethodNotYetImplemented errors", () => {

--- a/interpreters/tests/javascript/string-methods-implemented.test.ts
+++ b/interpreters/tests/javascript/string-methods-implemented.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@javascript/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("JavaScript string methods", () => {
   describe("toUpperCase() method", () => {

--- a/interpreters/tests/javascript/string-properties-methods.test.ts
+++ b/interpreters/tests/javascript/string-properties-methods.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { interpret } from "../../src/javascript/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@javascript/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("String properties", () => {
   describe("length property", () => {

--- a/interpreters/tests/jikiscript/compile.test.ts
+++ b/interpreters/tests/jikiscript/compile.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { compile } from "../../src/jikiscript/interpreter";
+import { compile } from "@jikiscript/interpreter";
 
 describe("JikiScript compile()", () => {
   describe("successful compilation", () => {

--- a/interpreters/tests/jikiscript/runtimeErrors.test.ts
+++ b/interpreters/tests/jikiscript/runtimeErrors.test.ts
@@ -1,5 +1,5 @@
 import { RuntimeErrorType } from "@jikiscript/error";
-import { Frame } from "../../src/shared/frames";
+import { Frame } from "@shared/frames";
 import { EvaluationContext, interpret } from "@jikiscript/interpreter";
 import { Location, Span } from "@jikiscript/location";
 import * as Jiki from "@jikiscript/jikiObjects";

--- a/interpreters/tests/jikiscript/statementDescriptions/callStatement.test.ts
+++ b/interpreters/tests/jikiscript/statementDescriptions/callStatement.test.ts
@@ -1,6 +1,6 @@
 import { interpret } from "@jikiscript/interpreter";
 import { describeFrame } from "@jikiscript/frameDescribers";
-import { DescriptionContext } from "../../../src/shared/frames";
+import { DescriptionContext } from "@shared/frames";
 import {
   getNameFunction,
   assertHTML,

--- a/interpreters/tests/jikiscript/statementDescriptions/helpers.ts
+++ b/interpreters/tests/jikiscript/statementDescriptions/helpers.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest";
-import { DescriptionContext } from "../../../src/shared/frames";
+import { DescriptionContext } from "@shared/frames";
 import { Location } from "@jikiscript/location";
 import { Span } from "@jikiscript/location";
 import * as Jiki from "@jikiscript/jikiObjects";

--- a/interpreters/tests/jikiscript/statementDescriptions/repeatStatement.test.ts
+++ b/interpreters/tests/jikiscript/statementDescriptions/repeatStatement.test.ts
@@ -1,6 +1,6 @@
 import { interpret } from "@jikiscript/interpreter";
 import { describeFrame } from "@jikiscript/frameDescribers";
-import { DescriptionContext } from "../../../src/shared/frames";
+import { DescriptionContext } from "@shared/frames";
 import {
   getNameFunction,
   assertHTML,

--- a/interpreters/tests/python/builtin.test.ts
+++ b/interpreters/tests/python/builtin.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { interpret } from "../../src/python";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Python builtin functions", () => {
   describe("print()", () => {

--- a/interpreters/tests/python/builtin.test.ts
+++ b/interpreters/tests/python/builtin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { interpret } from "../../src/python";
+import { interpret } from "@python/interpreter";
 import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Python builtin functions", () => {

--- a/interpreters/tests/python/compile.test.ts
+++ b/interpreters/tests/python/compile.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { compile } from "../../src/python/interpreter";
+import { compile } from "@python/interpreter";
 
 describe("Python compile()", () => {
   describe("successful compilation", () => {

--- a/interpreters/tests/python/concepts/typeCoercion.test.ts
+++ b/interpreters/tests/python/concepts/typeCoercion.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { interpret } from "../../../src/python/interpreter";
+import { interpret } from "@python/interpreter";
 
 describe("Python Type Coercion", () => {
   describe("with allowTypeCoercion disabled (default)", () => {

--- a/interpreters/tests/python/external-functions.test.ts
+++ b/interpreters/tests/python/external-functions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { interpret } from "../../src/python/interpreter";
-import type { ExternalFunction } from "../../src/shared/interfaces";
-import type { ExecutionContext } from "../../src/shared/interfaces";
+import { interpret } from "@python/interpreter";
+import type { ExternalFunction } from "@shared/interfaces";
+import type { ExecutionContext } from "@shared/interfaces";
 
 describe("Python External Functions", () => {
   describe("Basic function calls", () => {

--- a/interpreters/tests/python/f-strings.test.ts
+++ b/interpreters/tests/python/f-strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { interpret } from "../../src/python/interpreter";
+import { interpret } from "@python/interpreter";
 import { Parser } from "@python/parser";
 
 function parse(code: string) {

--- a/interpreters/tests/python/functions.test.ts
+++ b/interpreters/tests/python/functions.test.ts
@@ -1,4 +1,4 @@
-import { interpret } from "../../src/python/interpreter";
+import { interpret } from "@python/interpreter";
 import { describe, test, expect } from "vitest";
 import type { TestAugmentedFrame } from "@shared/frames";
 

--- a/interpreters/tests/python/list-attributes.test.ts
+++ b/interpreters/tests/python/list-attributes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { interpret } from "../../src/python/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@python/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Python list attributes", () => {
   describe("list properties", () => {

--- a/interpreters/tests/python/list-index.test.ts
+++ b/interpreters/tests/python/list-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { interpret } from "../../src/python/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@python/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Python list index() method", () => {
   describe("basic functionality", () => {

--- a/interpreters/tests/python/parser/for.test.ts
+++ b/interpreters/tests/python/parser/for.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Parser } from "../../../src/python/parser";
-import { ForInStatement, BreakStatement, ContinueStatement, BlockStatement } from "../../../src/python/statement";
-import { IdentifierExpression, ListExpression } from "../../../src/python/expression";
+import { Parser } from "@python/parser";
+import { ForInStatement, BreakStatement, ContinueStatement, BlockStatement } from "@python/statement";
+import { IdentifierExpression, ListExpression } from "@python/expression";
 
 describe("Python Parser - For Loops", () => {
   describe("Basic for-in loops", () => {

--- a/interpreters/tests/python/scanner.test.ts
+++ b/interpreters/tests/python/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { interpret } from "../../src/python/interpreter";
+import { interpret } from "@python/interpreter";
 
 // UNIMPLEMENTED TOKENS
 // When implementing a token, move it from this section to the appropriate implemented section

--- a/interpreters/tests/python/stdlib-errors.test.ts
+++ b/interpreters/tests/python/stdlib-errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { interpret } from "../../src/python/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@python/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Python stdlib errors", () => {
   describe("MethodNotYetImplemented errors", () => {

--- a/interpreters/tests/python/string-methods.test.ts
+++ b/interpreters/tests/python/string-methods.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { interpret } from "../../src/python/interpreter";
-import type { TestAugmentedFrame } from "../../src/shared/frames";
+import { interpret } from "@python/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Python string methods", () => {
   describe("upper() method", () => {

--- a/interpreters/tests/test-helpers.ts
+++ b/interpreters/tests/test-helpers.ts
@@ -1,4 +1,4 @@
-import { Frame } from "../src/shared/frames";
+import { Frame } from "@shared/frames";
 
 /**
  * Type-safe helper to get a frame at a specific index


### PR DESCRIPTION
## Summary

- Replace relative import paths (`../../src/...`) with TypeScript path aliases (`@javascript/*`, `@python/*`, `@shared/*`, etc.)
- Update 34 test files across JavaScript, Python, and JikiScript interpreters
- Add import guidelines to `.context/shared/common-issues.md` documenting best practices

## Benefits

- **Cleaner imports**: `@javascript/interpreter` instead of `../../src/javascript/interpreter`
- **Refactor-safe**: Imports don't break when files are moved
- **Consistency**: Aligns with production code patterns
- **Developer experience**: Easier to read and maintain

## Available Aliases

- `@jikiscript/*` → `src/jikiscript/*`
- `@javascript/*` → `src/javascript/*`
- `@python/*` → `src/python/*`
- `@shared/*` → `src/shared/*`
- `@utils/*` → `src/utils/*`

## Test Plan

- [x] All 2,472 tests pass
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Pre-commit hooks pass (formatting, linting, tests)
- [x] Benchmark tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)