### PR TITLE
Fix: Apply absolute paths to all pre-commit scripts for git worktree compatibility

### DIFF
--- a/app/scripts/pre-commit
+++ b/app/scripts/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Get absolute path to app directory and change to it
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$APP_DIR" || exit 1
+
 echo "Running pre-commit checks..."
 
 # Run TypeScript type checking
@@ -11,21 +16,26 @@ fi
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^app/||' || true)
-if [ -n "$STAGED_FILES" ]; then
-    echo "Formatting: $STAGED_FILES"
-    pnpm exec prettier --write $STAGED_FILES
-    git add $STAGED_FILES
+STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^app/||' || true)
+if [ -n "$STAGED_FILES_RELATIVE" ]; then
+    echo "Formatting: $STAGED_FILES_RELATIVE"
+    # Convert relative paths to absolute paths for prettier
+    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$APP_DIR/|")
+    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
+    # Re-add formatted files (use paths relative to current directory, which is APP_DIR)
+    git add $STAGED_FILES_RELATIVE
 else
     echo "No files to format"
 fi
 
 # Run lint check on staged files only (treating warnings as errors)
 echo "🔍 Running lint check on staged files..."
-STAGED_TS_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs)$' | sed 's|^app/||' || true)
-if [ -n "$STAGED_TS_FILES" ]; then
-    echo "Linting: $STAGED_TS_FILES"
-    pnpm exec eslint $STAGED_TS_FILES --max-warnings=0
+STAGED_TS_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs)$' | sed 's|^app/||' || true)
+if [ -n "$STAGED_TS_FILES_RELATIVE" ]; then
+    echo "Linting: $STAGED_TS_FILES_RELATIVE"
+    # Convert relative paths to absolute paths for eslint
+    STAGED_TS_FILES_ABSOLUTE=$(echo "$STAGED_TS_FILES_RELATIVE" | sed "s|^|$APP_DIR/|")
+    pnpm exec eslint $STAGED_TS_FILES_ABSOLUTE --max-warnings=0
     if [ $? -ne 0 ]; then
         echo "❌ Lint check failed (errors or warnings found). Commit aborted."
         exit 1

--- a/content/scripts/pre-commit
+++ b/content/scripts/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Get absolute path to content directory and change to it
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTENT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$CONTENT_DIR" || exit 1
+
 echo "Running pre-commit checks..."
 
 # Run TypeScript type checking
@@ -11,11 +16,14 @@ fi
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^content/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^content/||' || true)
-if [ -n "$STAGED_FILES" ]; then
-    echo "Formatting: $STAGED_FILES"
-    pnpm exec prettier --write $STAGED_FILES
-    git add $STAGED_FILES
+STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^content/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^content/||' || true)
+if [ -n "$STAGED_FILES_RELATIVE" ]; then
+    echo "Formatting: $STAGED_FILES_RELATIVE"
+    # Convert relative paths to absolute paths for prettier
+    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$CONTENT_DIR/|")
+    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
+    # Re-add formatted files (use paths relative to current directory, which is CONTENT_DIR)
+    git add $STAGED_FILES_RELATIVE
 else
     echo "No files to format"
 fi

--- a/curriculum/scripts/pre-commit
+++ b/curriculum/scripts/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Get absolute path to curriculum directory and change to it
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CURRICULUM_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$CURRICULUM_DIR" || exit 1
+
 echo "Running pre-commit checks..."
 
 # Run TypeScript type checking
@@ -11,11 +16,14 @@ fi
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^curriculum/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^curriculum/||' || true)
-if [ -n "$STAGED_FILES" ]; then
-    echo "Formatting: $STAGED_FILES"
-    pnpm exec prettier --write $STAGED_FILES
-    git add $STAGED_FILES
+STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^curriculum/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^curriculum/||' || true)
+if [ -n "$STAGED_FILES_RELATIVE" ]; then
+    echo "Formatting: $STAGED_FILES_RELATIVE"
+    # Convert relative paths to absolute paths for prettier
+    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$CURRICULUM_DIR/|")
+    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
+    # Re-add formatted files (use paths relative to current directory, which is CURRICULUM_DIR)
+    git add $STAGED_FILES_RELATIVE
 else
     echo "No files to format"
 fi

--- a/interpreters/scripts/pre-commit
+++ b/interpreters/scripts/pre-commit
@@ -1,12 +1,21 @@
+#!/bin/sh
+# Get absolute path to interpreters directory and change to it
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTERPRETERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$INTERPRETERS_DIR" || exit 1
+
 echo "Running pre-commit checks..."
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "^interpreters/" | grep -E '\.(ts|tsx|js|jsx|json|md|yml)$' | sed 's|^interpreters/||' || true)
-if [ -n "$STAGED_FILES" ]; then
-    echo "Formatting: $STAGED_FILES"
-    pnpm exec prettier --write $STAGED_FILES
-    git add $STAGED_FILES
+STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^interpreters/" | grep -E '\.(ts|tsx|js|jsx|json|md|yml)$' | sed 's|^interpreters/||' || true)
+if [ -n "$STAGED_FILES_RELATIVE" ]; then
+    echo "Formatting: $STAGED_FILES_RELATIVE"
+    # Convert relative paths to absolute paths for prettier
+    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$INTERPRETERS_DIR/|")
+    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
+    # Re-add formatted files (use paths relative to current directory, which is INTERPRETERS_DIR)
+    git add $STAGED_FILES_RELATIVE
 else
     echo "No files to format"
 fi


### PR DESCRIPTION
## Summary

Extended the git worktree compatibility fix from the app package to all packages in the monorepo (content, curriculum, interpreters) to prevent duplicate files from being created at the repository root when using git worktrees.

This PR includes:
- Cherry-picked commit a4044ce that fixed the issue in app/scripts/pre-commit
- Applied the same fix to content/scripts/pre-commit
- Applied the same fix to curriculum/scripts/pre-commit
- Applied the same fix to interpreters/scripts/pre-commit
- Added missing shebang to interpreters/scripts/pre-commit
- Documented the worktree compatibility issue in app/.context/git.md

## Problem

When using git worktrees, git hooks run from the worktree directory, but `pnpm exec` spawns Node.js processes whose `process.cwd()` defaults to the main repository root, not the package directory. This caused tools like Prettier and ESLint to write files relative to the wrong directory, creating duplicate files at the repository root instead of in the correct package directory.

## Solution

Each pre-commit script now:
1. Gets the absolute path to its package directory
2. Changes to that directory (`cd $PACKAGE_DIR`)
3. Converts relative file paths to absolute paths before passing to Prettier/ESLint
4. Uses relative paths for `git add` (which needs paths relative to repo root)

This ensures that Prettier and ESLint always write to the correct absolute paths, regardless of what `process.cwd()` returns.

## Test plan

- [x] All tests pass for all packages
- [x] Pre-commit hooks run successfully in the worktree
- [x] No duplicate files created at repository root

🤖 Generated with [Claude Code](https://claude.com/claude-code)