### PR TITLE
Fix CSP to allow API connections in production

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -114,7 +114,7 @@ export function middleware(request: NextRequest) {
     style-src 'self' 'unsafe-inline' https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com;
     font-src 'self';
-    connect-src 'self' https://api.stripe.com https://accounts.google.com ${isProduction ? "" : "http://localhost:* https://localhost:* ws://localhost:* ws://127.0.0.1:*"};
+    connect-src 'self' https://api.jiki.com https://api.stripe.com https://accounts.google.com ${isProduction ? "" : "http://localhost:* https://localhost:* ws://localhost:* ws://127.0.0.1:*"};
     frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://accounts.google.com;
     worker-src 'self' blob:;
     object-src 'none';


### PR DESCRIPTION
## Summary
- Add `https://api.jiki.com` to the `connect-src` Content Security Policy directive in middleware.ts
- Fixes authentication and API request failures in production caused by CSP blocking

## Problem
The production environment was blocking all requests to `https://api.jiki.com` because it wasn't included in the allowed `connect-src` domains. This caused the login functionality to fail with CSP violations.

## Solution
Updated the CSP directive in `middleware.ts:117` to include `https://api.jiki.com` in the allowed connection sources.

## Test plan
- [x] TypeScript type check passes
- [x] All unit tests pass
- [x] Deploy to production and verify login works
- [x] Verify CSP no longer blocks API requests in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)