### PR TITLE
Rename "Walkthrough" to "Deep Dive" in user-facing copy

### DIFF
--- a/app/components/coding-exercise/ui/HintsPanel.tsx
+++ b/app/components/coding-exercise/ui/HintsPanel.tsx
@@ -96,15 +96,15 @@ export default function HintsPanel({ hints, walkthroughVideoData, lessonSlug, cl
 
         {hasWalkthrough && (
           <div className={style.walkthroughSection}>
-            <h3>Walkthrough Video</h3>
-            <p>Still stuck? Watch a step-by-step walkthrough of this exercise.</p>
+            <h3>Deep Dive</h3>
+            <p>Still stuck? Watch a deep dive of Jeremy solving this exercise.</p>
             {walkthroughUnlocked ? (
               <InlineWalkthroughPlayer playbackId={walkthroughVideoData[0].id} lessonSlug={lessonSlug} />
             ) : (
               <div className={style.walkthroughThumbWrapper} onClick={handleWalkthroughClick}>
                 <img
                   src={`https://image.mux.com/${walkthroughVideoData[0].id}/thumbnail.jpg?width=400&height=225`}
-                  alt="Walkthrough video thumbnail"
+                  alt="Deep Dive video thumbnail"
                   className={style.walkthroughThumb}
                 />
                 <div className={style.walkthroughPlayBtn}>

--- a/app/components/dashboard/exercise-path/ui/WalkthroughCard.tsx
+++ b/app/components/dashboard/exercise-path/ui/WalkthroughCard.tsx
@@ -63,7 +63,7 @@ export function WalkthroughCard({ lesson, isCompleting }: WalkthroughCardProps) 
         <div className={styles.progress}>
           <div className={styles.progressFill} style={{ width: `${percentage}%` }} />
         </div>
-        <div className={styles.label}>Walkthrough</div>
+        <div className={styles.label}>Deep Dive</div>
       </div>
       <div className={styles.back}>
         <svg viewBox="0 0 24 24">

--- a/app/lib/modal/modals/WalkthroughConfirmModal.tsx
+++ b/app/lib/modal/modals/WalkthroughConfirmModal.tsx
@@ -18,7 +18,7 @@ export function WalkthroughConfirmModal({ onConfirm }: WalkthroughConfirmModalPr
   return (
     <div className={styles.content}>
       <h4>Try solving it yourself first?</h4>
-      <p>Before watching the walkthrough, you might want use these resources to help you pass the tests yourself:</p>
+      <p>Before watching the Deep Dive, you might want use these resources to help you pass the tests yourself:</p>
       <ul className={styles.resources}>
         <li>
           <span className={`${styles.resourceIcon} ${styles.blue}`}>
@@ -59,7 +59,7 @@ export function WalkthroughConfirmModal({ onConfirm }: WalkthroughConfirmModalPr
           I&apos;ll try first
         </button>
         <button className="ui-btn ui-btn-default ui-btn-primary" onClick={handleWatch}>
-          Watch walkthrough
+          Watch the Deep Dive
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Renames user-visible "Walkthrough" copy to "Deep Dive" on the dashboard walkthrough card, the hints panel walkthrough section, and the walkthrough confirmation modal.
- Reworded the hints-panel description to "Watch a deep dive of Jeremy solving this exercise."
- Internal identifiers (component names, file names, CSS classes, storage keys, API field names) left unchanged.

## Test plan
- [ ] Dashboard: card next to a completed lesson reads "Deep Dive"
- [ ] HintsPanel: section header reads "Deep Dive" and copy reads "Watch a deep dive of Jeremy solving this exercise."
- [ ] Confirm modal: body reads "Before watching the Deep Dive…" and button reads "Watch the Deep Dive"

🤖 Generated with [Claude Code](https://claude.com/claude-code)