### PR TITLE
Enable browser caching for static assets

### DIFF
--- a/app/public/_headers
+++ b/app/public/_headers
@@ -1,0 +1,2 @@
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary

- Add `public/_headers` file to configure Cloudflare Workers Static Assets cache headers
- Set `Cache-Control: public, max-age=31536000, immutable` for `_next/static/*` files

## Problem

Cloudflare Workers Static Assets currently serves all files with `Cache-Control: public, max-age=0, must-revalidate`, which forces browsers to revalidate on every page load. This negates caching benefits for static assets and results in unnecessary network requests.

## Solution

Created a `_headers` file in the `public/` directory to override cache headers specifically for Next.js build files in `_next/static/`. These files are content-addressed (have hashes in filenames), so they can be safely cached for one year.

## Benefits

- **Faster page loads** - Browser caches JS/CSS bundles without revalidation
- **Reduced bandwidth** - Eliminates redundant downloads of unchanged assets
- **Better performance** - Especially on repeat visits and navigation
- **Zero risk** - Hash-based filenames guarantee correct versioning

## Technical Details

Next.js generates filenames like `_next/static/chunks/8139-2e602539afd8900f.js`. When content changes, the hash changes, so old cached files become irrelevant. The HTML pages themselves are still fetched fresh, ensuring the browser always loads the correct asset versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)