### PR TITLE
Add /premium page with pricing comparison table

### DIFF
--- a/app/app/(hybrid)/premium/page.tsx
+++ b/app/app/(hybrid)/premium/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { PremiumPage } from "@/components/premium/PremiumPage";
+
+export const metadata: Metadata = {
+  title: "Premium - Jiki",
+  description:
+    "Accelerate your road to job-ready with Jiki Premium. Full access to courses, projects, AI support, and more."
+};
+
+export default function Page() {
+  return <PremiumPage />;
+}

--- a/app/components/layout/ExternalFooter.tsx
+++ b/app/components/layout/ExternalFooter.tsx
@@ -17,6 +17,9 @@ export function ExternalFooter() {
             <Link href="/articles/who-makes-runs-jiki" className={styles.link}>
               Our team
             </Link>
+            <Link href="/premium" className={styles.link}>
+              Jiki Premium
+            </Link>
           </div>
         </div>
         <div className={styles.section}>

--- a/app/components/premium/CategoryRow.tsx
+++ b/app/components/premium/CategoryRow.tsx
@@ -1,0 +1,15 @@
+import styles from "./PremiumPage.module.css";
+
+interface Props {
+  label: string;
+}
+
+export default function CategoryRow({ label }: Props) {
+  return (
+    <div className={styles["category-row"]}>
+      <div className={styles["category-label"]}>{label}</div>
+      <div />
+      <div className={styles["category-col-spacer-premium"]} />
+    </div>
+  );
+}

--- a/app/components/premium/CtaSection.tsx
+++ b/app/components/premium/CtaSection.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useAuthStore } from "@/lib/auth/authStore";
+import { showModal } from "@/lib/modal";
+import { Button } from "@/components/ui-kit/Button";
+import styles from "./PremiumPage.module.css";
+
+export default function CtaSection() {
+  const user = useAuthStore((state) => state.user);
+  const isPremium = user?.membership_type === "premium";
+
+  if (isPremium) {
+    return (
+      <div className={styles["cta-wrapper"]}>
+        <div className={styles["cta-banner"]}>
+          <h2 className={styles["cta-title"]}>You&apos;re already a Premium member</h2>
+          <p className={styles["cta-desc"]}>Thanks for supporting Jiki — enjoy full access to everything!</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (user) {
+    return (
+      <div className={styles["cta-wrapper"]}>
+        <div className={styles["cta-banner"]}>
+          <h2 className={styles["cta-title"]}>Ready to accelerate your learning?</h2>
+          <p className={styles["cta-desc"]}>Upgrade to Premium and unlock everything Jiki has to offer.</p>
+          <Button variant="white" onClick={() => showModal("premium-upgrade-modal")}>
+            Upgrade to Premium
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles["cta-wrapper"]}>
+      <div className={styles["cta-banner"]}>
+        <h2 className={styles["cta-title"]}>Get started for free</h2>
+        <p className={styles["cta-desc"]}>
+          Get started today for free and access hundreds of hours of free content. Upgrade to Premium when you want to
+          go even deeper.
+        </p>
+        <Button variant="white" onClick={() => (window.location.href = "/auth/signup")}>
+          Sign up for free
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/premium/FaqSection.tsx
+++ b/app/components/premium/FaqSection.tsx
@@ -1,0 +1,22 @@
+import styles from "./PremiumPage.module.css";
+import { FAQ_ITEMS } from "./pricing.data";
+
+export default function FaqSection() {
+  return (
+    <div className={styles["faq-section"]}>
+      <div className={styles["faq-inner"]}>
+        <h2 className={styles["faq-title"]}>Frequently asked questions</h2>
+        <div className={styles["faq-list"]}>
+          {FAQ_ITEMS.map((item) => (
+            <details key={item.question} className={styles["faq-item"]}>
+              <summary>{item.question}</summary>
+              <div className={styles["faq-answer"]}>
+                <p>{item.answer}</p>
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/premium/FeatureRow.tsx
+++ b/app/components/premium/FeatureRow.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import styles from "./PremiumPage.module.css";
+
+interface Props {
+  title: ReactNode;
+  desc: string;
+  free: boolean | string;
+  premium: boolean | string;
+}
+
+function CellValue({ value, variant }: { value: boolean | string; variant: "free" | "premium" }) {
+  if (typeof value === "string") {
+    const cls = variant === "free" ? styles["feature-value-free"] : styles["feature-value-premium"];
+    return <span className={cls}>{value}</span>;
+  }
+
+  if (value) {
+    const cls = variant === "free" ? styles["check-yes-free"] : styles["check-yes-premium"];
+    return (
+      <span className={`${styles["check-yes"]} ${cls}`}>
+        <svg aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+        </svg>
+      </span>
+    );
+  }
+
+  return <span className={styles["check-no"]}>✕</span>;
+}
+
+export default function FeatureRow({ title, desc, free, premium }: Props) {
+  return (
+    <div className={styles["feature-row"]}>
+      <div className={styles["feature-name"]}>
+        <span className={styles["feature-title"]}>{title}</span>
+        <span className={styles["feature-desc"]}>{desc}</span>
+      </div>
+      <div className={styles["feature-check"]}>
+        <CellValue value={free} variant="free" />
+      </div>
+      <div className={styles["feature-check-premium"]}>
+        <CellValue value={premium} variant="premium" />
+      </div>
+    </div>
+  );
+}

--- a/app/components/premium/PlanPrice.tsx
+++ b/app/components/premium/PlanPrice.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { PublicPremiumPrice } from "./PublicPremiumPrice";
+import styles from "./PremiumPage.module.css";
+
+interface Props {
+  variant: "free" | "premium";
+}
+
+export default function PlanPrice({ variant }: Props) {
+  const isFree = variant === "free";
+
+  return (
+    <>
+      <div className={`${styles["plan-name"]} ${isFree ? styles["plan-name-free"] : styles["plan-name-premium"]}`}>
+        {isFree ? "Basic" : "Premium"}
+      </div>
+
+      {isFree ? (
+        <div className={styles["plan-price"]}>
+          <span className={`${styles["price-amount"]} ${styles["price-amount-free"]}`}>Free</span>
+        </div>
+      ) : (
+        <div className={styles["plan-price"]}>
+          <span className={`${styles["price-amount"]} ${styles["price-amount-premium"]}`}>
+            <PublicPremiumPrice />
+          </span>
+        </div>
+      )}
+
+      {!isFree && <div className={styles["price-period"]}>per month</div>}
+    </>
+  );
+}

--- a/app/components/premium/PremiumPage.module.css
+++ b/app/components/premium/PremiumPage.module.css
@@ -1,0 +1,416 @@
+/* Premium page */
+
+.page-header {
+    position: relative;
+    z-index: 1;
+    padding: 56px 0 30px;
+    text-align: center;
+}
+
+.page-wrapper {
+    position: relative;
+    isolation: isolate;
+
+    &::before {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        z-index: -1;
+        height: 520px;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cg opacity='0.4'%3E%3Cline x1='14' y1='0' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3Cline x1='0' y1='14' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3C/g%3E%3C/svg%3E");
+        -webkit-mask-image: linear-gradient(to bottom, black 0%, black 65%, transparent 100%);
+        mask-image: linear-gradient(to bottom, black 0%, black 65%, transparent 100%);
+        pointer-events: none;
+        content: "";
+    }
+}
+
+.heading {
+    margin-bottom: 16px;
+    font-size: 52px;
+    font-weight: 700;
+    line-height: 1.15;
+    color: var(--color-gray-900);
+}
+
+.subheading {
+    max-width: 650px;
+    margin: 0 auto;
+    font-size: 20px;
+    line-height: 1.6;
+    color: var(--color-gray-500);
+}
+
+.main-content {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 10px 40px;
+}
+
+/* Pricing table */
+
+.pricing-table-wrapper {
+    overflow: hidden;
+    background: white;
+    border: 1.5px solid var(--color-gray-200);
+    border-radius: 20px;
+    box-shadow: 0 4px 16px var(--color-gray-500-10);
+}
+
+.table-header-row {
+    display: grid;
+    align-items: stretch;
+    grid-template-columns: 1fr 200px 220px;
+}
+
+.col-feature-header {
+    display: flex;
+    align-items: flex-start;
+    padding: 28px 0 24px 32px;
+    border-bottom: 1.5px solid var(--color-gray-200);
+}
+
+.col-free-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 28px 24px 24px;
+    text-align: center;
+    border-bottom: 1.5px solid var(--color-gray-200);
+    border-left: 1.5px solid var(--color-gray-100);
+}
+
+.col-premium-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 28px 24px 24px;
+    text-align: center;
+    background: var(--color-purple-50);
+    border-bottom: 1.5px solid var(--color-purple-200);
+}
+
+.compare-plans-title {
+    font-size: 25px;
+    font-weight: 700;
+    color: var(--color-gray-700);
+}
+
+.compare-plans-desc {
+    margin-top: 6px;
+    font-size: 16px;
+    line-height: 1.5;
+    color: var(--color-gray-500);
+}
+
+.plan-name {
+    margin-bottom: 2px;
+    font-size: 20px;
+    font-weight: 700;
+}
+
+.plan-name-free {
+    color: var(--color-gray-900);
+}
+
+.plan-name-premium {
+    color: var(--color-purple-700);
+}
+
+.plan-price {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 2px;
+}
+
+.price-amount {
+    font-size: 36px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.price-amount-free {
+    color: var(--color-gray-900);
+}
+
+.price-amount-premium {
+    color: var(--color-purple-700);
+}
+
+.price-period {
+    margin-bottom: 16px;
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--color-gray-500);
+}
+
+/* Category rows */
+
+.category-row {
+    display: grid;
+    grid-template-columns: 1fr 200px 220px;
+    background: var(--color-purple-700);
+    border-bottom: 2px solid var(--color-gray-200);
+}
+
+.category-label {
+    padding: 12px 32px;
+    font-size: 16px;
+    font-weight: 500;
+    color: white;
+}
+
+.category-col-spacer-premium {
+    background: var(--color-purple-700);
+}
+
+/* Feature rows */
+
+.feature-row {
+    display: grid;
+    grid-template-columns: 1fr 200px 220px;
+    border-bottom: 1px solid var(--color-gray-100);
+    transition: background 0.1s;
+
+    &:hover {
+        background: var(--color-gray-50);
+
+        & .feature-check-premium {
+            background: var(--color-purple-50);
+        }
+    }
+
+    &:last-child {
+        border-bottom: none;
+    }
+}
+
+.feature-name {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 14px 32px;
+    font-size: 16px;
+    color: var(--color-gray-700);
+}
+
+.feature-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 17px;
+    font-weight: 500;
+    color: var(--color-gray-900);
+}
+
+.feature-desc {
+    font-size: 16px;
+    line-height: 1.4;
+    color: var(--color-gray-500);
+}
+
+.feature-check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 14px 24px;
+    border-left: 1.5px solid var(--color-gray-100);
+}
+
+.feature-check-premium {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 14px 24px;
+    background: var(--color-purple-30);
+}
+
+.check-yes {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+
+    & svg {
+        width: 16px;
+        height: 16px;
+    }
+}
+
+.check-yes-free {
+    background: var(--color-gray-100);
+
+    & svg {
+        color: var(--color-gray-500);
+    }
+}
+
+.check-yes-premium {
+    background: var(--color-purple-200);
+
+    & svg {
+        color: var(--color-purple-700);
+    }
+}
+
+.check-no {
+    font-size: 19px;
+    line-height: 1;
+    color: var(--color-gray-300);
+}
+
+.feature-value-free {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--color-gray-700);
+}
+
+.feature-value-premium {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--color-purple-700);
+}
+
+/* CTA section */
+
+.cta-wrapper {
+    margin: 20px 0 60px;
+}
+
+.cta-banner {
+    padding: 52px 80px;
+    text-align: center;
+    background: var(--color-blue-600);
+    border-radius: 16px;
+}
+
+.cta-title {
+    margin-bottom: 10px;
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 1.2;
+    color: white;
+}
+
+.cta-desc {
+    margin-bottom: 20px;
+    font-size: 19px;
+    line-height: 1.6;
+    color: var(--color-blue-200);
+}
+
+.cta-btn {
+    display: inline-block;
+    padding: 16px 44px;
+    font-size: 18px;
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--color-blue-700);
+    background: white;
+    border: none;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px var(--color-blue-500-30);
+    transition: box-shadow 0.3s ease;
+    cursor: pointer;
+
+    &:hover {
+        box-shadow:
+            0 0 0 4px var(--color-blue-500-40),
+            0 4px 24px var(--color-blue-500-40);
+    }
+}
+
+/* FAQ section */
+
+.faq-section {
+    padding: 20px 40px 60px;
+    background: white;
+}
+
+.faq-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 40px;
+}
+
+.faq-title {
+    margin-bottom: 12px;
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--color-gray-900);
+}
+
+.faq-list {
+    margin: 0 0 20px;
+}
+
+.faq-item {
+    padding: 4px 0;
+    border-bottom: 1px solid var(--color-gray-200);
+
+    & summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 14px 0;
+        font-size: 19px;
+        font-weight: 600;
+        color: var(--color-gray-900);
+        cursor: pointer;
+        user-select: none;
+        list-style: none;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+
+        &::after {
+            display: inline-block;
+            flex-shrink: 0;
+            width: 20px;
+            height: 20px;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2.5' stroke='%230f172a'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='m8.25 4.5 7.5 7.5-7.5 7.5'/%3E%3C/svg%3E");
+            background-size: contain;
+            background-repeat: no-repeat;
+            transform: rotate(90deg);
+            transition: transform 0.2s ease;
+            content: "";
+        }
+
+        &:hover {
+            color: var(--color-blue-600);
+        }
+    }
+
+    &[open] summary {
+        color: var(--color-blue-600);
+
+        &::after {
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2.5' stroke='%232563eb'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='m8.25 4.5 7.5 7.5-7.5 7.5'/%3E%3C/svg%3E");
+            transform: rotate(270deg);
+        }
+    }
+}
+
+.faq-answer {
+    padding: 4px 0 18px;
+    font-size: 17px;
+    line-height: 1.8;
+    color: var(--color-gray-700);
+
+    & a {
+        text-decoration: none;
+        color: var(--color-blue-600);
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}

--- a/app/components/premium/PremiumPage.tsx
+++ b/app/components/premium/PremiumPage.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import HeaderLayout from "../layout/HeaderLayout";
+import CtaSection from "./CtaSection";
+import FaqSection from "./FaqSection";
+import styles from "./PremiumPage.module.css";
+import PricingTable from "./PricingTable";
+
+export function PremiumPage() {
+  return (
+    <HeaderLayout>
+      <div className={styles["page-wrapper"]}>
+        <header className={styles["page-header"]}>
+          <h1 className={styles.heading}>Jiki Premium</h1>
+          <p className={styles.subheading}>
+            Accelerate your road to job-ready. Unlock every course, every project, unlimited AI support, and everything
+            else Jiki has to offer.
+          </p>
+        </header>
+
+        <div className={styles["main-content"]}>
+          <PricingTable />
+        </div>
+
+        <FaqSection />
+
+        <div className={styles["main-content"]}>
+          <CtaSection />
+        </div>
+      </div>
+    </HeaderLayout>
+  );
+}

--- a/app/components/premium/PricingTable.tsx
+++ b/app/components/premium/PricingTable.tsx
@@ -1,0 +1,45 @@
+import CategoryRow from "./CategoryRow";
+import FeatureRow from "./FeatureRow";
+import PlanPrice from "./PlanPrice";
+import styles from "./PremiumPage.module.css";
+import { FEATURE_CATEGORIES } from "./pricing.data";
+
+export default function PricingTable() {
+  return (
+    <div className={styles["pricing-table-wrapper"]}>
+      <div className={styles["table-header-row"]}>
+        <div className={styles["col-feature-header"]}>
+          <div>
+            <div className={styles["compare-plans-title"]}>Compare plans</div>
+            <p className={styles["compare-plans-desc"]}>
+              Here&apos;s what&apos;s included in each plan,
+              <br />
+              so you can choose with confidence.
+            </p>
+          </div>
+        </div>
+        <div className={styles["col-free-header"]}>
+          <PlanPrice variant="free" />
+        </div>
+        <div className={styles["col-premium-header"]}>
+          <PlanPrice variant="premium" />
+        </div>
+      </div>
+
+      {FEATURE_CATEGORIES.map((category) => (
+        <div key={category.label}>
+          <CategoryRow label={category.label} />
+          {category.features.map((feature, i) => (
+            <FeatureRow
+              key={i}
+              title={feature.title}
+              desc={feature.desc}
+              free={feature.free}
+              premium={feature.premium}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/components/premium/PublicPremiumPrice.tsx
+++ b/app/components/premium/PublicPremiumPrice.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuthStore } from "@/lib/auth/authStore";
+import { fetchExternalPricing } from "@/lib/api/externalPricing";
+import type { PremiumPrices } from "@/lib/pricing";
+
+function fractionDigits(currency: string): number {
+  return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
+}
+
+function formatMonthly(prices: PremiumPrices): string {
+  const currencyUpper = prices.currency.toUpperCase();
+  const divisor = Math.pow(10, fractionDigits(currencyUpper));
+  const amount = prices.monthly / divisor;
+
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currencyUpper,
+    currencyDisplay: "narrowSymbol",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2
+  }).format(amount);
+}
+
+export function PublicPremiumPrice() {
+  const user = useAuthStore((state) => state.user);
+  const [publicPrices, setPublicPrices] = useState<PremiumPrices | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      return;
+    }
+    let cancelled = false;
+    fetchExternalPricing()
+      .then((res) => {
+        if (!cancelled) {
+          setPublicPrices(res.premium_prices);
+        }
+      })
+      .catch(() => {
+        // Fail silently — fallback below renders nothing.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const prices = user?.premium_prices ?? publicPrices;
+  if (!prices) {
+    return <>—</>;
+  }
+
+  return <>{formatMonthly(prices)}</>;
+}

--- a/app/components/premium/pricing.data.tsx
+++ b/app/components/premium/pricing.data.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import type { FaqItem, FeatureCategoryData } from "./pricing.types";
+
+export const FEATURE_CATEGORIES: FeatureCategoryData[] = [
+  {
+    label: "Coding Fundamentals",
+    features: [
+      {
+        title: "Coding Exercises",
+        desc: "Learn by doing with our growing library of interactive exercises.",
+        free: true,
+        premium: true
+      },
+      {
+        title: "Full Concept Library",
+        desc: "Bite-sized lessons covering every coding concept you need to know.",
+        free: true,
+        premium: true
+      },
+      {
+        title: "Jiki Projects",
+        desc: "Combine the skills you've learned into real, end-to-end projects.",
+        free: false,
+        premium: true
+      },
+      {
+        title: "Talk to Jiki",
+        desc: "Get unstuck with AI-powered hints and explanations from Jiki.",
+        free: "30 mins",
+        premium: "Unlimited"
+      }
+    ]
+  },
+  {
+    label: "Build with Jeremy",
+    features: [
+      {
+        title: "Building Fundamentals series",
+        desc: "Watch Jeremy build a web platform from scratch — servers, databases, auth, and more.",
+        free: "First episodes",
+        premium: "Full access"
+      },
+      {
+        title: "How Things Work series",
+        desc: "Deep dives into the trickier bits of Exercism and Jiki, and why they're built that way.",
+        free: "Sample Episode",
+        premium: "Full access"
+      },
+      {
+        title: "Early access to new features",
+        desc: "Try out new features before everyone else.",
+        free: false,
+        premium: true
+      }
+    ]
+  },
+  {
+    label: "Support",
+    features: [
+      {
+        title: "Community forums",
+        desc: "Ask questions and learn alongside other Jiki students.",
+        free: true,
+        premium: true
+      },
+      {
+        title: "Q&A livestreams with Jeremy",
+        desc: "Join live Q&A sessions where Jeremy answers your coding and building questions.",
+        free: false,
+        premium: true
+      }
+    ]
+  },
+  {
+    label: "Certificates",
+    features: [
+      {
+        title: "Earn certificates for courses",
+        desc: "Show off what you've learned with shareable certificates.",
+        free: false,
+        premium: true
+      }
+    ]
+  },
+  {
+    label: "Experience",
+    features: [
+      {
+        title: "Ad-free learning",
+        desc: "Focus on learning without distractions.",
+        free: false,
+        premium: true
+      }
+    ]
+  }
+];
+
+export const FAQ_ITEMS: FaqItem[] = [
+  {
+    question: "Can I try Jiki for free?",
+    answer:
+      "Yes! You can sign up for free and use the Basic plan for as long as you like. Upgrade to Premium whenever you need full access — there's no obligation."
+  },
+  {
+    question: "Is there a minimum contract length?",
+    answer: "No minimum contract — Premium is billed monthly and you can cancel at any time from your account settings."
+  },
+  {
+    question: "What happens if I cancel my Premium subscription?",
+    answer:
+      "You'll keep Premium access until the end of your current billing period, and then your account will move back to the Basic plan. You don't lose any of your progress — you just lose access to Premium-only features."
+  },
+  {
+    question: "Do you offer discounts for students or those who can't afford Premium?",
+    answer: (
+      <>
+        We want Jiki to be accessible to everyone. If cost is a barrier, please{" "}
+        <Link href="/articles/support">get in touch</Link> and we&apos;ll do what we can to help.
+      </>
+    )
+  },
+  {
+    question: "Can I upgrade or downgrade later?",
+    answer:
+      "Absolutely. You can upgrade to Premium at any time from your account, and you can cancel just as easily whenever you'd like."
+  }
+];

--- a/app/components/premium/pricing.types.ts
+++ b/app/components/premium/pricing.types.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+export interface FaqItem {
+  question: string;
+  answer: ReactNode;
+}
+
+export interface FeatureRowData {
+  title: ReactNode;
+  desc: string;
+  free: boolean | string;
+  premium: boolean | string;
+}
+
+export interface FeatureCategoryData {
+  label: string;
+  features: FeatureRowData[];
+}

--- a/app/components/ui-kit/Button/Button.tsx
+++ b/app/components/ui-kit/Button/Button.tsx
@@ -14,7 +14,11 @@ function Spinner({ variant }: { variant: ButtonVariant }) {
   const spinnerClasses = [
     "w-[18px] h-[18px] border-2 rounded-full",
     "animate-[ui-spin_0.6s_linear_infinite]",
-    variant === "primary" ? "border-white/30 border-t-white" : "border-blue-500/30 border-t-blue-500"
+    variant === "primary"
+      ? "border-white/30 border-t-white"
+      : variant === "white"
+        ? "border-gray-400/30 border-t-gray-800"
+        : "border-blue-500/30 border-t-blue-500"
   ].join(" ");
 
   return <div className={spinnerClasses} />;
@@ -92,6 +96,20 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             "hover:border-blue-500",
             "hover:shadow-[0_0_0_4px_rgba(59,130,246,0.1),0_4px_16px_rgba(59,130,246,0.2)]"
           ]
+      ]
+        .flat()
+        .filter(Boolean)
+        .join(" "),
+
+      white: [
+        // Colors
+        "border-white text-gray-800 bg-white",
+
+        // Shadows
+        "shadow-[0_2px_8px_var(--color-shadow-subtle)]",
+
+        // Hover states (only when not loading/disabled)
+        !loading && !disabled && ["hover:shadow-[0_0_0_4px_rgba(255,255,255,0.25),0_4px_16px_rgba(0,0,0,0.15)]"]
       ]
         .flat()
         .filter(Boolean)

--- a/app/components/ui-kit/Button/ButtonWithRenderProps.tsx
+++ b/app/components/ui-kit/Button/ButtonWithRenderProps.tsx
@@ -4,7 +4,7 @@ import type { ButtonProps } from "./types";
 interface ButtonRenderProps {
   isLoading: boolean;
   isDisabled: boolean;
-  variant: "primary" | "secondary";
+  variant: "primary" | "secondary" | "white";
   className: string;
   buttonProps: {
     type: "button";
@@ -15,8 +15,8 @@ interface ButtonRenderProps {
 
 interface ButtonWithRenderPropsProps extends Omit<ButtonProps, "children" | "icon"> {
   children: (props: ButtonRenderProps) => ReactNode;
-  renderIcon?: (props: { isLoading: boolean; variant: "primary" | "secondary" }) => ReactNode;
-  renderSpinner?: (props: { variant: "primary" | "secondary" }) => ReactNode;
+  renderIcon?: (props: { isLoading: boolean; variant: "primary" | "secondary" | "white" }) => ReactNode;
+  renderSpinner?: (props: { variant: "primary" | "secondary" | "white" }) => ReactNode;
   renderContent?: (props: { children: ReactNode; isLoading: boolean }) => ReactNode;
 }
 
@@ -63,17 +63,29 @@ export const ButtonWithRenderProps = forwardRef<HTMLButtonElement, ButtonWithRen
         ${!isDisabled ? "hover:border-blue-500 hover:shadow-[0_0_0_4px_rgba(59,130,246,0.15)]" : ""}
       `
         .trim()
+        .replace(/\s+/g, " "),
+      white: `
+        border-white text-gray-800 bg-white shadow-[0_2px_4px_rgba(0,0,0,0.05)]
+        ${!isDisabled ? "hover:shadow-[0_0_0_4px_rgba(255,255,255,0.25),0_4px_16px_rgba(0,0,0,0.15)]" : ""}
+      `
+        .trim()
         .replace(/\s+/g, " ")
     };
 
     const buttonClassName = `${baseClasses} ${variantClasses[variant]} ${className || ""}`;
 
     // Default spinner renderer
-    const defaultSpinnerRenderer = ({ variant: spinnerVariant }: { variant: "primary" | "secondary" }) => (
+    const defaultSpinnerRenderer = ({ variant: spinnerVariant }: { variant: "primary" | "secondary" | "white" }) => (
       <div
         className={`
           w-[18px] h-[18px] border-2 rounded-full animate-[ui-spin_0.6s_linear_infinite]
-          ${spinnerVariant === "primary" ? "border-white/30 border-t-white" : "border-blue-500/30 border-t-blue-500"}
+          ${
+            spinnerVariant === "primary"
+              ? "border-white/30 border-t-white"
+              : spinnerVariant === "white"
+                ? "border-gray-400/30 border-t-gray-800"
+                : "border-blue-500/30 border-t-blue-500"
+          }
         `
           .trim()
           .replace(/\s+/g, " ")}

--- a/app/components/ui-kit/Button/types.ts
+++ b/app/components/ui-kit/Button/types.ts
@@ -8,7 +8,7 @@ import type { BaseUIProps, DisableableProps, LoadingProps, IconProps, FullWidthP
 /**
  * Button style variants
  */
-export type ButtonVariant = "primary" | "secondary";
+export type ButtonVariant = "primary" | "secondary" | "white";
 
 /**
  * Props for the Button component


### PR DESCRIPTION
## Summary
- New `/premium` page (under `(hybrid)`) that introduces Jiki Premium and compares Basic vs Premium feature-by-feature
- Pricing table grouped into Coding Fundamentals, Build with Jeremy, Support, Certificates, Experience
- Bottom CTA varies by auth state: signup for logged-out, upgrade modal for logged-in basic, thank-you for premium
- Adds a `white` variant to the ui-kit `Button` component (white bg, gray-800 text) for use on dark CTA banners
- Adds a "Jiki Premium" link to the external footer

## Test plan
- [ ] Visit `/premium` logged out — page SSRs, shows "Sign up for free" CTA
- [ ] Visit `/premium` as a Basic user — CTA opens premium upgrade modal
- [ ] Visit `/premium` as a Premium user — shows thank-you message
- [ ] Footer "Jiki Premium" link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)