### PR TITLE
Show full Mux controls once a video lesson is completed

### DIFF
--- a/app/components/video-exercise/VideoExercise.module.css
+++ b/app/components/video-exercise/VideoExercise.module.css
@@ -91,6 +91,14 @@
     transition: opacity 500ms;
 }
 
+.muxPlayerCompleted {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    transition: opacity 500ms;
+}
+
 .muxPlayerHidden {
     opacity: 0;
     visibility: hidden;
@@ -268,7 +276,7 @@
 }
 
 /* Override UI button styles for stronger disabled state */
-.continueWrapper button:disabled {
+.continueWrapper button:disabled:not(:global(.ui-btn-loading)) {
     background: var(--color-gray-100);
     color: var(--color-gray-400);
     box-shadow: none;

--- a/app/components/video-exercise/VideoExercise.tsx
+++ b/app/components/video-exercise/VideoExercise.tsx
@@ -54,7 +54,7 @@ export default function VideoExercise({ lessonData, onReady }: { lessonData: Vid
               loop={false}
               muted={false}
               volume={0.5}
-              className={`${styles.muxPlayer} ${isVideoVisible ? styles.muxPlayerVisible : styles.muxPlayerHidden}`}
+              className={`${videoWatched ? styles.muxPlayerCompleted : styles.muxPlayer} ${isVideoVisible ? styles.muxPlayerVisible : styles.muxPlayerHidden}`}
               onPlay={handleVideoPlay}
               onEnded={handleVideoEnd}
               onTimeUpdate={handleTimeUpdate}


### PR DESCRIPTION
Restore the default Mux control bar (seek button + time range) when the
lesson is already complete or has just finished, so students can scrub
back through the video. Also stop the disabled-state override from
graying out the Continue button while it is in its "Saving..." loading
state, keeping the green primary styling consistent.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
