### PR TITLE
Tweak gap between tabs and dashboard button on coding exercise RHS

### DIFF
--- a/app/components/coding-exercise/RHS.tsx
+++ b/app/components/coding-exercise/RHS.tsx
@@ -102,7 +102,7 @@ export function RHS({ orchestrator }: RHSProps) {
 
   return (
     <div className={styles.rightColumn}>
-      <div className="flex items-center justify-between gap-8 px-[32px] py-[8px] bg-white overflow-x-auto flex-shrink-0">
+      <div className="flex items-center justify-between gap-[24px] px-[32px] py-[8px] bg-white overflow-x-auto flex-shrink-0">
         <PageTabs className="shrink-0" tabs={tabs} activeTabId={activeTab} onTabChange={setActiveTab} />
         <button
           onClick={() => router.push("/dashboard")}


### PR DESCRIPTION
## Summary
- Reduce gap between PageTabs and Dashboard button from 32px to 24px on the coding exercise right column header.

## Test plan
- [ ] Visually verify spacing on the coding exercise right column

🤖 Generated with [Claude Code](https://claude.com/claude-code)