### PR TITLE
Fix io-test-updates e2e: wait for results, not pending view

### DIFF
--- a/app/tests/e2e/coding-exercise/io-test-updates.test.ts
+++ b/app/tests/e2e/coding-exercise/io-test-updates.test.ts
@@ -13,7 +13,11 @@ test.describe("IO Test Updates E2E", () => {
 
     // Run tests
     await page.locator('[data-testid="run-button"]').click();
-    await page.locator('[data-ci="inspected-test-result-view"]').waitFor();
+    // Wait for test results to actually be populated (inspected-test-result-view also renders in pending state)
+    await page.waitForFunction(() => {
+      const orchestrator = (window as any).testOrchestrator;
+      return orchestrator?.getStore().getState().testSuiteResult !== null;
+    });
   });
 
   test("should update actual value when running code multiple times", async ({ page }) => {


### PR DESCRIPTION
## Summary
- The `io-test-updates` e2e test has been failing on main since #457
- Root cause: `beforeEach` waited on `[data-ci=\"inspected-test-result-view\"]`, but #457 added a pre-run preview view that shares the same selector — so the wait resolved before `testSuiteResult` populated and `getFirstExpect()` returned null (TypeError on `firstExpect.actual`)
- Switch to polling `testSuiteResult !== null`, matching the existing pattern in `test-completion-navigation.test.ts`

## Test plan
- [x] `pnpm exec playwright test tests/e2e/coding-exercise/io-test-updates.test.ts --project=chromium` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)