### PR TITLE
Fix LLM chat proxy deploy: load curriculum CSS as text

### DIFF
--- a/llm-chat-proxy/wrangler.toml
+++ b/llm-chat-proxy/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [[rules]]
 type = "Text"
-globs = ["**/*.javascript", "**/*.py", "**/*.jiki", "**/*.md"]
+globs = ["**/*.css", "**/*.javascript", "**/*.py", "**/*.jiki", "**/*.md"]
 fallthrough = true
 
 [[routes]]


### PR DESCRIPTION
## Summary
- Cloudflare Worker deploy (`Deploy Cloudflare Workers / Deploy LLM Chat Proxy`) has been failing on `main` since #484. Curriculum exercise `index.ts` modules import their category `exercise.css`, which references web-absolute `url(/static/...)` assets. The Next.js app handles those fine, but esbuild (via wrangler) tried to resolve them at bundle time and failed with 10 `Could not resolve` errors.
- Add `**/*.css` to the existing `Text` rule in `llm-chat-proxy/wrangler.toml`. esbuild then imports CSS as a string and skips `url()` resolution. The Worker never reads the content.

## Test plan
- [ ] `Deploy Cloudflare Workers / Deploy LLM Chat Proxy` job goes green on this PR
- [ ] Worker behaviour unchanged (CSS was never used at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)