### PR TITLE
Smooth lesson loading transitions, show Jiki during auth check

### DIFF
--- a/app/app/(app)/lesson/[slug]/page.tsx
+++ b/app/app/(app)/lesson/[slug]/page.tsx
@@ -1,17 +1,7 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import LessonLoadingModal from "@/components/common/LessonLoadingModal/LessonLoadingModal";
-import { fetchUserCourse } from "@/lib/api/courses";
-import { fetchLesson, fetchUserLesson } from "@/lib/api/lessons";
-import type { UserCourse } from "@/types/course";
-import type { LessonWithData } from "@/types/lesson";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-
-const CodingExercise = dynamic(() => import("@/components/coding-exercise/CodingExercise"), { ssr: false });
-const VideoExercise = dynamic(() => import("@/components/video-exercise/VideoExercise"), { ssr: false });
-const ChooseLanguage = dynamic(() => import("@/components/choose-language/ChooseLanguage"), { ssr: false });
+import Lesson from "@/components/lesson/Lesson";
+import { use } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -20,118 +10,6 @@ interface PageProps {
 }
 
 export default function LessonPage({ params }: PageProps) {
-  const router = useRouter();
-  const [lesson, setLesson] = useState<LessonWithData | null>(null);
-  const [userCourse, setUserCourse] = useState<UserCourse | null>(null);
-  const [isCompleted, setIsCompleted] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // Update document title when lesson loads
-  useEffect(() => {
-    if (lesson) {
-      document.title = `${lesson.title} - Jiki`;
-    }
-  }, [lesson]);
-
-  // Load lesson and user course on mount
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadData() {
-      try {
-        setLoading(true);
-        const resolvedParams = await params;
-
-        if (cancelled) {
-          return;
-        }
-
-        const [lessonData, userCourseData, userLessonResult] = await Promise.all([
-          fetchLesson(resolvedParams.slug),
-          fetchUserCourse(),
-          fetchUserLesson(resolvedParams.slug).catch(() => null)
-        ]);
-
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (!cancelled) {
-          setLesson(lessonData);
-          setUserCourse(userCourseData);
-          setIsCompleted(userLessonResult?.status === "completed");
-        }
-      } catch (err) {
-        if (!cancelled) {
-          console.error("Failed to fetch lesson:", err);
-          // Auth/network/rate-limit errors never reach here (handled globally)
-          // Only application errors (404, 500, validation) reach this catch block
-          setError(err instanceof Error ? err.message : "Failed to load lesson");
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    }
-
-    void loadData();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [params]);
-
-  if (loading) {
-    return <LessonLoadingModal />;
-  }
-
-  if (error || !lesson) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <p className="text-red-600 mb-4">Error: {error || "Lesson not found"}</p>
-          <button
-            onClick={() => router.push("/dashboard")}
-            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-          >
-            Back to Dashboard
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  // Render appropriate component based on lesson type
-  if (lesson.type === "video") {
-    return <VideoExercise lessonData={lesson} />;
-  }
-
-  if (lesson.type === "exercise") {
-    return (
-      <CodingExercise
-        language={userCourse?.language || "javascript"}
-        exerciseSlug={lesson.data.slug}
-        context={{ type: "lesson", slug: lesson.slug, walkthroughVideoData: lesson.walkthrough_video_data }}
-        isCompleted={isCompleted}
-      />
-    );
-  }
-
-  if (lesson.type === "choose_language") {
-    return <ChooseLanguage lessonData={lesson} />;
-  }
-
-  // Quiz type - not yet implemented
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="text-center">
-        <p className="text-gray-600 mb-4">Quiz lessons are not yet implemented</p>
-        <button
-          onClick={() => router.push("/dashboard")}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-        >
-          Back to Dashboard
-        </button>
-      </div>
-    </div>
-  );
+  const { slug } = use(params);
+  return <Lesson slug={slug} />;
 }

--- a/app/app/(app)/projects/[slug]/page.tsx
+++ b/app/app/(app)/projects/[slug]/page.tsx
@@ -132,6 +132,7 @@ export default function ProjectPage({ params }: PageProps) {
       context={{ type: "project", slug: project.slug }}
       levelId={userCourse?.current_level_slug ?? undefined}
       isCompleted={project.status === "completed"}
+      onReady={() => {}}
     />
   );
 }

--- a/app/app/dev/choose-language/page.tsx
+++ b/app/app/dev/choose-language/page.tsx
@@ -31,5 +31,5 @@ const mockLessonData: ChooseLanguageLesson = {
 };
 
 export default function ChooseLanguagePage() {
-  return <ChooseLanguage lessonData={mockLessonData} />;
+  return <ChooseLanguage lessonData={mockLessonData} onReady={() => {}} />;
 }

