### PR TITLE
js interpreter: error on bare function references

### DIFF
--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -1,5 +1,20 @@
 # JavaScript Interpreter Evolution
 
+## 2026-05-12: Guard bare function references (UnexpectedUncalledFunction)
+
+A bare callable identifier used as a value (e.g. `circle;` as a statement, or `let g = circle;`) now raises `UnexpectedUncalledFunction` instead of silently stepping. Mirrors JikiScript's `UnexpectedUncalledFunctionInExpression` so semantics match across interpreters.
+
+### Mechanism
+
+- New AST node `CalleeIdentifierExpression extends IdentifierExpression` in `src/javascript/expression.ts`. It inherits the `"IdentifierExpression"` type tag so node-allowance checks and existing `instanceof IdentifierExpression` introspection sites keep matching unchanged.
+- Parser rewrite in `finishCallExpression` (`src/javascript/parser.ts`): a `rewriteCallee` helper walks into `GroupingExpression`s and swaps a bare `IdentifierExpression` callee for `CalleeIdentifierExpression`. Other callee shapes (`MemberExpression`, nested `CallExpression`, `NewExpression`) are untouched.
+- Dispatch in `executor.evaluate` checks `CalleeIdentifierExpression` before `IdentifierExpression` (subclass first). The new `executeCalleeIdentifierExpression` does the environment lookup without the callable guard; `executeIdentifierExpression` adds the guard via `isCallable(value)`.
+- New `RuntimeErrorType` `UnexpectedUncalledFunction` with translations in both `system` and `en` locale files.
+
+### Consequence — first-class function values
+
+As a deliberate side-effect, JS-style first-class function values are now disallowed: `let g = f;`, `return f;`, and `someFn(f)` (passing a function by identifier) all raise the new error. This matches JikiScript and forecloses callback-style higher-order functions for now. Note that `obj.method;` (a bare member-callable) still silently steps — that case goes through `executeMemberExpression` and is intentionally out of scope; track as a follow-up if it surfaces.
+
 ## 2025-10-09: Added String Search Methods (indexOf, lastIndexOf, includes, startsWith, endsWith)
 
 ### Overview

