### PR TITLE
Fix JS parser to accept Allman-style else / else if

### DIFF
--- a/interpreters/src/javascript/parser.ts
+++ b/interpreters/src/javascript/parser.ts
@@ -41,6 +41,10 @@ import { translate } from "./translator";
 import type { LanguageFeatures, NodeType } from "./interfaces";
 import type { EvaluationContext } from "./interpreter";
 
+interface SkipOptions {
+  skipEOL?: boolean;
+}
+
 export class Parser {
   private readonly scanner: Scanner;
   private current: number = 0;
@@ -293,10 +297,7 @@ export class Parser {
     }
 
     while (!this.isAtEnd()) {
-      // Skip EOL tokens before checking for RIGHT_BRACE
-      while (this.check("EOL")) {
-        this.advance();
-      }
+      this.skipEOL();
 
       // Check if we've reached the closing brace
       if (this.check("RIGHT_BRACE")) {
@@ -353,7 +354,8 @@ export class Parser {
     const thenBranch = this.requireBlockStatement("if");
     let elseBranch: Statement | null = null;
 
-    if (this.match("ELSE")) {
+    // Allow Allman-style: `else` on the line after the closing brace.
+    if (this.match("ELSE", { skipEOL: true })) {
       // Allow "else if" without requiring braces directly after "else"
       if (this.check("IF")) {
         elseBranch = this.statement();
@@ -915,21 +917,41 @@ export class Parser {
     this.error("MissingExpression", this.peek().location);
   }
 
-  private match(...tokenTypes: TokenType[]): boolean {
-    for (const tokenType of tokenTypes) {
+  private match(...tokenTypes: TokenType[]): boolean;
+  private match(tokenType: TokenType, options: SkipOptions): boolean;
+  private match(...args: (TokenType | SkipOptions)[]): boolean {
+    const { types, options } = this.parseTokenArgs(args);
+    const savedPosition = this.current;
+    if (options.skipEOL) {
+      this.skipEOL();
+    }
+    for (const tokenType of types) {
       if (this.check(tokenType)) {
         this.advance();
         return true;
       }
     }
+    this.current = savedPosition;
     return false;
   }
 
-  private check(...tokenTypes: TokenType[]): boolean {
-    if (this.isAtEnd()) {
+  private check(...tokenTypes: TokenType[]): boolean;
+  private check(tokenType: TokenType, options: SkipOptions): boolean;
+  private check(...args: (TokenType | SkipOptions)[]): boolean {
+    const { types, options } = this.parseTokenArgs(args);
+    let lookaheadIndex = this.current;
+    if (options.skipEOL) {
+      while (lookaheadIndex < this.tokens.length && this.tokens[lookaheadIndex].type === "EOL") {
+        lookaheadIndex++;
+      }
+    }
+    if (lookaheadIndex >= this.tokens.length) {
       return false;
     }
-    return tokenTypes.includes(this.peek().type);
+    if (this.tokens[lookaheadIndex].type === "EOF") {
+      return false;
+    }
+    return types.includes(this.tokens[lookaheadIndex].type);
   }
 
   private advance(): Token {
@@ -939,19 +961,33 @@ export class Parser {
     return this.previous();
   }
 
-  private consume(tokenType: TokenType, errorType: SyntaxErrorType): Token {
+  private consume(tokenType: TokenType, errorType: SyntaxErrorType, options: SkipOptions = {}): Token {
+    if (options.skipEOL) {
+      this.skipEOL();
+    }
     if (this.check(tokenType)) {
       return this.advance();
     }
     this.error(errorType, this.peek().location);
   }
 
+  private skipEOL(): void {
+    while (!this.isAtEnd() && this.peek().type === "EOL") {
+      this.current++;
+    }
+  }
+
+  private parseTokenArgs(args: (TokenType | SkipOptions)[]): { types: TokenType[]; options: SkipOptions } {
+    const last = args[args.length - 1];
+    if (typeof last === "object") {
+      return { types: args.slice(0, -1) as TokenType[], options: last };
+    }
+    return { types: args as TokenType[], options: {} };
+  }
+
   private requireBlockStatement(keyword: string): Statement {
     if (this.languageFeatures.enforceFormatting) {
-      // Skip EOL tokens that might be between the ) and {
-      while (this.check("EOL")) {
-        this.advance();
-      }
+      this.skipEOL();
       if (!this.check("LEFT_BRACE")) {
         this.error("BlockRequired", this.peek().location, { keyword });
       }
@@ -1132,10 +1168,7 @@ export class Parser {
 
     const elements: Expression[] = [];
 
-    // Skip EOL tokens after opening bracket
-    while (this.check("EOL")) {
-      this.advance();
-    }
+    this.skipEOL();
 
     // Handle empty array
     if (this.check("RIGHT_BRACKET")) {
@@ -1150,10 +1183,7 @@ export class Parser {
 
     // Parse array elements
     do {
-      // Skip EOL tokens before element
-      while (this.check("EOL")) {
-        this.advance();
-      }
+      this.skipEOL();
 
       // Check for trailing comma before closing bracket
       if (this.check("RIGHT_BRACKET")) {
@@ -1163,12 +1193,7 @@ export class Parser {
       elements.push(this.assignment());
     } while (this.match("COMMA"));
 
-    // Skip EOL tokens before closing bracket
-    while (this.check("EOL")) {
-      this.advance();
-    }
-
-    this.consume("RIGHT_BRACKET", "MissingRightBracketInArray");
+    this.consume("RIGHT_BRACKET", "MissingRightBracketInArray", { skipEOL: true });
     const rightBracket = this.previous();
 
     return new ArrayExpression(elements, Location.between(leftBracket, rightBracket));
@@ -1182,10 +1207,7 @@ export class Parser {
 
     const elements = new Map<string, Expression>();
 
-    // Skip EOL tokens after opening brace
-    while (this.check("EOL")) {
-      this.advance();
-    }
+    this.skipEOL();
 
     // Handle empty object
     if (this.check("RIGHT_BRACE")) {
@@ -1200,10 +1222,7 @@ export class Parser {
 
     // Parse object properties
     do {
-      // Skip EOL tokens before property
-      while (this.check("EOL")) {
-        this.advance();
-      }
+      this.skipEOL();
 
       // Check for trailing comma before closing brace
       if (this.check("RIGHT_BRACE")) {
@@ -1233,12 +1252,7 @@ export class Parser {
       elements.set(key, value);
     } while (this.match("COMMA"));
 
-    // Skip EOL tokens before closing brace
-    while (this.check("EOL")) {
-      this.advance();
-    }
-
-    this.consume("RIGHT_BRACE", "MissingRightBraceInDictionary");
+    this.consume("RIGHT_BRACE", "MissingRightBraceInDictionary", { skipEOL: true });
     const rightBrace = this.previous();
 
     return new DictionaryExpression(elements, Location.between(leftBrace, rightBrace));

--- a/interpreters/tests/javascript/concepts/if.test.ts
+++ b/interpreters/tests/javascript/concepts/if.test.ts
@@ -133,6 +133,58 @@ describe("if statement concept", () => {
   });
 
   describe("else if statements", () => {
+    test("allows else if on a new line (Allman-style)", () => {
+      const code = `let x = 1;
+if (x === 1) {
+  x = 10;
+}
+else if (x === 2) {
+  x = 20;
+}`;
+      const { frames, error } = interpret(code);
+      expect(error).toBeNull();
+      expect((frames[frames.length - 1] as TestAugmentedFrame).variables.x.value).toBe(10);
+    });
+
+    test("allows plain else on a new line (Allman-style)", () => {
+      const code = `let x = 0;
+if (false) {
+  x = 1;
+}
+else {
+  x = 2;
+}`;
+      const { frames, error } = interpret(code);
+      expect(error).toBeNull();
+      expect((frames[frames.length - 1] as TestAugmentedFrame).variables.x.value).toBe(2);
+    });
+
+    test("allows multiple blank lines between } and else", () => {
+      const code = `let x = 0;
+if (false) {
+  x = 1;
+}
+
+
+else {
+  x = 2;
+}`;
+      const { frames, error } = interpret(code);
+      expect(error).toBeNull();
+      expect((frames[frames.length - 1] as TestAugmentedFrame).variables.x.value).toBe(2);
+    });
+
+    test("a trailing if-with-no-else followed by a separate statement still parses", () => {
+      const code = `let x = 0;
+if (true) {
+  x = 1;
+}
+x = 2;`;
+      const { frames, error } = interpret(code);
+      expect(error).toBeNull();
+      expect((frames[frames.length - 1] as TestAugmentedFrame).variables.x.value).toBe(2);
+    });
+
     test("executes else if branch when first condition is false and else if is true", () => {
       const { frames, error } = interpret(`
         let result = 0;


### PR DESCRIPTION
## Summary
- Fixes a parser bug where the JS interpreter rejected `else` / `else if` placed on the line after the preceding block's closing brace.
- Adds three reusable EOL-handling primitives to the parser (`skipEOL()`, `{ skipEOL: true }` on `check`/`match`/`consume`) and refactors the eight ad-hoc EOL-skip loops in object/array/block parsing to use them.

## Repro (now fixed)
```js
if (x) {
  ...
}
else if (y) {
  ...
}
```
Previously failed with `MissingExpression` on the `else` token.

## Test plan
- [x] New tests in `tests/javascript/concepts/if.test.ts` covering Allman `else if`, Allman plain `else`, multiple blank lines between `}` and `else`, and `if`-with-no-else followed by a sibling statement (rewind regression guard).
- [x] Full JS interpreter test suite (3406 passing).
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)