### PR TITLE
Make rocket-launch reset opt-in

### DIFF
--- a/app/components/landing-page/hooks/useRocketLaunch.ts
+++ b/app/components/landing-page/hooks/useRocketLaunch.ts
@@ -7,7 +7,12 @@ import { useState, type MouseEvent } from "react";
 // CSS keyframe delays must match.
 const TOTAL_LAUNCH_MS = 650;
 
-export function useRocketLaunch(action: string | (() => void)) {
+interface UseRocketLaunchOptions {
+  resetAfterLaunch?: boolean;
+}
+
+export function useRocketLaunch(action: string | (() => void), options: UseRocketLaunchOptions = {}) {
+  const { resetAfterLaunch = false } = options;
   const router = useRouter();
   const [launching, setLaunching] = useState(false);
 
@@ -21,7 +26,9 @@ export function useRocketLaunch(action: string | (() => void)) {
       } else {
         action();
       }
-      setLaunching(false);
+      if (resetAfterLaunch) {
+        setLaunching(false);
+      }
     }, TOTAL_LAUNCH_MS);
   };
 

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -40,8 +40,15 @@ const navigationItems: Array<{
 export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
   const user = useAuthStore((state) => state.user);
   const isPremium = user && tierIncludes(user.membership_type, "premium");
-  const { launching, handleClick } = useRocketLaunch(() =>
-    showModal("premium-upgrade-modal", {}, premiumModalStyles.premiumModalOverlay, premiumModalStyles.premiumModalWidth)
+  const { launching, handleClick } = useRocketLaunch(
+    () =>
+      showModal(
+        "premium-upgrade-modal",
+        {},
+        premiumModalStyles.premiumModalOverlay,
+        premiumModalStyles.premiumModalWidth
+      ),
+    { resetAfterLaunch: true }
   );
 
   return (


### PR DESCRIPTION
## Summary
- `useRocketLaunch` now takes an optional `{ resetAfterLaunch }` flag (default `false`).
- Landing-page CTAs navigate away after launch, so they keep their state.
- The sidebar premium-upgrade button opens a modal in place, so it passes `resetAfterLaunch: true` and the rocket returns to its idle state once the modal opens — ready for the next click.

## Test plan
- [ ] On `/` (landing page), the rocket on the signup CTAs stays in its launched state after the click navigates.
- [ ] In the app sidebar, click "Upgrade to Premium" → the rocket fires, the modal opens, the rocket resets so a second click works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)