### PR TITLE
Disable production sourcemaps

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import path from "path";
 
 const nextConfig: NextConfig = {
+  productionBrowserSourceMaps: false,
   experimental: {
     reactCompiler: true
   },

--- a/app/tests/unit/config/next.config.test.ts
+++ b/app/tests/unit/config/next.config.test.ts
@@ -1,0 +1,8 @@
+import nextConfig from "@/next.config";
+
+describe("Next.js Configuration", () => {
+  it("should disable sourcemaps in production", () => {
+    expect(nextConfig).toBeDefined();
+    expect(nextConfig.productionBrowserSourceMaps).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Disabled sourcemaps in production builds to prevent code exposure
- Added test to ensure sourcemaps remain disabled

## Changes
- Set `productionBrowserSourceMaps: false` in `next.config.ts`
- Created `tests/unit/config/next.config.test.ts` to enforce this setting

## Test plan
- ✅ New test passes
- ✅ All existing tests pass
- ✅ TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)