### PR TITLE
Fix git worktree instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,10 @@
 # 1. Ensure you're on main and up-to-date
 git checkout main && git pull
 
-# 2. Create a new feature branch
-git checkout -b feature-branch-name
+# 2. Create an isolated worktree directory with a new branch
+git worktree add ../worktrees/front-end-app-feature-branch -b feature-branch-name
 
-# 3. Create an isolated worktree directory
-git worktree add ../worktrees/front-end-app-feature-branch feature-branch-name
-
-# 4. Change to the worktree directory
+# 3. Change to the worktree directory
 cd ../worktrees/front-end-app-feature-branch
 ```
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -8,13 +8,10 @@
 # 1. Ensure you're on main and up-to-date
 git checkout main && git pull
 
-# 2. Create a new feature branch
-git checkout -b feature-branch-name
+# 2. Create an isolated worktree directory with a new branch
+git worktree add ../../worktrees/front-end-app-feature-branch -b feature-branch-name
 
-# 3. Create an isolated worktree directory
-git worktree add ../../worktrees/front-end-app-feature-branch feature-branch-name
-
-# 4. Change to the worktree directory
+# 3. Change to the worktree directory
 cd ../../worktrees/front-end-app-feature-branch/app
 ```
 

--- a/content/AGENTS.md
+++ b/content/AGENTS.md
@@ -8,13 +8,10 @@
 # 1. Ensure you're on main and up-to-date
 git checkout main && git pull
 
-# 2. Create a new feature branch
-git checkout -b feature-branch-name
+# 2. Create an isolated worktree directory with a new branch
+git worktree add ../../worktrees/front-end-app-feature-branch -b feature-branch-name
 
-# 3. Create an isolated worktree directory
-git worktree add ../../worktrees/front-end-app-feature-branch feature-branch-name
-
-# 4. Change to the worktree directory
+# 3. Change to the worktree directory
 cd ../../worktrees/front-end-app-feature-branch/content
 ```
 

--- a/curriculum/AGENTS.md
+++ b/curriculum/AGENTS.md
@@ -8,13 +8,10 @@
 # 1. Ensure you're on main and up-to-date
 git checkout main && git pull
 
-# 2. Create a new feature branch
-git checkout -b feature-branch-name
+# 2. Create an isolated worktree directory with a new branch
+git worktree add ../../worktrees/front-end-app-feature-branch -b feature-branch-name
 
-# 3. Create an isolated worktree directory
-git worktree add ../../worktrees/front-end-app-feature-branch feature-branch-name
-
-# 4. Change to the worktree directory
+# 3. Change to the worktree directory
 cd ../../worktrees/front-end-app-feature-branch/curriculum
 ```
 

--- a/interpreters/AGENTS.md
+++ b/interpreters/AGENTS.md
@@ -8,13 +8,10 @@
 # 1. Ensure you're on main and up-to-date
 git checkout main && git pull
 
-# 2. Create a new feature branch
-git checkout -b feature-branch-name
+# 2. Create an isolated worktree directory with a new branch
+git worktree add ../../worktrees/front-end-app-feature-branch -b feature-branch-name
 
-# 3. Create an isolated worktree directory
-git worktree add ../../worktrees/front-end-app-feature-branch feature-branch-name
-
-# 4. Change to the worktree directory
+# 3. Change to the worktree directory
 cd ../../worktrees/front-end-app-feature-branch/interpreters
 ```
 


### PR DESCRIPTION
## Summary

Removed redundant `git checkout -b` step from git worktree instructions. The `git worktree add -b` command creates and checks out the branch automatically.

## Changes

Updated all AGENTS.md files to use the correct worktree command:
- Before: `git checkout -b feature-branch-name` followed by `git worktree add ... feature-branch-name`
- After: `git worktree add ... -b feature-branch-name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)