### PR TITLE
Remove rectangle function from relational-snowman

### DIFF
--- a/curriculum/src/exercises/relational-snowman/Exercise.ts
+++ b/curriculum/src/exercises/relational-snowman/Exercise.ts
@@ -7,8 +7,8 @@ export class RelationalSnowmanExercise extends DrawExercise {
   }
 
   public get availableFunctions() {
-    const { rectangle, circle } = this.getAllAvailableFunctions();
-    return [rectangle, circle];
+    const { circle } = this.getAllAvailableFunctions();
+    return [circle];
   }
 
   public setupBackground(imageUrl: string) {

--- a/curriculum/src/exercises/relational-snowman/index.ts
+++ b/curriculum/src/exercises/relational-snowman/index.ts
@@ -5,13 +5,6 @@ import type { VisualExerciseCore, FunctionInfo } from "../types";
 
 const functions: FunctionInfo[] = [
   {
-    name: "rectangle",
-    signature: "rectangle(left, top, width, height, color)",
-    description: "Draw a rectangle at position (left, top) with the given width, height, and color",
-    examples: ['rectangle(0, 0, 100, 60, "skyblue")'],
-    category: "Drawing Shapes"
-  },
-  {
     name: "circle",
     signature: "circle(cx, cy, radius, color)",
     description: "Draw a circle centered at (cx, cy) with the given radius and color",


### PR DESCRIPTION
## Summary
- The snowman exercise only draws circles, so the `rectangle` function was unused
- Removed it from `availableFunctions` in `Exercise.ts` and from the `functions` list in `index.ts`

## Test plan
- [x] `pnpm test` passes (662 tests)
- [x] Pre-commit checks (typecheck, lint, format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)