--- a/app/app/dev/coding-exercise/page.tsx
+++ b/app/app/dev/coding-exercise/page.tsx
@@ -13,6 +13,7 @@ export default function CodingExerciseDevPage() {
       language="javascript"
       context={{ type: "lesson", slug: "maze-solve-basic" }}
       isCompleted={false}
+      onReady={() => {}}
     />
   );
 }

--- a/app/app/dev/video-exercise/page.tsx
+++ b/app/app/dev/video-exercise/page.tsx
@@ -22,5 +22,5 @@ const mockLessonData: VideoLesson = {
 };
 
 export default function VideoExercisePage() {
-  return <VideoExercise lessonData={mockLessonData} />;
+  return <VideoExercise lessonData={mockLessonData} onReady={() => {}} />;
 }

--- a/app/components/choose-language/ChooseLanguage.tsx
+++ b/app/components/choose-language/ChooseLanguage.tsx
@@ -38,8 +38,10 @@ export default function ChooseLanguage({ lessonData, onReady }: ChooseLanguagePr
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
-    onReady();
-  }, [onReady]);
+    if (!isInitializing) {
+      onReady();
+    }
+  }, [isInitializing, onReady]);
 
   const handleReady = () => {
     setIsInitializing(false);

--- a/app/components/choose-language/ChooseLanguage.tsx
+++ b/app/components/choose-language/ChooseLanguage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { LessonQuitButton } from "@/components/lesson/LessonQuitButton";
 import { setLanguageChoice } from "@/lib/api/courses";
@@ -26,15 +26,20 @@ type LanguageOption = ProgrammingLanguage | "random";
 
 interface ChooseLanguageProps {
   lessonData: ChooseLanguageLesson;
+  onReady: () => void;
 }
 
-export default function ChooseLanguage({ lessonData }: ChooseLanguageProps) {
+export default function ChooseLanguage({ lessonData, onReady }: ChooseLanguageProps) {
   const router = useRouter();
   const [step, setStep] = useState<Step>("video");
   const [isInitializing, setIsInitializing] = useState(true);
   const [hasVisitedSelector, setHasVisitedSelector] = useState(false);
   const [selectedLanguage, setSelectedLanguage] = useState<LanguageOption | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    onReady();
+  }, [onReady]);
 
   const handleReady = () => {
     setIsInitializing(false);

--- a/app/components/coding-exercise/CodingExercise.tsx
+++ b/app/components/coding-exercise/CodingExercise.tsx
@@ -35,11 +35,13 @@ export default function CodingExercise({
     onGoToDashboard: () => router.push("/dashboard")
   });
 
+  // Fire onReady once loading settles — success OR error — so the parent
+  // dismisses the loading modal and the error UI becomes visible.
   useEffect(() => {
-    if (!isLoading && !loadError) {
+    if (!isLoading) {
       onReady();
     }
-  }, [isLoading, loadError, onReady]);
+  }, [isLoading, onReady]);
 
   // Error state
   if (loadError) {

--- a/app/components/coding-exercise/CodingExercise.tsx
+++ b/app/components/coding-exercise/CodingExercise.tsx
@@ -2,7 +2,7 @@
 
 import type { ExerciseSlug } from "@jiki/curriculum";
 import { useRouter } from "next/navigation";
-import LessonLoadingModal from "@/components/common/LessonLoadingModal/LessonLoadingModal";
+import { useEffect } from "react";
 import CodingExerciseContent from "./CodingExerciseContent";
 import { useExerciseLoader } from "./hooks/useExerciseLoader";
 import type { ExerciseContext } from "./lib/types";
@@ -14,9 +14,17 @@ interface CodingExerciseProps {
   context: ExerciseContext;
   levelId?: string;
   isCompleted: boolean;
+  onReady: () => void;
 }
 
-export default function CodingExercise({ language, exerciseSlug, context, levelId, isCompleted }: CodingExerciseProps) {
+export default function CodingExercise({
+  language,
+  exerciseSlug,
+  context,
+  levelId,
+  isCompleted,
+  onReady
+}: CodingExerciseProps) {
   const router = useRouter();
   const { orchestrator, isLoading, loadError } = useExerciseLoader({
     language,
@@ -27,6 +35,12 @@ export default function CodingExercise({ language, exerciseSlug, context, levelI
     onGoToDashboard: () => router.push("/dashboard")
   });
 
+  useEffect(() => {
+    if (!isLoading && !loadError) {
+      onReady();
+    }
+  }, [isLoading, loadError, onReady]);
+
   // Error state
   if (loadError) {
     return (
@@ -36,9 +50,9 @@ export default function CodingExercise({ language, exerciseSlug, context, levelI
     );
   }
 
-  // Loading state
+  // Loading — the parent renders LessonLoadingModal as an overlay until onReady fires
   if (isLoading) {
-    return <LessonLoadingModal />;
+    return null;
   }
 
   // At this point, orchestrator is guaranteed to be set

--- a/app/components/layout/auth/global/ClientAuthInitializer.tsx
+++ b/app/components/layout/auth/global/ClientAuthInitializer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import LoadingJiki from "@/components/ui/LoadingJiki";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { useEffect, useRef, type ReactNode } from "react";
 
@@ -34,16 +35,8 @@ export function ClientAuthInitializer({ children }: ClientAuthProviderProps) {
   // Wait for initial auth check to complete before rendering children
   // Use the store's hasCheckedAuth as the single source of truth
   if (!hasCheckedAuth) {
-    return <LoadingSpinner />;
+    return <LoadingJiki />;
   }
 
   return <>{children}</>;
-}
-
-function LoadingSpinner() {
-  return (
-    <div className="flex items-center justify-center min-h-screen">
-      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
-    </div>
-  );
 }

--- a/app/components/lesson/Lesson.tsx
+++ b/app/components/lesson/Lesson.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import LessonLoadingModal from "@/components/common/LessonLoadingModal/LessonLoadingModal";
+import { fetchUserCourse } from "@/lib/api/courses";
+import { fetchLesson, fetchUserLesson } from "@/lib/api/lessons";
+import type { UserCourse } from "@/types/course";
+import type { LessonWithData } from "@/types/lesson";
+import { useCallback, useEffect, useState } from "react";
+import LessonContent from "./LessonContent";
+import LessonError from "./LessonError";
+
+interface LessonProps {
+  slug: string;
+}
+
+export default function Lesson({ slug }: LessonProps) {
+  const [lesson, setLesson] = useState<LessonWithData | null>(null);
+  const [userCourse, setUserCourse] = useState<UserCourse | null>(null);
+  const [isCompleted, setIsCompleted] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [innerReady, setInnerReady] = useState(false);
+
+  const handleReady = useCallback(() => setInnerReady(true), []);
+
+  // Update document title when lesson loads
+  useEffect(() => {
+    if (lesson) {
+      document.title = `${lesson.title} - Jiki`;
+    }
+  }, [lesson]);
+
+  // Load lesson and user course on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadData() {
+      try {
+        setLoading(true);
+        const [lessonData, userCourseData, userLessonResult] = await Promise.all([
+          fetchLesson(slug),
+          fetchUserCourse(),
+          fetchUserLesson(slug).catch(() => null)
+        ]);
+        if (cancelled) {
+          return;
+        }
+        setLesson(lessonData);
+        setUserCourse(userCourseData);
+        setIsCompleted(userLessonResult?.status === "completed");
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Failed to fetch lesson:", err);
+          // Auth/network/rate-limit errors never reach here (handled globally)
+          // Only application errors (404, 500, validation) reach this catch block
+          setError(err instanceof Error ? err.message : "Failed to load lesson");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (error) {
+    return <LessonError error={error} />;
+  }
+
+  const showModal = loading || !lesson || !innerReady;
+
+  // LessonContent must mount *underneath* the modal (not behind an early return) so its
+  // dynamic chunk and exercise loader can run in the background. The child fires onReady
+  // when truly ready, which flips innerReady and unmounts the modal in a single render —
+  // keeping one modal instance alive across the whole load so its CSS animations don't restart.
+  return (
+    <>
+      {lesson && (
+        <LessonContent lesson={lesson} userCourse={userCourse} isCompleted={isCompleted} onReady={handleReady} />
+      )}
+      {showModal && <LessonLoadingModal />}
+    </>
+  );
+}

--- a/app/components/lesson/LessonContent.tsx
+++ b/app/components/lesson/LessonContent.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import type { UserCourse } from "@/types/course";
+import type { LessonWithData } from "@/types/lesson";
+
+const CodingExercise = dynamic(() => import("@/components/coding-exercise/CodingExercise"), { ssr: false });
+const VideoExercise = dynamic(() => import("@/components/video-exercise/VideoExercise"), { ssr: false });
+const ChooseLanguage = dynamic(() => import("@/components/choose-language/ChooseLanguage"), { ssr: false });
+
+interface LessonContentProps {
+  lesson: LessonWithData;
+  userCourse: UserCourse | null;
+  isCompleted: boolean;
+  onReady: () => void;
+}
+
+export default function LessonContent({ lesson, userCourse, isCompleted, onReady }: LessonContentProps) {
+  const router = useRouter();
+
+  if (lesson.type === "video") {
+    return <VideoExercise lessonData={lesson} onReady={onReady} />;
+  }
+
+  if (lesson.type === "exercise") {
+    return (
+      <CodingExercise
+        language={userCourse?.language || "javascript"}
+        exerciseSlug={lesson.data.slug}
+        context={{ type: "lesson", slug: lesson.slug, walkthroughVideoData: lesson.walkthrough_video_data }}
+        isCompleted={isCompleted}
+        onReady={onReady}
+      />
+    );
+  }
+
+  if (lesson.type === "choose_language") {
+    return <ChooseLanguage lessonData={lesson} onReady={onReady} />;
+  }
+
+  // Quiz type - not yet implemented
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center">
+        <p className="text-gray-600 mb-4">Quiz lessons are not yet implemented</p>
+        <button
+          onClick={() => router.push("/dashboard")}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Back to Dashboard
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/lesson/LessonContent.tsx
+++ b/app/components/lesson/LessonContent.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import type { UserCourse } from "@/types/course";
 import type { LessonWithData } from "@/types/lesson";
 
@@ -17,8 +18,6 @@ interface LessonContentProps {
 }
 
 export default function LessonContent({ lesson, userCourse, isCompleted, onReady }: LessonContentProps) {
-  const router = useRouter();
-
   if (lesson.type === "video") {
     return <VideoExercise lessonData={lesson} onReady={onReady} />;
   }
@@ -40,6 +39,16 @@ export default function LessonContent({ lesson, userCourse, isCompleted, onReady
   }
 
   // Quiz type - not yet implemented
+  return <QuizNotImplemented onReady={onReady} />;
+}
+
+function QuizNotImplemented({ onReady }: { onReady: () => void }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    onReady();
+  }, [onReady]);
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="text-center">

--- a/app/components/lesson/LessonError.tsx
+++ b/app/components/lesson/LessonError.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function LessonError({ error }: { error: string }) {
+  const router = useRouter();
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center">
+        <p className="text-red-600 mb-4">Error: {error}</p>
+        <button
+          onClick={() => router.push("/dashboard")}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Back to Dashboard
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ui/LoadingJiki.module.css
+++ b/app/components/ui/LoadingJiki.module.css
@@ -1,5 +1,6 @@
 .container {
-    flex: 1;
+    width: 100vw;
+    height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -11,7 +12,7 @@
 .delayed {
     opacity: 0;
     animation: fadeIn 0.3s ease-out forwards;
-    animation-delay: 1s;
+    animation-delay: 5s;
 }
 
 @keyframes fadeIn {

--- a/app/components/video-exercise/VideoExercise.tsx
+++ b/app/components/video-exercise/VideoExercise.tsx
@@ -3,6 +3,7 @@
 import { LessonQuitButton } from "@/components/lesson/LessonQuitButton";
 import type { Lesson, VideoSource } from "@/types/lesson";
 import MuxPlayer from "@mux/mux-player-react";
+import { useEffect } from "react";
 import { FloatingPill } from "./ui/FloatingPill";
 import { NoVideoPlaceholder } from "./ui/NoVideoPlaceholder";
 import { useVideoExercise } from "./lib/useVideoExercise";
@@ -10,9 +11,13 @@ import styles from "./VideoExercise.module.css";
 
 type VideoLesson = Lesson & { type: "video"; data: { sources: VideoSource[] } };
 
-export default function VideoExercise({ lessonData }: { lessonData: VideoLesson }) {
+export default function VideoExercise({ lessonData, onReady }: { lessonData: VideoLesson; onReady: () => void }) {
   const videoSource = lessonData.data.sources[0] as VideoSource | undefined;
   const playbackId = videoSource?.id ?? "";
+
+  useEffect(() => {
+    onReady();
+  }, [onReady]);
 
   const {
     playerRef,

--- a/app/components/video-exercise/VideoExercise.tsx
+++ b/app/components/video-exercise/VideoExercise.tsx
@@ -15,10 +15,6 @@ export default function VideoExercise({ lessonData, onReady }: { lessonData: Vid
   const videoSource = lessonData.data.sources[0] as VideoSource | undefined;
   const playbackId = videoSource?.id ?? "";
 
-  useEffect(() => {
-    onReady();
-  }, [onReady]);
-
   const {
     playerRef,
     videoWatched,
@@ -34,6 +30,12 @@ export default function VideoExercise({ lessonData, onReady }: { lessonData: Vid
     autoplay,
     handleContinue
   } = useVideoExercise(lessonData.slug);
+
+  useEffect(() => {
+    if (!isInitializing) {
+      onReady();
+    }
+  }, [isInitializing, onReady]);
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Keep a single `LessonLoadingModal` instance mounted across page fetch, dynamic chunk load, and exercise loader stages so its CSS animations don't restart at each handoff.
- Replace the auth-gate spinner with `LoadingJiki` so the wakeup image actually shows on hard refresh.

## Test plan

- [ ] Hard-refresh a lesson page: loading modal should animate smoothly without restart between page → chunk → exercise loader stages
- [ ] Hard-refresh while signed out: Jiki wakeup image appears during auth check (not a plain spinner)
- [ ] Existing lesson navigation still works (soft nav from index → lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)