### PR TITLE
Tweak subscription checkout and welcome-to-premium modal styling

### DIFF
--- a/app/lib/modal/index.ts
+++ b/app/lib/modal/index.ts
@@ -7,6 +7,7 @@ export {
   showConfirmation,
   showInfo,
   showModal,
+  showSubscriptionCheckout,
   showSubscriptionModal,
   showSubscriptionSuccess,
   showPaymentProcessing,

--- a/app/lib/modal/modals/SubscriptionCheckoutModal.module.css
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal.module.css
@@ -1,3 +1,8 @@
+.modal {
+    max-width: 520px;
+    padding: 40px;
+}
+
 .orderHeader {
     display: flex;
     align-items: flex-start;

--- a/app/lib/modal/modals/WelcomeToPremiumModal.module.css
+++ b/app/lib/modal/modals/WelcomeToPremiumModal.module.css
@@ -8,7 +8,6 @@
     flex-direction: column;
     align-items: center;
     text-align: center;
-    gap: 16px;
 }
 
 .badge {
@@ -18,12 +17,13 @@
     padding: 6px 14px;
     background: linear-gradient(135deg, var(--color-purple-500) 0%, var(--color-blue-500) 100%);
     border-radius: 20px;
-    font-size: 15px;
+    font-size: 13px;
     font-weight: 600;
     color: white;
     letter-spacing: 0.5px;
     position: relative;
     overflow: hidden;
+    margin-bottom: 20px;
 }
 
 .badge::after {
@@ -57,7 +57,7 @@
     font-weight: 700;
     color: var(--color-gray-900);
     line-height: 1.2;
-    margin: 0;
+    margin: 0 0 4px 0;
 }
 
 .highlight {
@@ -71,8 +71,8 @@
     font-size: 16px;
     color: var(--color-gray-600);
     line-height: 1.6;
-    margin: 0;
-    max-width: 350px;
+    margin: 0 0 16px 0;
+    max-width: 400px;
 }
 
 .actions {

--- a/app/lib/modal/modals/WelcomeToPremiumModal.tsx
+++ b/app/lib/modal/modals/WelcomeToPremiumModal.tsx
@@ -30,8 +30,8 @@ export function WelcomeToPremiumModal({ onClose }: WelcomeToPremiumModalProps) {
       </h2>
 
       <p className={styles.description}>
-        Great, you now have all the benefits included in the Premium Plan! Unlimited chats with Jiki on all lessons, and
-        so much more awaits you.
+        Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki,
+        Projects, and Build with Jeremy!
       </p>
 
       <div className={styles.actions}>

--- a/app/lib/modal/store.ts
+++ b/app/lib/modal/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { MembershipTier } from "@/lib/pricing";
 import confirmationStyles from "@/app/styles/components/confirmation-modal.module.css";
 import paymentProcessingStyles from "./modals/PaymentProcessingModal.module.css";
+import subscriptionCheckoutStyles from "./modals/SubscriptionCheckoutModal.module.css";
 import welcomeToPremiumStyles from "./modals/WelcomeToPremiumModal.module.css";
 import walkthroughConfirmStyles from "./modals/WalkthroughConfirmModal.module.css";
 
@@ -113,6 +114,16 @@ export const showSubscriptionSuccess = (props: {
   onClose?: () => void;
 }) => {
   showModal("subscription-success-modal", props);
+};
+
+// Convenience function for subscription checkout modal
+export const showSubscriptionCheckout = (props: {
+  clientSecret: string;
+  selectedTier: MembershipTier;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+}) => {
+  showModal("subscription-checkout-modal", props, undefined, subscriptionCheckoutStyles.modal);
 };
 
 // Convenience function for payment processing modal

--- a/app/lib/subscriptions/handlers.ts
+++ b/app/lib/subscriptions/handlers.ts
@@ -12,7 +12,7 @@ import {
 } from "@/lib/api/subscriptions";
 import { createCheckoutReturnUrl } from "@/lib/subscriptions/checkout";
 import { getApiUrl } from "@/lib/api/config";
-import { hideModal, showModal } from "@/lib/modal";
+import { hideModal, showSubscriptionCheckout } from "@/lib/modal";
 import toast from "react-hot-toast";
 
 // Types for handler functions
@@ -47,7 +47,7 @@ export async function handleSubscribe({ interval, userEmail, returnPath }: Subsc
     hideModal();
 
     // Show the checkout modal using the global modal system
-    showModal("subscription-checkout-modal", {
+    showSubscriptionCheckout({
       clientSecret: response.client_secret,
       selectedTier: "premium",
       onCancel: () => {

--- a/app/tests/unit/components/settings/subscription/handlers.test.ts
+++ b/app/tests/unit/components/settings/subscription/handlers.test.ts
@@ -4,7 +4,7 @@
 import * as subscriptionApi from "@/lib/api/subscriptions";
 import * as checkoutUtils from "@/lib/subscriptions/checkout";
 import * as handlers from "@/components/settings/subscription/handlers";
-import { showModal } from "@/lib/modal";
+import { showSubscriptionCheckout } from "@/lib/modal";
 import toast from "react-hot-toast";
 
 // Mock the external dependencies
@@ -15,7 +15,7 @@ jest.mock("react-hot-toast");
 
 const mockSubscriptionApi = subscriptionApi as jest.Mocked<typeof subscriptionApi>;
 const mockCheckoutUtils = checkoutUtils as jest.Mocked<typeof checkoutUtils>;
-const mockShowModal = showModal as jest.MockedFunction<typeof showModal>;
+const mockShowSubscriptionCheckout = showSubscriptionCheckout as jest.MockedFunction<typeof showSubscriptionCheckout>;
 const mockToast = toast as jest.Mocked<typeof toast>;
 
 describe("Subscription handlers", () => {
@@ -51,7 +51,7 @@ describe("Subscription handlers", () => {
         "https://example.com/settings?session_id={CHECKOUT_SESSION_ID}",
         "test@example.com"
       );
-      expect(mockShowModal).toHaveBeenCalledWith("subscription-checkout-modal", {
+      expect(mockShowSubscriptionCheckout).toHaveBeenCalledWith({
         clientSecret: "cs_test_123",
         selectedTier: "premium",
         onCancel: expect.any(Function)


### PR DESCRIPTION
## Summary
- Route the Stripe checkout modal through `showSubscriptionCheckout` so it picks up its own CSS module overrides (`max-width: 520px`, `padding: 40px`) — previously `handlers.ts` was calling `showModal` directly and bypassing the per-modal class.
- Adjust spacing/typography on the welcome-to-premium modal: badge font 13px with 20px bottom margin, title 4px bottom margin, description 16px bottom margin and 400px max-width, removed the container gap, refreshed the description copy.

## Test plan
- [x] `pnpm test tests/unit/components/settings/subscription/handlers.test.ts`
- [ ] Manually open the Stripe checkout modal and confirm width/padding
- [ ] Manually open the welcome-to-premium modal and confirm spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)