### PR TITLE
Restore success message for visual exercise scenarios

### DIFF
--- a/app/components/coding-exercise/ui/test-results-view/PassMessage.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/PassMessage.tsx
@@ -1,0 +1,36 @@
+import { useOrchestratorStore } from "../../lib/Orchestrator";
+import { useOrchestrator } from "../../lib/OrchestratorContext";
+
+interface PassMessageProps {
+  testIdx: number;
+}
+
+export function PassMessage({ testIdx }: PassMessageProps) {
+  const orchestrator = useOrchestrator();
+  const { exerciseTitle } = useOrchestratorStore(orchestrator);
+
+  return <p className="font-semibold">{congratsMessages[stringToHash(exerciseTitle, testIdx)]}</p>;
+}
+
+function stringToHash(input: string, testIdx: number): number {
+  const PRIME = 31;
+  let hash = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * PRIME + input.charCodeAt(i)) % congratsMessages.length;
+  }
+
+  hash = (hash + testIdx * PRIME) % congratsMessages.length;
+
+  return hash;
+}
+
+const congratsMessages = [
+  "Well done!",
+  "Nice work!",
+  "Fantastic job!",
+  "Amazing effort!",
+  "Great achievement!",
+  "Congratulations!",
+  "Congrats!"
+];

--- a/app/components/coding-exercise/ui/test-results-view/VisualTestResultView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/VisualTestResultView.tsx
@@ -1,14 +1,17 @@
 import styles from "../../CodingExercise.module.css";
+import { PassMessage } from "./PassMessage";
 
 interface VisualTestResultViewProps {
   isPassing: boolean;
   errorHtml: string;
+  testIdx?: number;
 }
 
-export function VisualTestResultView({ isPassing, errorHtml }: VisualTestResultViewProps) {
+export function VisualTestResultView({ isPassing, errorHtml, testIdx = 0 }: VisualTestResultViewProps) {
   return (
     <div className={styles.testFeedback}>
       <span className={styles.badge}>{isPassing ? "Pass" : "Fail"}</span>
+      {isPassing && <PassMessage testIdx={testIdx} />}
       {!isPassing && errorHtml && <div className={styles.message} dangerouslySetInnerHTML={{ __html: errorHtml }} />}
     </div>
   );

--- a/app/components/coding-exercise/ui/test-results-view/visual/VisualInspectedView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/visual/VisualInspectedView.tsx
@@ -97,11 +97,14 @@ function VisualInspectedResultView() {
 
 function TestResultInfo({ firstExpect }: { firstExpect: TestExpect | null }) {
   const orchestrator = useOrchestrator();
-  const { currentTest } = useOrchestratorStore(orchestrator);
+  const { currentTest, testSuiteResult } = useOrchestratorStore(orchestrator);
 
   if (!firstExpect) {
     return null;
   }
+
+  const testIdx =
+    testSuiteResult && currentTest ? testSuiteResult.tests.findIndex((test) => test.slug === currentTest.slug) : 0;
 
   let errorHtml = firstExpect.errorHtml || "";
   if ("actual" in firstExpect) {
@@ -113,6 +116,7 @@ function TestResultInfo({ firstExpect }: { firstExpect: TestExpect | null }) {
       <VisualTestResultView
         isPassing={false}
         errorHtml="Your code worked correctly, but you need to fix your formatting. Look for orange underlines in your code."
+        testIdx={Math.max(0, testIdx)}
       />
     );
   }
@@ -121,5 +125,5 @@ function TestResultInfo({ firstExpect }: { firstExpect: TestExpect | null }) {
     return <VisualTestResultView isPassing={false} errorHtml="Uh Oh. Your code has an error in it." />;
   }
 
-  return <VisualTestResultView isPassing={firstExpect.pass} errorHtml={errorHtml} />;
+  return <VisualTestResultView isPassing={firstExpect.pass} errorHtml={errorHtml} testIdx={Math.max(0, testIdx)} />;
 }


### PR DESCRIPTION
## Summary
- PassMessage component was removed in #457 (IO exercise hint rewrite), but the removal also affected visual exercises
- Visual exercises should continue showing a congratulatory message on passing scenarios; this PR restores that

## Test plan
- [ ] Pass a visual exercise scenario and confirm the congrats message renders
- [ ] Confirm IO exercises still render without a congrats message

🤖 Generated with [Claude Code](https://claude.com/claude-code)