### PR TITLE
Reword scrubber-disabled tooltip when code has been edited

### DIFF
--- a/app/components/coding-exercise/ui/scrubber/Scrubber.tsx
+++ b/app/components/coding-exercise/ui/scrubber/Scrubber.tsx
@@ -28,7 +28,7 @@ export default function Scrubber() {
   // Tooltip reasons - separated by what they affect
   const getGlobalDisabledReason = () => {
     if (hasCodeBeenEdited) {
-      return "Scrubber disabled: Code has been edited. Run tests to re-enable.";
+      return 'The code has been edited so we\'ve disabled the scrubber. Press "Run code" to re-enable it.';
     }
     if (isSpotlightActive) {
       return "Scrubber disabled: Spotlight mode is active.";

--- a/app/tests/e2e/coding-exercise/scrubber-tooltip.test.ts
+++ b/app/tests/e2e/coding-exercise/scrubber-tooltip.test.ts
@@ -26,8 +26,9 @@ test.describe("Scrubber Tooltip E2E", () => {
       await expect(tooltip).toBeVisible();
 
       // Check tooltip content
-      await expect(tooltip).toContainText("Code has been edited");
-      await expect(tooltip).toContainText("Run tests to re-enable");
+      await expect(tooltip).toContainText(
+        'The code has been edited so we\'ve disabled the scrubber. Press "Run code" to re-enable it.'
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Softens the scrubber tooltip copy from "Scrubber disabled: Code has been edited. Run tests to re-enable." to "The code has been edited so we've disabled the scrubber. Press \"Run code\" to re-enable it."
- Updates the matching e2e assertion.

## Test plan

- [ ] Scrubber tooltip e2e test passes against the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)