### PR TITLE
Fix Jikiscript-era leftovers in JS-facing curriculum copy

### DIFF
--- a/curriculum/src/exercises/finish-wall/llm-metadata.ts
+++ b/curriculum/src/exercises/finish-wall/llm-metadata.ts
@@ -38,7 +38,7 @@ export const llmMetadata: LLMMetadata = {
         Solution approach:
         1. Set the fill color
         2. Initialize a counter variable (starting at -1 or 0 depending on approach)
-        3. Use repeat 5 times
+        3. Use repeat(5)
         4. Inside loop: increment counter, then draw rectangle at (counter * 20, 0, 20, 10)
       `
     }

--- a/curriculum/src/exercises/space-invaders-conditional/llm-metadata.ts
+++ b/curriculum/src/exercises/space-invaders-conditional/llm-metadata.ts
@@ -24,7 +24,7 @@ export const llmMetadata: LLMMetadata = {
         2. Use isAlienAbove() to detect whether to shoot
         3. Use an if statement to conditionally call shoot()
         4. Wrap the check-and-move pattern in a repeat(10) loop
-        5. The full solution: repeat 10 times { if (isAlienAbove()) { shoot() } move() }
+        5. The full solution: repeat(10) { if (isAlienAbove()) { shoot() } move() }
 
         Common mistakes:
         - Shooting without checking (hits empty columns and loses)

--- a/curriculum/src/exercises/stars/metadata.json
+++ b/curriculum/src/exercises/stars/metadata.json
@@ -8,7 +8,7 @@
     },
     {
       "question": "How do I run the loop the right number of times?",
-      "answer": "A `repeat n times` loop matches the input directly. If `n` is 3, you go around 3 times."
+      "answer": "A `repeat(n)` loop matches the input directly. If `n` is 3, you go around 3 times."
     },
     {
       "question": "What happens inside the loop?",

--- a/curriculum/src/exercises/three-letter-acronym/llm-metadata.ts
+++ b/curriculum/src/exercises/three-letter-acronym/llm-metadata.ts
@@ -10,21 +10,21 @@ interface LLMMetadata {
 export const llmMetadata: LLMMetadata = {
   description: `
     This exercise teaches string indexing and concatenation.
-    Students learn to access individual characters in a string using [1]
+    Students learn to access individual characters in a string using [0]
     and combine them using the + operator (or a template string).
   `,
 
   tasks: {
     "create-acronym-function": {
       description: `
-        Students need to get the first character of each word using [1]
+        Students need to get the first character of each word using [0]
         and join them together with the + operator.
 
         The solution is a single return statement:
-        return word1[1] + word2[1] + word3[1]
+        return word1[0] + word2[0] + word3[0]
 
         Common mistakes:
-        - Forgetting the correct string indexing for the language
+        - Using [1] instead of [0] (JavaScript is 0-indexed)
         - Returning just one character instead of all three
         - Getting the concatenation syntax wrong
       `

--- a/curriculum/src/exercises/three-letter-acronym/metadata.json
+++ b/curriculum/src/exercises/three-letter-acronym/metadata.json
@@ -4,7 +4,7 @@
   "hints": [
     {
       "question": "How do I get just the first character of a word?",
-      "answer": "Indexing into the string. The first character is at index `[1]` in this language."
+      "answer": "Indexing into the string. The first character is at index `[0]`."
     },
     {
       "question": "How do I build the three-letter result?",


### PR DESCRIPTION
## Summary

Small follow-up to #478. Three concrete artifacts of the Jikiscript era leaking into JS-facing curriculum copy:

- `three-letter-acronym` hint and `llm-metadata.ts` told students the first character of a string is at index `[1]`. True in Jikiscript; JavaScript is 0-indexed. `solution.javascript` already uses `[0]`.
- `finish-wall`, `space-invaders-conditional`, `stars`: the Jikiscript wordform `repeat N times` appeared in hints and llm-metadata. The `repeat` keyword itself is valid JS in our interpreter (`interpreters/src/javascript/parser.ts:385`, `scanner.ts:47`), but the call form is `repeat(n) { … }`, not `repeat n times`. Only the wording is wrong.

This PR overlaps trivially with #478 on `three-letter-acronym/llm-metadata.ts:24` — that line gets touched in both PRs (concatenate removal in #478, index fix here). Whichever lands second will need a one-line merge.

## Test plan

- [x] `pnpm test:curriculum` — 662 passed
- [x] `pnpm typecheck` — clean
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)