### PR TITLE
Wire up UnhandledErrorView for runtime errors

### DIFF
--- a/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
+++ b/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
@@ -152,6 +152,15 @@ export class TestSuiteManager {
       // Check if it's a SyntaxError (has location property)
       if (error && typeof error === "object" && "location" in error) {
         this.handleSyntaxError(error as SyntaxError);
+      } else {
+        if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
+          throw error;
+        }
+        const state = this.store.getState();
+        state.setHasUnhandledError(true);
+        state.setUnhandledErrorBase64(
+          btoa(JSON.stringify({ error: String(error), code, type: "Error firing runCode" }))
+        );
       }
       this.store.getState().setStatus("error");
     }

--- a/app/components/coding-exercise/ui/test-results-view/ScenariosPanel.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/ScenariosPanel.tsx
@@ -4,10 +4,15 @@ import { useOrchestratorStore } from "../../lib/Orchestrator";
 import { useOrchestrator } from "../../lib/OrchestratorContext";
 import { SyntaxErrorView } from "./SyntaxErrorView";
 import TestResultsView from "./TestResultsView";
+import { UnhandledErrorView } from "./UnhandledErrorView";
 
 export default function ScenariosPanel() {
   const orchestrator = useOrchestrator();
-  const { hasSyntaxError } = useOrchestratorStore(orchestrator);
+  const { hasSyntaxError, hasUnhandledError } = useOrchestratorStore(orchestrator);
+
+  if (hasUnhandledError) {
+    return <UnhandledErrorView />;
+  }
 
   if (hasSyntaxError) {
     return <SyntaxErrorView />;

--- a/app/components/coding-exercise/ui/test-results-view/UnhandledErrorView.module.css
+++ b/app/components/coding-exercise/ui/test-results-view/UnhandledErrorView.module.css
@@ -1,0 +1,27 @@
+.wrapper {
+    min-width: 0;
+}
+
+.icon {
+    margin: 0 auto 20px;
+}
+
+.headingStrong {
+    font-weight: 700;
+    text-decoration: underline;
+    text-decoration-style: double;
+}
+
+.body {
+    max-width: 500px;
+}
+
+.bodyStrong {
+    font-weight: 500;
+    color: var(--color-gray-600);
+}
+
+.copyButton {
+    max-width: 500px;
+    margin: 16px auto 0;
+}

--- a/app/components/coding-exercise/ui/test-results-view/UnhandledErrorView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/UnhandledErrorView.tsx
@@ -1,22 +1,30 @@
+import { CopyToClipboardButton } from "@/components/ui-kit/CopyToClipboardButton";
 import { Icon } from "@/components/ui-kit/Icon";
+import { useOrchestratorStore } from "../../lib/Orchestrator";
+import { useOrchestrator } from "../../lib/OrchestratorContext";
+import syntaxErrorStyles from "./SyntaxErrorView.module.css";
+import styles from "./UnhandledErrorView.module.css";
 
 export function UnhandledErrorView() {
-  // TODO: use orchestrator's error store
-  // const { unhandledErrorBase64 } = useErrorStore();
+  const orchestrator = useOrchestrator();
+  const { unhandledErrorBase64 } = useOrchestratorStore(orchestrator);
+
   return (
-    <div className="border-t-1 border-borderColor6">
-      <div className="text-center py-40 px-40 max-w-[600px] mx-auto">
-        <Icon name="bug" size={48} className="m-auto mb-20" color="gray-500" alt="An image of a bug" />
-        <div className="text-h5 mb-6 text-textColor6">
-          Oops! Something went <strong className="font-bold">very</strong> wrong.
-        </div>
-        <div className="mb-20 text-textColor6 leading-160 text-16 text-balance">
-          It would be very helpful if you could tell us about this error so we can improve things. Please click the
-          button below to copy the mysterious text to your clipboard, and share it with us on Discord or the forum.
-          Thank you! 💙
-        </div>
-        {/* <CopyToClipboardButton textToCopy={unhandledErrorBase64} /> */}
-      </div>
+    <div className={`${syntaxErrorStyles.container} ${styles.wrapper}`}>
+      <Icon name="bug" size={48} className={styles.icon} color="gray-500" alt="An image of a bug" />
+      <h3 className={syntaxErrorStyles.heading}>
+        Oops! Something went <strong className={styles.headingStrong}>very</strong> wrong.
+      </h3>
+      <p className={`${syntaxErrorStyles.message} ${styles.body}`}>
+        <strong className={styles.bodyStrong}>This is our error, not yours!</strong> Please tell us about this error so
+        we can fix it. Please click the button below to copy the mysterious text to your clipboard, and share it with us
+        on{" "}
+        <a href="https://forum.jiki.io" target="_blank" rel="noreferrer">
+          the forum
+        </a>
+        . Thank you! 💙
+      </p>
+      <CopyToClipboardButton textToCopy={unhandledErrorBase64} className={styles.copyButton} />
     </div>
   );
 }

--- a/app/components/ui-kit/CopyToClipboardButton/CopyToClipboardButton.module.css
+++ b/app/components/ui-kit/CopyToClipboardButton/CopyToClipboardButton.module.css
@@ -1,0 +1,66 @@
+@keyframes copiedFadeOut {
+    0% {
+        opacity: 1;
+        top: 0;
+    }
+    100% {
+        opacity: 0;
+        top: -25px;
+    }
+}
+
+.button {
+    position: relative;
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+    width: 100%;
+    min-width: 0;
+    border: 1px solid var(--color-gray-300);
+    border-radius: 5px;
+    padding: 12px 20px;
+    background-color: white;
+    color: var(--color-gray-700);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-weight: 400;
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.button:hover {
+    background-color: var(--color-gray-50);
+}
+
+.text {
+    flex-grow: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.3;
+    user-select: text;
+}
+
+.icon {
+    margin-left: 16px;
+    color: var(--color-gray-500);
+    flex-shrink: 0;
+}
+
+.message {
+    position: absolute;
+    left: 50%;
+    z-index: 50;
+    padding: 8px 16px 8px 40px;
+    margin-left: -53px;
+    border-radius: 8px;
+    background-color: var(--color-gray-900);
+    color: white;
+    font-weight: 600;
+    line-height: 1.5;
+    box-shadow: 0px 4px 24px 0px rgba(0, 0, 0, 0.15);
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjgiIGZpbGw9IiM1OUQyQUUiLz4KPHBhdGggZD0iTTEwLjg1NjkgNS4xNDI2NEw3LjAyMzk3IDEwLjYxNzlDNi45MjEzOCAxMC43NjU0IDYuNzU0MTggMTAuODU0NSA2LjU3NDYgMTAuODU3NEM2LjM5NTAzIDEwLjg2MDQgNi4yMjQ5NyAxMC43NzY5IDYuMTE3NTYgMTAuNjMyOUw1LjE0MjU4IDkuMzMzMTIiIHN0cm9rZT0iIzEzMEI0MyIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K");
+    background-repeat: no-repeat;
+    background-position: 16px center;
+    animation: copiedFadeOut 0.7s ease-in forwards;
+}

--- a/app/components/ui-kit/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/app/components/ui-kit/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Icon } from "../Icon";
+import styles from "./CopyToClipboardButton.module.css";
+
+interface CopyToClipboardButtonProps {
+  textToCopy: string;
+  className?: string;
+}
+
+export function CopyToClipboardButton({ textToCopy, className }: CopyToClipboardButtonProps) {
+  const [justCopied, setJustCopied] = useState(false);
+
+  const handleClick = useCallback(() => {
+    navigator.clipboard.writeText(textToCopy).catch((err: unknown) => {
+      console.error("Clipboard write failed:", err);
+      // Fallback for non-secure contexts (http, older browsers).
+      const textarea = document.createElement("textarea");
+      textarea.value = textToCopy;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand("copy");
+      } catch (fallbackErr) {
+        console.error("Clipboard fallback failed:", fallbackErr);
+      }
+      document.body.removeChild(textarea);
+    });
+    setJustCopied(true);
+  }, [textToCopy]);
+
+  useEffect(() => {
+    if (!justCopied) {
+      return;
+    }
+    const timer = setTimeout(() => setJustCopied(false), 1000);
+    return () => clearTimeout(timer);
+  }, [justCopied]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={className ? `${styles.button} ${className}` : styles.button}
+      aria-label="Copy to clipboard"
+    >
+      <div className={styles.text}>{textToCopy}</div>
+      <span className={styles.icon}>
+        <Icon name="clipboard" size={24} alt="Copy to clipboard" />
+      </span>
+      {justCopied ? <span className={styles.message}>Copied</span> : null}
+    </button>
+  );
+}

--- a/app/components/ui-kit/CopyToClipboardButton/index.ts
+++ b/app/components/ui-kit/CopyToClipboardButton/index.ts
@@ -1,0 +1,1 @@
+export { CopyToClipboardButton } from "./CopyToClipboardButton";

--- a/app/icons/clipboard.svg
+++ b/app/icons/clipboard.svg
@@ -1,0 +1,60 @@
+<svg
+  id="clipboard"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M20.25 8.24902V5.24902C20.25 4.4206 19.5784 3.74902 18.75 3.74902H14.75"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M6.25 3.74902H2.25C1.42157 3.74902 0.75 4.4206 0.75 5.24902V21.749C0.75 22.5775 1.42157 23.249 2.25 23.249H8.25"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M14.421 4.73603C14.3187 5.04233 14.0319 5.2489 13.709 5.24903H7.291C6.96805 5.2489 6.68135 5.04233 6.579 4.73603L5.579 1.73603C5.50233 1.50724 5.54057 1.25552 5.68174 1.05983C5.82291 0.864136 6.04971 0.748439 6.291 0.749026H14.709C14.9503 0.748439 15.1771 0.864136 15.3183 1.05983C15.4594 1.25552 15.4977 1.50724 15.421 1.73603L14.421 4.73603Z"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M11.25 12.749C11.25 11.9206 11.9216 11.249 12.75 11.249H21.75C22.5784 11.249 23.25 11.9206 23.25 12.749V21.749C23.25 22.5775 22.5784 23.249 21.75 23.249H12.75C11.9216 23.249 11.25 22.5775 11.25 21.749V12.749Z"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M14.25 14.249H20.25"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M14.25 17.249H20.25"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M14.25 20.249H16.5"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/app/tests/unit/components/coding-exercise/lib/orchestrator/TaskManager-TestSuiteManager.integration.test.ts
+++ b/app/tests/unit/components/coding-exercise/lib/orchestrator/TaskManager-TestSuiteManager.integration.test.ts
@@ -176,19 +176,17 @@ describe("TaskManager and TestSuiteManager Integration", () => {
       expect(task1Progress?.passedScenarios).toEqual([]);
     });
 
-    it("should handle syntax errors without crashing task progress", async () => {
+    it("should handle non-syntax errors without crashing task progress", async () => {
       const exercise = createMockExercise();
       taskManager.initializeTaskProgress(exercise);
 
-      // Mock a syntax error
+      // Mock a generic (non-syntax) error
       mockRunTests.mockImplementation(() => {
-        throw new Error("Syntax error in code");
+        throw new Error("Some other error");
       });
 
-      await testSuiteManager.runCode("invalid code", exercise);
-
-      // Verify error handling
-      expect(mockStore.getState().setStatus).toHaveBeenCalledWith("error");
+      // Non-syntax errors are re-thrown in dev/test so they surface in the Next.js overlay.
+      await expect(testSuiteManager.runCode("invalid code", exercise)).rejects.toThrow("Some other error");
 
       // Task progress should remain in initialized state
       const initializeCalls = (mockStore.getState().setTaskProgress as jest.Mock).mock.calls;

--- a/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
@@ -194,13 +194,12 @@ describe("TestSuiteManager", () => {
         throw new Error("Some other error");
       });
 
-      // Run the code
-      await manager.runCode(mockCode, mockExercise);
+      // Non-syntax errors are re-thrown in dev/test so they surface in the Next.js overlay.
+      await expect(manager.runCode(mockCode, mockExercise)).rejects.toThrow("Some other error");
 
-      // Verify error status was set but not as syntax error
+      // Syntax-error handling was reset before the throw.
       const state = mockStore.getState();
       expect(state.setHasSyntaxError).toHaveBeenCalledWith(false);
-      expect(state.setStatus).toHaveBeenCalledWith("error");
     });
 
     it("should run tests and submit asynchronously (fire-and-forget)", async () => {


### PR DESCRIPTION
## Summary
- Render `UnhandledErrorView` (previously dead code) when an uncaught error escapes `TestSuiteManager.runCode` or `EditorManager` mount; in dev/test the error is re-thrown so it surfaces in the Next.js overlay.
- New `CopyToClipboardButton` UI-kit component + `clipboard` icon, ported from the exercism bootcamp.
- `ScenariosPanel` short-circuits to the error view before `SyntaxErrorView`, so any unhandled crash takes precedence.

## Test plan
- [x] `pnpm test` (1639 passed)
- [x] `pnpm typecheck`
- [x] `pnpm run lint`
- [ ] Manual: force `hasUnhandledError` via the orchestrator store in DevTools (e.g. through React DevTools), confirm the right pane swaps to the bug-icon view, the copy button copies the base64 payload, and the "Copied" pill animates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)