### PR TITLE
Port Wordle exercise rendering from bootcamp

### DIFF
--- a/app/app/styles/exercises.css
+++ b/app/app/styles/exercises.css
@@ -13,5 +13,4 @@
 @import "./exercises/space-invaders.css";
 @import "./exercises/tic-tac-toe.css";
 @import "./exercises/weather.css";
-@import "./exercises/wordle.css";
 @import "./exercises/plant-the-flowers.css";

--- a/curriculum/src/VisualExercise.ts
+++ b/curriculum/src/VisualExercise.ts
@@ -94,6 +94,8 @@ export interface Animation {
     height?: number | string;
     gridRow?: number;
     gridColumn?: number;
-    innerHTML?: number;
+    innerHTML?: number | string;
+    backgroundColor?: string;
+    color?: string;
   };
 }

--- a/curriculum/src/exercise-categories/wordle/WordleExercise.ts
+++ b/curriculum/src/exercise-categories/wordle/WordleExercise.ts
@@ -219,6 +219,7 @@ export default class WordleExercise extends VisualExercise {
 
   constructor() {
     super();
+    this.view.classList.add("exercise-wordle");
     this.populateView();
   }
 

--- a/curriculum/src/exercise-categories/wordle/WordleExercise.ts
+++ b/curriculum/src/exercise-categories/wordle/WordleExercise.ts
@@ -10,6 +10,15 @@ import { VisualExercise } from "../../VisualExercise";
 
 type LetterState = "correct" | "present" | "absent";
 
+const STATE_COLORS: Record<LetterState, string> = {
+  correct: "rgb(106, 170, 100)",
+  present: "rgb(201, 180, 88)",
+  absent: "rgb(120, 124, 126)"
+};
+
+const NUM_ROWS = 6;
+const NUM_COLS = 5;
+
 const COMMON_WORDS = [
   "which",
   "about",
@@ -204,18 +213,43 @@ export default class WordleExercise extends VisualExercise {
     return "wordle";
   }
 
-  // Row states: up to 6 rows, each with 5 letter states
   rowStates: LetterState[][] = [];
   private targetWord: string = "";
+  private guessRows: HTMLElement[] = [];
 
   constructor() {
     super();
+    this.populateView();
   }
 
   availableFunctions: ExternalFunction[] = [];
 
   getState() {
     return {};
+  }
+
+  protected populateView() {
+    const container = document.createElement("div");
+    container.classList.add("container");
+    this.view.appendChild(container);
+
+    const board = document.createElement("div");
+    board.classList.add("board");
+    container.appendChild(board);
+
+    for (let row = 0; row < NUM_ROWS; row++) {
+      const rowEl = document.createElement("div");
+      rowEl.classList.add("guess");
+      for (let col = 0; col < NUM_COLS; col++) {
+        const letter = document.createElement("div");
+        letter.classList.add("letter", `letter-${row}-${col}`);
+        letter.style.color = "rgba(255,255,255,0)";
+        letter.style.backgroundColor = "rgb(211,211,211)";
+        rowEl.appendChild(letter);
+      }
+      board.appendChild(rowEl);
+      this.guessRows.push(rowEl);
+    }
   }
 
   // --- Setup methods (called from scenario setup) ---
@@ -228,29 +262,54 @@ export default class WordleExercise extends VisualExercise {
     return this.rowStates[idx] ?? [];
   }
 
+  // Pre-fill rows with guess letters during scenario setup (no animation).
+  public drawGuesses(words: string[]) {
+    words.forEach((word, idx) => this.drawGuessImmediate(idx, word));
+  }
+
+  public drawGuess(rowIdx: number, word: string) {
+    this.drawGuessImmediate(rowIdx, word);
+  }
+
+  private drawGuessImmediate(rowIdx: number, word: string) {
+    const row = this.guessRows[rowIdx];
+    const letters = row.getElementsByClassName("letter");
+    for (let i = 0; i < NUM_COLS; i++) {
+      const letter = letters[i] as HTMLElement;
+      letter.textContent = (word[i] ?? "").toLowerCase();
+      letter.style.color = "rgba(255,255,255,1)";
+    }
+  }
+
   // --- Exercise functions (provided to student code) ---
 
-  protected colorRow(_executionCtx: ExecutionContext, rowIdx: Shared.JikiObject, states: Shared.JikiObject) {
+  protected colorRow(executionCtx: ExecutionContext, rowIdx: Shared.JikiObject, states: Shared.JikiObject) {
     if (!isNumber(rowIdx) || !isList(states)) return;
     const stateValues = states.value.map((s: Shared.JikiObject) => {
       if (isString(s)) return s.value as LetterState;
       return "absent" as LetterState;
     });
-    this.rowStates[rowIdx.value - 1] = stateValues;
+    const idx = rowIdx.value - 1;
+    this.rowStates[idx] = stateValues;
+    this.animateColorRow(executionCtx, idx, stateValues);
   }
 
   protected addWord(
-    _executionCtx: ExecutionContext,
+    executionCtx: ExecutionContext,
     rowIdx: Shared.JikiObject,
-    _word: Shared.JikiObject,
+    word: Shared.JikiObject,
     states: Shared.JikiObject
   ) {
     if (!isNumber(rowIdx) || !isList(states)) return;
+    const wordValue = isString(word) ? word.value : "";
     const stateValues = states.value.map((s: Shared.JikiObject) => {
       if (isString(s)) return s.value as LetterState;
       return "absent" as LetterState;
     });
-    this.rowStates[rowIdx.value - 1] = stateValues;
+    const idx = rowIdx.value - 1;
+    this.rowStates[idx] = stateValues;
+    this.animateDrawGuess(executionCtx, idx, wordValue);
+    this.animateColorRow(executionCtx, idx, stateValues);
   }
 
   protected getTargetWord(_executionCtx: ExecutionContext): string {
@@ -259,5 +318,38 @@ export default class WordleExercise extends VisualExercise {
 
   protected getCommonWords(_executionCtx: ExecutionContext): string[] {
     return [...COMMON_WORDS];
+  }
+
+  private animateDrawGuess(executionCtx: ExecutionContext, rowIdx: number, word: string) {
+    for (let col = 0; col < NUM_COLS; col++) {
+      const char = (word[col] ?? "").toLowerCase();
+      this.animations.push({
+        targets: `#${this.view.id} .letter-${rowIdx}-${col}`,
+        offset: executionCtx.getCurrentTimeInMs(),
+        duration: 1,
+        transformations: {
+          innerHTML: char,
+          color: "rgba(255,255,255,1)"
+        }
+      });
+    }
+    executionCtx.fastForward(1);
+  }
+
+  private animateColorRow(executionCtx: ExecutionContext, rowIdx: number, states: LetterState[]) {
+    states.forEach((state, col) => {
+      if (col >= NUM_COLS) return;
+      const backgroundColor = STATE_COLORS[state];
+      this.animations.push({
+        targets: `#${this.view.id} .letter-${rowIdx}-${col}`,
+        offset: executionCtx.getCurrentTimeInMs(),
+        duration: 1,
+        transformations: {
+          backgroundColor,
+          color: "rgb(255,255,255)"
+        }
+      });
+    });
+    executionCtx.fastForward(1);
   }
 }

--- a/curriculum/src/exercise-categories/wordle/WordleExercise.ts
+++ b/curriculum/src/exercise-categories/wordle/WordleExercise.ts
@@ -230,13 +230,9 @@ export default class WordleExercise extends VisualExercise {
   }
 
   protected populateView() {
-    const container = document.createElement("div");
-    container.classList.add("container");
-    this.view.appendChild(container);
-
     const board = document.createElement("div");
     board.classList.add("board");
-    container.appendChild(board);
+    this.view.appendChild(board);
 
     for (let row = 0; row < NUM_ROWS; row++) {
       const rowEl = document.createElement("div");

--- a/curriculum/src/exercise-categories/wordle/exercise.css
+++ b/curriculum/src/exercise-categories/wordle/exercise.css
@@ -2,7 +2,44 @@
     width: 100%;
     height: 100%;
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
+}
+
+.exercise-wordle .container {
+    width: 90%;
+    max-width: 360px;
+    aspect-ratio: 5 / 6;
+    position: relative;
+}
+
+.exercise-wordle .board {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    inset: 0;
+    display: grid;
+    gap: 1%;
+    grid-template-rows: repeat(6, 1fr);
+}
+
+.exercise-wordle .guess {
+    display: grid;
+    gap: 1%;
+    grid-template-columns: repeat(5, 1fr);
+    container-type: size;
+}
+
+.exercise-wordle .letter {
+    height: 100%;
+    font-size: 70cqh;
+    background-color: rgb(211, 211, 211);
+    border: 1px solid #ccc;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: bold;
+    text-transform: uppercase;
+    color: #333;
+    position: relative;
 }

--- a/curriculum/src/exercise-categories/wordle/exercise.css
+++ b/curriculum/src/exercise-categories/wordle/exercise.css
@@ -18,6 +18,7 @@
         gap: 1%;
         grid-template-columns: repeat(5, 1fr);
         container-type: size;
+        line-height: 1;
     }
 
     .letter {

--- a/curriculum/src/exercise-categories/wordle/exercise.css
+++ b/curriculum/src/exercise-categories/wordle/exercise.css
@@ -1,45 +1,51 @@
 .exercise-wordle {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
+    .board {
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        border: 0;
 
-.exercise-wordle .container {
-    width: 90%;
-    max-width: 360px;
-    aspect-ratio: 5 / 6;
-    position: relative;
-}
+        display: grid;
+        gap: 1%;
+        grid-template-rows: repeat(6, 1fr);
+    }
 
-.exercise-wordle .board {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    inset: 0;
-    display: grid;
-    gap: 1%;
-    grid-template-rows: repeat(6, 1fr);
-}
+    .guess {
+        display: grid;
+        gap: 1%;
+        grid-template-columns: repeat(5, 1fr);
+        container-type: size;
+    }
 
-.exercise-wordle .guess {
-    display: grid;
-    gap: 1%;
-    grid-template-columns: repeat(5, 1fr);
-    container-type: size;
-}
+    .letter {
+        height: 100%;
+        font-size: 70cqh;
+        background-color: rgb(211, 211, 211);
+        border: 1px solid #ccc;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-weight: bold;
+        text-transform: uppercase;
+        color: #333;
+        position: relative;
+    }
 
-.exercise-wordle .letter {
-    height: 100%;
-    font-size: 70cqh;
-    background-color: rgb(211, 211, 211);
-    border: 1px solid #ccc;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-weight: bold;
-    text-transform: uppercase;
-    color: #333;
-    position: relative;
+    .letter[data-state="correct"] {
+        background-color: rgb(106, 170, 100);
+        color: white;
+    }
+
+    .letter[data-state="present"] {
+        background-color: rgb(201, 180, 88);
+        color: white;
+    }
+
+    .letter[data-state="absent"] {
+        background-color: rgb(120, 124, 126);
+        color: white;
+    }
 }

--- a/curriculum/src/exercises/wordle-process-game/scenarios.ts
+++ b/curriculum/src/exercises/wordle-process-game/scenarios.ts
@@ -20,7 +20,9 @@ export const scenarios: VisualScenario[] = [
     description: "Deal with a first correct guess.",
     taskId: "process-game",
     functionCall: { name: "process_game", args: ["hello", ["hello"]] },
-
+    setup(exercise) {
+      (exercise as ProcessGameExercise).drawGuesses(["hello"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGameExercise;
       return [
@@ -39,7 +41,9 @@ export const scenarios: VisualScenario[] = [
     description: "Deal with two guesses.",
     taskId: "process-game",
     functionCall: { name: "process_game", args: ["hello", ["hallo", "hello"]] },
-
+    setup(exercise) {
+      (exercise as ProcessGameExercise).drawGuesses(["hallo", "hello"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGameExercise;
       return [
@@ -64,7 +68,9 @@ export const scenarios: VisualScenario[] = [
     description: "Deal with three guesses.",
     taskId: "process-game",
     functionCall: { name: "process_game", args: ["hello", ["hulal", "hallo", "hello"]] },
-
+    setup(exercise) {
+      (exercise as ProcessGameExercise).drawGuesses(["hulal", "hallo", "hello"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGameExercise;
       return [
@@ -98,7 +104,9 @@ export const scenarios: VisualScenario[] = [
       name: "process_game",
       args: ["block", ["jumpy", "trend", "jumbo", "crisp", "gowfy", "block"]]
     },
-
+    setup(exercise) {
+      (exercise as ProcessGameExercise).drawGuesses(["jumpy", "trend", "jumbo", "crisp", "gowfy", "block"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGameExercise;
       return [

--- a/curriculum/src/exercises/wordle-process-guess/scenarios.ts
+++ b/curriculum/src/exercises/wordle-process-guess/scenarios.ts
@@ -20,7 +20,9 @@ export const scenarios: VisualScenario[] = [
     description: "Deal with a fully correct guess",
     taskId: "process-guess",
     functionCall: { name: "process_guess", args: ["hello", "hello"] },
-
+    setup(exercise) {
+      (exercise as ProcessGuessExercise).drawGuesses(["hello"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGuessExercise;
       return [
@@ -39,7 +41,9 @@ export const scenarios: VisualScenario[] = [
     description: "Handle when some letters are wrong",
     taskId: "process-guess",
     functionCall: { name: "process_guess", args: ["hello", "hallu"] },
-
+    setup(exercise) {
+      (exercise as ProcessGuessExercise).drawGuesses(["hallu"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGuessExercise;
       return [
@@ -58,7 +62,9 @@ export const scenarios: VisualScenario[] = [
     description: "Deal with letters in the wrong place",
     taskId: "process-guess",
     functionCall: { name: "process_guess", args: ["hello", "hlelo"] },
-
+    setup(exercise) {
+      (exercise as ProcessGuessExercise).drawGuesses(["hlelo"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGuessExercise;
       return [
@@ -77,7 +83,9 @@ export const scenarios: VisualScenario[] = [
     description: "Deal with a more complex scenario",
     taskId: "process-guess",
     functionCall: { name: "process_guess", args: ["hello", "ehola"] },
-
+    setup(exercise) {
+      (exercise as ProcessGuessExercise).drawGuesses(["ehola"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGuessExercise;
       return [
@@ -96,7 +104,9 @@ export const scenarios: VisualScenario[] = [
     description: "And finally a different word!",
     taskId: "process-guess",
     functionCall: { name: "process_guess", args: ["break", "beaks"] },
-
+    setup(exercise) {
+      (exercise as ProcessGuessExercise).drawGuesses(["beaks"]);
+    },
     expectations(exercise) {
       const ex = exercise as ProcessGuessExercise;
       return [


### PR DESCRIPTION
## Summary
- The three Wordle exercises (`wordle-process-guess`, `wordle-process-game`, `wordle-solver`) were migrated with only their state-tracking; the board, letter text, and green/yellow/grey colouring were missing. The learner saw a blank exercise area while expectations still passed on `statesForRow`.
- This restores the visual layer 1:1 with the bootcamp `WordleExercise.tsx` / `wordle.css`, adapted to the curriculum's `VisualExercise` / `Animation` model.

## Changes
- **`src/exercise-categories/wordle/WordleExercise.ts`** — `populateView` now builds the 6×5 board with stable per-cell classes (`.letter-{row}-{col}`). `colorRow` and `addWord` push `backgroundColor`/`color` (and `innerHTML` for `addWord`) animations scoped to `this.view.id`, so timeline scrubbing reverses cleanly. New public `drawGuesses` / `drawGuess` for scenario setup.
- **`src/exercise-categories/wordle/exercise.css`** — full board styling (grid layout, letter typography) replacing the previous stub.
- **`src/VisualExercise.ts`** — extends `Animation.transformations` with `backgroundColor`, `color`, and widens `innerHTML` to `number | string`. The app already spreads transformations straight into `anime.js`, so no runtime change is needed.
- **`wordle-process-guess` & `wordle-process-game` scenarios** — each scenario now has a `setup` hook calling `drawGuesses(...)` to pre-render the guess letters before the student's `color_row` calls (mirrors the bootcamp `[["setupView"], ["drawGuesses", [["word"]]]]` setup).
- `wordle-solver` is unchanged: student code calls `add_word`, which now both draws letters and colours.

## Deliberate deviations from bootcamp
- Stable per-cell classes instead of random IDs (simpler, better for scrubbing).
- Colouring is driven by animations, not by `data-state` CSS attribute selectors — required so the timeline can reverse on scrub.
- `WordleGame` Jiki class and `color_top_row` are not ported (no scenarios use them).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 662 tests pass
- [ ] `pnpm dev:app` → open each wordle exercise; confirm the board renders, letters fade in / colour in correctly when the solution runs, and scrubbing the timeline reverses both letters and colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)