--- a/interpreters/src/javascript/assertion-helpers.ts
+++ b/interpreters/src/javascript/assertion-helpers.ts
@@ -94,7 +94,7 @@ function getSubStatements(stmt: Statement): Statement[] {
   if (stmt instanceof ForStatement) {
     const result: Statement[] = [stmt.body];
     if (stmt.init && !(stmt.init instanceof Expression)) {
-      result.push(stmt.init as unknown as Statement);
+      result.push(stmt.init);
     }
     return result;
   }

--- a/interpreters/src/javascript/executor.ts
+++ b/interpreters/src/javascript/executor.ts
@@ -8,6 +8,7 @@ import {
   UnaryExpression,
   GroupingExpression,
   IdentifierExpression,
+  CalleeIdentifierExpression,
   AssignmentExpression,
   UpdateExpression,
   TemplateLiteralExpression,
@@ -53,6 +54,7 @@ import { executeBinaryExpression } from "./executor/executeBinaryExpression";
 import { executeUnaryExpression } from "./executor/executeUnaryExpression";
 import { executeGroupingExpression } from "./executor/executeGroupingExpression";
 import { executeIdentifierExpression } from "./executor/executeIdentifierExpression";
+import { executeCalleeIdentifierExpression } from "./executor/executeCalleeIdentifierExpression";
 import { executeUpdateExpression } from "./executor/executeUpdateExpression";
 import { executeBlockStatement } from "./executor/executeBlockStatement";
 import { executeExpressionStatement } from "./executor/executeExpressionStatement";
@@ -135,7 +137,8 @@ export type RuntimeErrorType =
   | "InOperatorRequiresIntegerIndex"
   | "InWithArrayNotAllowed"
   | "ClassNotFound"
-  | "PropertyNotFoundOnInstance";
+  | "PropertyNotFoundOnInstance"
+  | "UnexpectedUncalledFunction";
 
 export class RuntimeError extends Error {
   public category: string = "RuntimeError";
@@ -518,6 +521,10 @@ export class Executor {
 
     if (expression instanceof GroupingExpression) {
       return executeGroupingExpression(this, expression);
+    }
+
+    if (expression instanceof CalleeIdentifierExpression) {
+      return executeCalleeIdentifierExpression(this, expression);
     }
 
     if (expression instanceof IdentifierExpression) {

--- a/interpreters/src/javascript/executor/executeBreakStatement.ts
+++ b/interpreters/src/javascript/executor/executeBreakStatement.ts
@@ -13,7 +13,7 @@ export function executeBreakStatement(executor: Executor, statement: BreakStatem
   executor.executeFrame<EvaluationResultBreakStatement>(statement, () => {
     return {
       type: "BreakStatement",
-    } as EvaluationResultBreakStatement;
+    };
   });
 
   throw new BreakFlowControlError(statement.location);

--- a/interpreters/src/javascript/executor/executeCalleeIdentifierExpression.ts
+++ b/interpreters/src/javascript/executor/executeCalleeIdentifierExpression.ts
@@ -1,20 +1,15 @@
 import type { Executor } from "../executor";
-import type { IdentifierExpression } from "../expression";
+import type { CalleeIdentifierExpression } from "../expression";
 import type { EvaluationResultIdentifierExpression } from "../evaluation-result";
-import { isCallable } from "../functions";
 
-export function executeIdentifierExpression(
+export function executeCalleeIdentifierExpression(
   executor: Executor,
-  expression: IdentifierExpression
+  expression: CalleeIdentifierExpression
 ): EvaluationResultIdentifierExpression {
   const value = executor.environment.get(expression.name.lexeme);
 
   if (value === undefined) {
     executor.error("VariableNotDeclared", expression.location, { name: expression.name.lexeme });
-  }
-
-  if (isCallable(value)) {
-    executor.error("UnexpectedUncalledFunction", expression.location, { name: expression.name.lexeme });
   }
 
   return {

--- a/interpreters/src/javascript/executor/executeContinueStatement.ts
+++ b/interpreters/src/javascript/executor/executeContinueStatement.ts
@@ -13,7 +13,7 @@ export function executeContinueStatement(executor: Executor, statement: Continue
   executor.executeFrame<EvaluationResultContinueStatement>(statement, () => {
     return {
       type: "ContinueStatement",
-    } as EvaluationResultContinueStatement;
+    };
   });
 
   throw new ContinueFlowControlError(statement.location);

--- a/interpreters/src/javascript/executor/executeReturnStatement.ts
+++ b/interpreters/src/javascript/executor/executeReturnStatement.ts
@@ -1,7 +1,6 @@
 import type { Executor } from "../executor";
 import { ReturnValue } from "../functions";
 import type { ReturnStatement } from "../statement";
-import type { EvaluationResultReturnStatement } from "../evaluation-result";
 import { createJSObject } from "../jikiObjects";
 
 export function executeReturnStatement(executor: Executor, statement: ReturnStatement): void {
@@ -23,7 +22,7 @@ export function executeReturnStatement(executor: Executor, statement: ReturnStat
       jikiObject: value.jikiObject,
       immutableJikiObject: value.jikiObject.clone(),
     };
-  }) as EvaluationResultReturnStatement;
+  });
 
   // evaluationResult can be undefined for bare return statements
   throw new ReturnValue(evaluationResult.jikiObject, statement.location);

--- a/interpreters/src/javascript/expression.ts
+++ b/interpreters/src/javascript/expression.ts
@@ -70,6 +70,11 @@ export class IdentifierExpression extends Expression {
   }
 }
 
+// Used by the parser for the callee of a CallExpression so the executor can
+// skip the uncalled-function guard. Inherits IdentifierExpression's type tag
+// so node-allowance checks and AST introspection treat it as an identifier.
+export class CalleeIdentifierExpression extends IdentifierExpression {}
+
 export class AssignmentExpression extends Expression {
   constructor(
     public target: Token | MemberExpression,

--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -117,7 +117,7 @@
       "InWithArrayNotAllowed": "Although the 'in' keyword can be used with arrays, it's a more advanced feature. For now, stick to using it just with dictionaries.",
       "ClassNotFound": "The class '{{name}}' is not defined.",
       "PropertyNotFoundOnInstance": "Property '{{property}}' does not exist on instances of '{{className}}'.",
-      "UnexpectedUncalledFunction": "You used the `{{name}}` function as if it's a variable. Did you forget to add `()` at the end?"
+      "UnexpectedUncalledFunction": "You referenced the `{{name}}` function but didn't actually use it. Did you forget to add `()` at the end?"
     },
     "disabledLanguageFeature": {
       "DisabledFeatureExcludeListViolation": "The `{{lexeme}}` feature is not available yet at your current level.",

--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -116,7 +116,8 @@
       "InOperatorRequiresIntegerIndex": "The 'in' operator requires an integer index when used with arrays, but got {{type}}.",
       "InWithArrayNotAllowed": "Although the 'in' keyword can be used with arrays, it's a more advanced feature. For now, stick to using it just with dictionaries.",
       "ClassNotFound": "The class '{{name}}' is not defined.",
-      "PropertyNotFoundOnInstance": "Property '{{property}}' does not exist on instances of '{{className}}'."
+      "PropertyNotFoundOnInstance": "Property '{{property}}' does not exist on instances of '{{className}}'.",
+      "UnexpectedUncalledFunction": "You used the `{{name}}` function as if it's a variable. Did you forget to add `()` at the end?"
     },
     "disabledLanguageFeature": {
       "DisabledFeatureExcludeListViolation": "The `{{lexeme}}` feature is not available yet at your current level.",

--- a/interpreters/src/javascript/locales/system/translation.json
+++ b/interpreters/src/javascript/locales/system/translation.json
@@ -116,7 +116,8 @@
       "InOperatorRequiresIntegerIndex": "InOperatorRequiresIntegerIndex: type: {{type}}",
       "InWithArrayNotAllowed": "InWithArrayNotAllowed",
       "ClassNotFound": "ClassNotFound: name: {{name}}",
-      "PropertyNotFoundOnInstance": "PropertyNotFoundOnInstance: property: {{property}}: className: {{className}}"
+      "PropertyNotFoundOnInstance": "PropertyNotFoundOnInstance: property: {{property}}: className: {{className}}",
+      "UnexpectedUncalledFunction": "UnexpectedUncalledFunction: name: {{name}}"
     },
     "disabledLanguageFeature": {
       "DisabledFeatureExcludeListViolation": "ExcludeListViolation: tokenType: {{tokenType}}: lexeme: {{lexeme}}",

--- a/interpreters/src/javascript/parser.ts
+++ b/interpreters/src/javascript/parser.ts
@@ -6,6 +6,7 @@ import {
   UnaryExpression,
   GroupingExpression,
   IdentifierExpression,
+  CalleeIdentifierExpression,
   AssignmentExpression,
   UpdateExpression,
   TemplateLiteralExpression,
@@ -773,7 +774,7 @@ export class Parser {
         // Dot notation: obj.prop
         // Keywords are allowed as property names after a dot (e.g. "abc".repeat(3))
         const propertyToken = this.advance();
-        if (propertyToken.type !== "IDENTIFIER" && !KeywordTokens.includes(propertyToken.type as any)) {
+        if (propertyToken.type !== "IDENTIFIER" && !KeywordTokens.includes(propertyToken.type)) {
           this.error("InvalidDictionaryKey", propertyToken.location);
         }
         const property = new LiteralExpression(propertyToken.lexeme, propertyToken.location);
@@ -828,7 +829,20 @@ export class Parser {
     this.consume("RIGHT_PAREN", "MissingRightParenthesisAfterFunctionCall");
     const rightParen = this.previous();
 
-    return new CallExpression(callee, args, Location.between(callee, rightParen));
+    return new CallExpression(this.rewriteCallee(callee), args, Location.between(callee, rightParen));
+  }
+
+  private rewriteCallee(expr: Expression): Expression {
+    if (expr instanceof GroupingExpression) {
+      return new GroupingExpression(this.rewriteCallee(expr.inner), expr.location);
+    }
+    if (expr instanceof CalleeIdentifierExpression) {
+      return expr;
+    }
+    if (expr instanceof IdentifierExpression) {
+      return new CalleeIdentifierExpression(expr.name, expr.location);
+    }
+    return expr;
   }
 
   private primary(): Expression {

--- a/interpreters/src/jikiscript/executor/executeChangePropertyStatement.ts
+++ b/interpreters/src/jikiscript/executor/executeChangePropertyStatement.ts
@@ -29,11 +29,7 @@ export function executeChangePropertyStatement(executor: Executor, statement: Ch
     // Do the update
     const oldValue = object.jikiObject.getField(statement.property.lexeme);
     try {
-      setter.fn.apply(undefined, [
-        executor.getExecutionContext(),
-        object.jikiObject,
-        value.jikiObject as Jiki.JikiObject,
-      ]);
+      setter.fn.apply(undefined, [executor.getExecutionContext(), object.jikiObject, value.jikiObject]);
     } catch (e: unknown) {
       if (e instanceof LogicError) {
         executor.error("LogicErrorInExecution", statement.location, { message: e.message });

--- a/interpreters/src/jikiscript/executor/executeInstantiationExpression.ts
+++ b/interpreters/src/jikiscript/executor/executeInstantiationExpression.ts
@@ -42,7 +42,7 @@ export function executeInstantiationExpression(
 
     const object = jikiClass.instantiate(
       executor.getExecutionContext(),
-      args.map(arg => (arg.jikiObject as JikiTypes.JikiObject).toArg())
+      args.map(arg => arg.jikiObject.toArg())
     );
 
     return {

--- a/interpreters/src/jikiscript/executor/executeSetPropertyStatement.ts
+++ b/interpreters/src/jikiscript/executor/executeSetPropertyStatement.ts
@@ -40,7 +40,7 @@ export function executeSetPropertyStatement(executor: Executor, statement: SetPr
     }
 
     executor.guardNoneJikiObject(value.jikiObject, statement.location);
-    executor.contextualThis.setField(statement.property.lexeme, value.jikiObject as any);
+    executor.contextualThis.setField(statement.property.lexeme, value.jikiObject);
 
     return {
       type: "SetPropertyStatement",

--- a/interpreters/src/jikiscript/executor/executeUnaryExpression.ts
+++ b/interpreters/src/jikiscript/executor/executeUnaryExpression.ts
@@ -12,7 +12,7 @@ export function executeUnaryExpression(
   switch (expression.operator.type) {
     case "NOT": {
       executor.verifyBoolean(operand.jikiObject, expression.operand);
-      const notResult = new Jiki.Boolean(!(operand.jikiObject as Jiki.Boolean).value);
+      const notResult = new Jiki.Boolean(!operand.jikiObject.value);
       return {
         type: "UnaryExpression",
         jikiObject: notResult,
@@ -22,7 +22,7 @@ export function executeUnaryExpression(
     }
     case "MINUS": {
       executor.verifyNumber(operand.jikiObject, expression.operand);
-      const minusResult = new Jiki.Number(-(operand.jikiObject as Jiki.Number).value);
+      const minusResult = new Jiki.Number(-operand.jikiObject.value);
       return {
         type: "UnaryExpression",
         jikiObject: minusResult,

--- a/interpreters/src/jikiscript/stdlib.ts
+++ b/interpreters/src/jikiscript/stdlib.ts
@@ -88,8 +88,8 @@ function randomNumber(ctx: ExecutionContext, minObj: Jiki.JikiObject, maxObj: Ji
   verifyType(minObj, Jiki.Number, "number", 1);
   verifyType(maxObj, Jiki.Number, "number", 2);
 
-  const min = Math.trunc((minObj as Jiki.Number).value);
-  const max = Math.trunc((maxObj as Jiki.Number).value);
+  const min = Math.trunc(minObj.value);
+  const max = Math.trunc(maxObj.value);
 
   if (min > max) {
     ctx.logicError(

--- a/interpreters/src/python/describers/describeCallExpression.ts
+++ b/interpreters/src/python/describers/describeCallExpression.ts
@@ -9,7 +9,7 @@ export function describeCallExpression(expression: CallExpression, result: Evalu
   // First, describe evaluation of all arguments
   for (let i = 0; i < result.args.length; i++) {
     const argResult = result.args[i];
-    const argSteps = describeExpression(expression.args[i], argResult as any, { functionDescriptions: {} });
+    const argSteps = describeExpression(expression.args[i], argResult, { functionDescriptions: {} });
     if (argSteps.length > 0) {
       steps.push(...argSteps);
     }

--- a/interpreters/src/python/describers/describeSteps.ts
+++ b/interpreters/src/python/describers/describeSteps.ts
@@ -14,16 +14,16 @@ export function describeExpression(
 ): string[] {
   switch (result.type) {
     case "BinaryExpression":
-      return describeBinaryExpression(expression, result as any, context);
+      return describeBinaryExpression(expression, result, context);
 
     case "UnaryExpression":
-      return describeUnaryExpression(expression, result as any, context);
+      return describeUnaryExpression(expression, result, context);
 
     case "SubscriptExpression":
-      return describeSubscriptExpression(expression, result as any);
+      return describeSubscriptExpression(expression, result);
 
     case "CallExpression":
-      return describeCallExpression(expression as any, result as any);
+      return describeCallExpression(expression as any, result);
 
     case "IdentifierExpression": {
       const identResult = result as any;

--- a/interpreters/tests/javascript/uncalled-function.test.ts
+++ b/interpreters/tests/javascript/uncalled-function.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { interpret } from "@javascript/interpreter";
+import { changeLanguage } from "@javascript/translator";
+import type { ExternalFunction } from "@shared/interfaces";
+import type { ExecutionContext } from "@javascript/executor";
+import type { TestAugmentedFrame } from "@shared/frames";
+
+const circle: ExternalFunction = {
+  name: "circle",
+  func: (_ctx: ExecutionContext) => undefined,
+  description: "draws a circle",
+  arity: 4,
+};
+
+describe("UnexpectedUncalledFunction", () => {
+  it("errors on bare external function reference as a statement", () => {
+    const code = `circle(55, 40, 20, "white");
+circle
+circle(55, 40, 20, "white");`;
+    const result = interpret(code, { externalFunctions: [circle] });
+
+    expect(result.error).toBeNull();
+    expect(result.frames[0].status).toBe("SUCCESS");
+
+    const errorFrame = result.frames[1] as TestAugmentedFrame;
+    expect(errorFrame.status).toBe("ERROR");
+    expect(errorFrame.error?.type).toBe("UnexpectedUncalledFunction");
+    expect(errorFrame.error?.context?.name).toBe("circle");
+  });
+
+  it("errors on bare user-defined function reference as a statement", () => {
+    const code = `function f() {}
+f;`;
+    const result = interpret(code);
+
+    const errorFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+    expect(errorFrame.status).toBe("ERROR");
+    expect(errorFrame.error?.type).toBe("UnexpectedUncalledFunction");
+    expect(errorFrame.error?.context?.name).toBe("f");
+  });
+
+  it("errors on assigning a bare function reference to a variable", () => {
+    const code = `function f() {}
+let g = f;`;
+    const result = interpret(code);
+
+    const errorFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+    expect(errorFrame.status).toBe("ERROR");
+    expect(errorFrame.error?.type).toBe("UnexpectedUncalledFunction");
+    expect(errorFrame.error?.context?.name).toBe("f");
+  });
+
+  it("errors on passing a bare function reference as an argument", () => {
+    const code = `function f() {}
+function h(x) {}
+h(f);`;
+    const result = interpret(code);
+
+    const errorFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+    expect(errorFrame.status).toBe("ERROR");
+    expect(errorFrame.error?.type).toBe("UnexpectedUncalledFunction");
+    expect(errorFrame.error?.context?.name).toBe("f");
+  });
+
+  describe("system language", () => {
+    beforeAll(async () => {
+      await changeLanguage("system");
+    });
+    afterAll(async () => {
+      await changeLanguage("en");
+    });
+
+    it("produces the expected message", () => {
+      const code = `function f() {}
+f;`;
+      const result = interpret(code);
+
+      const errorFrame = result.frames[result.frames.length - 1] as TestAugmentedFrame;
+      expect(errorFrame.error?.message).toBe("UnexpectedUncalledFunction: name: f");
+    });
+  });
+
+  describe("regressions", () => {
+    it("parenthesised callee still calls successfully", () => {
+      const code = `function f() { return 1; }
+(f)();`;
+      const result = interpret(code);
+      expect(result.frames.every(f => f.status === "SUCCESS")).toBe(true);
+    });
+
+    it("double-parenthesised callee still calls successfully", () => {
+      const code = `function f() { return 1; }
+((f))();`;
+      const result = interpret(code);
+      expect(result.frames.every(f => f.status === "SUCCESS")).toBe(true);
+    });
+
+    it("normal call of external function still works", () => {
+      const result = interpret(`circle(1, 2, 3, "red");`, { externalFunctions: [circle] });
+      expect(result.frames[0].status).toBe("SUCCESS");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Bare function-as-value usage in JS (e.g. `circle;` as a statement, `let g = f;`, `someFn(f)`) now raises `UnexpectedUncalledFunction` instead of silently stepping, matching JikiScript's `UnexpectedUncalledFunctionInExpression`.
- Parser introduces `CalleeIdentifierExpression` (subclass of `IdentifierExpression`, same `type` tag, so node-allowlists and `instanceof` introspection keep matching) for the callee of a `CallExpression`; the rewrite peers through `GroupingExpression` so `(foo)()` still calls.
- Executor dispatches the subclass first; the new `executeCalleeIdentifierExpression` skips the `isCallable` guard that's been added to `executeIdentifierExpression`.

The first commit also runs `eslint --fix` across the interpreters package to clear 17 pre-existing `no-unnecessary-type-assertion` warnings that had been silently accumulating on main and were blocking the pre-commit hook. Touches 12 files outside the bare-callable work; all mechanical (drops redundant `as` casts plus one unused import).

## Out of scope

Bare member-callable references like `obj.method;` still silently step. Different code path (`executeMemberExpression` returns a `JSBoundMethod`); intentionally not fixed here. Track as follow-up if it surfaces.

## Test plan

- [x] `pnpm test` in interpreters: 3382 pass, 119 skipped
- [x] `pnpm --filter @jiki/curriculum test`: 662 pass (caught a real regression mid-implementation when an earlier draft tripped `assertNodeAllowed` — fixed by keeping the inherited type tag)
- [x] `pnpm --filter @jiki/app test`: 1634 pass
- [x] Typecheck across all three packages
- [x] Lint clean
- [x] New `tests/javascript/uncalled-function.test.ts` covers: bare statement, user-defined function, assignment, argument-passing, parenthesised callee regression, double-parenthesised callee regression, normal-call regression, system-language message

🤖 Generated with [Claude Code](https://claude.com/claude-code)