### PR TITLE
Use context slug for lesson submission and surface API errors

### DIFF
--- a/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
+++ b/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
@@ -1,5 +1,7 @@
 import type { ExerciseDefinition } from "@jiki/curriculum";
+import toast from "react-hot-toast";
 import type { StoreApi } from "zustand/vanilla";
+import { ApiError, AuthenticationError, NetworkError, RateLimitError } from "@/lib/api/client";
 import { processMessageContent } from "../../ui/messageUtils";
 import type { TestSuiteResult, TestExpect } from "../test-results-types";
 import type { ExerciseContext, OrchestratorStore } from "../types";
@@ -56,67 +58,39 @@ export class TestSuiteManager {
   }
 
   /**
-   * Get lesson slug from the current URL
+   * Submit exercise files to the backend (fire and forget).
+   * Network/auth/rate-limit errors are handled globally; surface other
+   * HTTP errors (e.g. 422/500) via a toast so the student knows their
+   * submission wasn't recorded.
    */
-  private getLessonSlugFromURL(): string | null {
-    // Get the pathname from window location
-    if (typeof window === "undefined") {
-      return null;
+  private submitExerciseFiles(code: string): void {
+    if (!this.context) {
+      return;
     }
 
-    const pathname = window.location.pathname;
-    // URL format is /lesson/[slug], so extract the slug
-    const match = pathname.match(/\/lesson\/([^/]+)/);
-    return match ? match[1] : null;
-  }
+    const files = [{ filename: "solution.js", code }];
 
-  /**
-   * Submit exercise files to the backend (fire and forget)
-   */
-  private async submitExerciseFiles(code: string): Promise<void> {
-    try {
-      // Check if this is a project submission
-      if (this.context?.type === "project") {
-        const { submitProjectExercise } = await import("@/lib/api/projects");
+    const submission =
+      this.context.type === "project"
+        ? import("@/lib/api/projects").then(({ submitProjectExercise }) =>
+            submitProjectExercise(this.context!.slug, files)
+          )
+        : import("@/lib/api/lessons").then(({ submitLessonExercise }) =>
+            submitLessonExercise(this.context!.slug, files)
+          );
 
-        // Fire and forget - we don't await or care about the response
-        void submitProjectExercise(this.context.slug, [
-          {
-            filename: "solution.js", // or appropriate extension
-            code: code
-          }
-        ]).catch(() => {
-          // Silently ignore errors (no internet, etc.)
-        });
+    void submission.catch((error: unknown) => {
+      // Network/auth/rate-limit errors get a global UI treatment already.
+      if (error instanceof NetworkError || error instanceof AuthenticationError || error instanceof RateLimitError) {
         return;
       }
-
-      // Handle lesson submission (existing logic)
-      const lessonSlug = this.getLessonSlugFromURL();
-      if (!lessonSlug) {
-        return; // Can't submit without a lesson slug
+      if (error instanceof ApiError) {
+        console.warn("Failed to submit exercise:", error);
+        toast.error("Couldn't save your submission. Please try again.", { id: "exercise-submission-error" });
+        return;
       }
-
-      const { api } = await import("@/lib/api/client");
-
-      // Fire and forget - we don't await or care about the response
-      void api
-        .post(`/internal/lessons/${lessonSlug}/exercise_submissions`, {
-          submission: {
-            files: [
-              {
-                filename: "solution.js", // or appropriate extension
-                code: code
-              }
-            ]
-          }
-        })
-        .catch(() => {
-          // Silently ignore errors (no internet, etc.)
-        });
-    } catch {
-      // Silently ignore any import or other errors
-    }
+      console.warn("Failed to submit exercise:", error);
+    });
   }
 
   /**
@@ -125,9 +99,8 @@ export class TestSuiteManager {
   async runCode(code: string, exercise: ExerciseDefinition): Promise<void> {
     this.prepareStateForTestRun();
 
-    // Submit exercise files asynchronously (gets lesson slug from URL)
-    // Fire and forget - don't await
-    void this.submitExerciseFiles(code);
+    // Fire and forget - submission is recorded server-side but doesn't block the test run
+    this.submitExerciseFiles(code);
 
     try {
       // Import and run our new test runner

--- a/app/lib/api/lessons.ts
+++ b/app/lib/api/lessons.ts
@@ -46,6 +46,20 @@ export interface ExerciseSubmissionFile {
   content: string;
 }
 
+export interface LessonSubmissionFile {
+  filename: string;
+  code: string;
+}
+
+/**
+ * Submit exercise files for a lesson
+ */
+export async function submitLessonExercise(slug: string, files: LessonSubmissionFile[]): Promise<void> {
+  await api.post(`/internal/lessons/${slug}/exercise_submissions`, {
+    submission: { files }
+  });
+}
+
 export interface LatestExerciseSubmission {
   uuid: string;
   context_type: string;

--- a/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
@@ -1,27 +1,35 @@
 import { TestSuiteManager } from "@/components/coding-exercise/lib/orchestrator/TestSuiteManager";
+import { ApiError, AuthenticationError, NetworkError, RateLimitError } from "@/lib/api/client";
+import type { ExerciseContext } from "@/components/coding-exercise/lib/types";
 import { createMockExercise, createMockOrchestratorStore } from "@/tests/mocks";
 
-// Mock the test runner
 jest.mock("@/components/coding-exercise/lib/test-runner/runTests", () => ({
   runTests: jest.fn()
 }));
 
-// Mock the API client dynamically
-jest.mock("@/lib/api/client", () => ({
-  api: {
-    post: jest.fn().mockResolvedValue({})
-  }
+jest.mock("@/lib/api/lessons", () => ({
+  submitLessonExercise: jest.fn().mockResolvedValue(undefined)
 }));
 
+jest.mock("@/lib/api/projects", () => ({
+  submitProjectExercise: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { error: jest.fn() }
+}));
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("TestSuiteManager", () => {
-  let manager: TestSuiteManager;
   let mockStore: any;
+  const mockCode = "console.log('test')";
+  const mockExercise = createMockExercise();
 
-  beforeEach(() => {
-    // Clear all mocks
-    jest.clearAllMocks();
-
-    // Create fresh store and manager for each test
+  function buildManager(context?: ExerciseContext) {
     mockStore = createMockOrchestratorStore({
       setHasSyntaxError: jest.fn(),
       setStatus: jest.fn(),
@@ -33,152 +41,159 @@ describe("TestSuiteManager", () => {
       currentTest: null,
       language: "javascript"
     });
-    manager = new TestSuiteManager(mockStore);
+    return new TestSuiteManager(mockStore, undefined, context);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  describe("runCode", () => {
-    const mockCode = "console.log('test')";
-    const mockExercise = createMockExercise();
+  describe("runCode submission", () => {
+    it("submits to the lesson endpoint when context is a lesson", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
 
-    it("should submit exercise files to the backend when running tests", async () => {
-      const { api } = await import("@/lib/api/client");
+      const { submitLessonExercise } = await import("@/lib/api/lessons");
       const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-
-      // Mock getLessonSlugFromURL to return a specific slug
-      jest.spyOn(manager as any, "getLessonSlugFromURL").mockReturnValue("solve-a-maze");
-
-      // Mock successful test run
-      (runTests as jest.Mock).mockReturnValue({
-        tests: [],
-        passed: true
-      });
-
-      // Run the code
-      await manager.runCode(mockCode, mockExercise);
-
-      // Verify API was called with correct parameters
-      expect(api.post).toHaveBeenCalledWith("/internal/lessons/solve-a-maze/exercise_submissions", {
-        submission: {
-          files: [
-            {
-              filename: "solution.js",
-              code: mockCode
-            }
-          ]
-        }
-      });
-
-      // Verify test runner was called with language parameter
-      expect(runTests).toHaveBeenCalledWith(mockCode, mockExercise, "javascript");
-
-      // Verify store methods were called
-      const state = mockStore.getState();
-      expect(state.setHasSyntaxError).toHaveBeenCalledWith(false);
-      expect(state.setStatus).toHaveBeenCalledWith("running");
-      expect(state.setError).toHaveBeenCalledWith(null);
-      expect(state.setTestSuiteResult).toHaveBeenCalled();
-    });
-
-    it("should extract lesson slug from URL correctly", async () => {
-      const { api } = await import("@/lib/api/client");
-      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-
-      // Test different URL patterns
-      const testCases = [
-        { slug: "solve-a-maze" },
-        { slug: "win-space-invaders" },
-        { slug: "solve-a-maze-with-numbers" }
-      ];
-
-      for (const testCase of testCases) {
-        // Mock getLessonSlugFromURL to return the test slug
-        jest.spyOn(manager as any, "getLessonSlugFromURL").mockReturnValue(testCase.slug);
-
-        // Clear previous calls
-        (api.post as jest.Mock).mockClear();
-        (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
-
-        // Run the code
-        await manager.runCode(mockCode, mockExercise);
-
-        // Verify API was called with correct lesson slug
-        expect(api.post).toHaveBeenCalledWith(
-          `/internal/lessons/${testCase.slug}/exercise_submissions`,
-          expect.any(Object)
-        );
-      }
-    });
-
-    it("should not submit if no lesson slug in URL", async () => {
-      const { api } = await import("@/lib/api/client");
-      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-
-      // Mock getLessonSlugFromURL to return null (no lesson slug)
-      jest.spyOn(manager as any, "getLessonSlugFromURL").mockReturnValue(null);
-
       (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
 
-      // Run the code
+      await manager.runCode(mockCode, mockExercise);
+      await flushMicrotasks();
+
+      expect(submitLessonExercise).toHaveBeenCalledWith("solve-a-maze", [{ filename: "solution.js", code: mockCode }]);
+    });
+
+    it("submits to the project endpoint when context is a project", async () => {
+      const manager = buildManager({ type: "project", slug: "build-a-blog" });
+
+      const { submitProjectExercise } = await import("@/lib/api/projects");
+      const { submitLessonExercise } = await import("@/lib/api/lessons");
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
+
+      await manager.runCode(mockCode, mockExercise);
+      await flushMicrotasks();
+
+      expect(submitProjectExercise).toHaveBeenCalledWith("build-a-blog", [{ filename: "solution.js", code: mockCode }]);
+      expect(submitLessonExercise).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when no context is provided", async () => {
+      const manager = buildManager();
+
+      const { submitLessonExercise } = await import("@/lib/api/lessons");
+      const { submitProjectExercise } = await import("@/lib/api/projects");
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
+
+      await manager.runCode(mockCode, mockExercise);
+      await flushMicrotasks();
+
+      expect(submitLessonExercise).not.toHaveBeenCalled();
+      expect(submitProjectExercise).not.toHaveBeenCalled();
+    });
+
+    it("runs tests with the language regardless of submission state", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
+
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
+
       await manager.runCode(mockCode, mockExercise);
 
-      // Verify API was NOT called
-      expect(api.post).not.toHaveBeenCalled();
-
-      // Verify tests still ran with language parameter
       expect(runTests).toHaveBeenCalledWith(mockCode, mockExercise, "javascript");
     });
 
-    it("should handle submission errors silently", async () => {
-      const { api } = await import("@/lib/api/client");
+    it("does not block test execution when submission fails", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
+
+      const { submitLessonExercise } = await import("@/lib/api/lessons");
+      (submitLessonExercise as jest.Mock).mockRejectedValueOnce(new NetworkError("offline"));
+
       const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-
-      // Mock getLessonSlugFromURL
-      jest.spyOn(manager as any, "getLessonSlugFromURL").mockReturnValue("solve-a-maze");
-
-      // Mock API to throw error
-      (api.post as jest.Mock).mockRejectedValue(new Error("Network error"));
       (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
 
-      // Run the code - should not throw
       await expect(manager.runCode(mockCode, mockExercise)).resolves.not.toThrow();
-
-      // Verify tests still ran despite API error with language parameter
-      expect(runTests).toHaveBeenCalledWith(mockCode, mockExercise, "javascript");
       expect(mockStore.getState().setTestSuiteResult).toHaveBeenCalled();
     });
+  });
 
-    it("should handle syntax errors correctly", async () => {
+  describe("submission error handling", () => {
+    it("toasts on a generic ApiError (e.g. 500)", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
+
+      const { submitLessonExercise } = await import("@/lib/api/lessons");
+      (submitLessonExercise as jest.Mock).mockRejectedValueOnce(new ApiError(500, "Internal Server Error"));
+
       const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
 
-      const syntaxError = {
-        message: "Unexpected token",
-        location: { line: 5 }
-      };
+      const toast = (await import("react-hot-toast")).default;
 
-      // Mock test runner to throw syntax error
+      await manager.runCode(mockCode, mockExercise);
+      await flushMicrotasks();
+
+      expect(toast.error).toHaveBeenCalledTimes(1);
+      expect((toast.error as jest.Mock).mock.calls[0][0]).toMatch(/submission|attempt/i);
+    });
+
+    it("does not toast on NetworkError (handled globally)", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
+
+      const { submitLessonExercise } = await import("@/lib/api/lessons");
+      (submitLessonExercise as jest.Mock).mockRejectedValueOnce(new NetworkError("offline"));
+
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
+
+      const toast = (await import("react-hot-toast")).default;
+
+      await manager.runCode(mockCode, mockExercise);
+      await flushMicrotasks();
+
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("does not toast on AuthenticationError or RateLimitError (handled globally)", async () => {
+      const { submitLessonExercise } = await import("@/lib/api/lessons");
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      const toast = (await import("react-hot-toast")).default;
+
+      for (const error of [new AuthenticationError("Unauthorized"), new RateLimitError("Too Many Requests", 1)]) {
+        const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
+        (submitLessonExercise as jest.Mock).mockRejectedValueOnce(error);
+        (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
+
+        await manager.runCode(mockCode, mockExercise);
+        await flushMicrotasks();
+      }
+
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("runCode error handling", () => {
+    it("handles syntax errors correctly", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
+
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      const syntaxError = { message: "Unexpected token", location: { line: 5 } };
       (runTests as jest.Mock).mockImplementation(() => {
         throw syntaxError;
       });
 
-      // Run the code
       await manager.runCode(mockCode, mockExercise);
 
-      // Verify error handling
       const state = mockStore.getState();
       expect(state.setHasSyntaxError).toHaveBeenCalledWith(true);
       expect(state.setTestSuiteResult).toHaveBeenCalledWith(null);
       expect(state.setInformationWidgetData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          line: 5,
-          status: "ERROR"
-        })
+        expect.objectContaining({ line: 5, status: "ERROR" })
       );
-      // The html should contain the error message (header is now added by InformationWidget)
-      const widgetCall = state.setInformationWidgetData.mock.calls[0][0];
+      const widgetCall = (state.setInformationWidgetData as jest.Mock).mock.calls[0][0];
       expect(widgetCall.html).toContain("Unexpected token");
       expect(widgetCall.html).not.toContain("Oops, something went wrong!");
       expect(state.setShouldShowInformationWidget).toHaveBeenCalledWith(true);
@@ -186,120 +201,47 @@ describe("TestSuiteManager", () => {
       expect(state.setStatus).toHaveBeenCalledWith("error");
     });
 
-    it("should handle non-syntax errors correctly", async () => {
-      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+    it("rethrows non-syntax errors in test/dev so they surface in the overlay", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
 
-      // Mock test runner to throw regular error
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
       (runTests as jest.Mock).mockImplementation(() => {
         throw new Error("Some other error");
       });
 
-      // Non-syntax errors are re-thrown in dev/test so they surface in the Next.js overlay.
       await expect(manager.runCode(mockCode, mockExercise)).rejects.toThrow("Some other error");
 
-      // Syntax-error handling was reset before the throw.
-      const state = mockStore.getState();
-      expect(state.setHasSyntaxError).toHaveBeenCalledWith(false);
-    });
-
-    it("should run tests and submit asynchronously (fire-and-forget)", async () => {
-      const { api } = await import("@/lib/api/client");
-      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-
-      // Mock getLessonSlugFromURL
-      jest.spyOn(manager as any, "getLessonSlugFromURL").mockReturnValue("solve-a-maze");
-
-      // Create a promise that we can control
-      let resolveApiCall: () => void;
-      const apiPromise = new Promise<void>((resolve) => {
-        resolveApiCall = resolve;
-      });
-
-      // Mock API to return our controlled promise
-      (api.post as jest.Mock).mockReturnValue(apiPromise);
-      (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
-
-      // Run the code and await it
-      await manager.runCode(mockCode, mockExercise);
-
-      // After runCode completes, verify test results were set
-      expect(mockStore.getState().setTestSuiteResult).toHaveBeenCalled();
-
-      // Resolve the API call (which is fire-and-forget)
-      resolveApiCall!();
-      await apiPromise;
-
-      // API should have been called
-      expect(api.post).toHaveBeenCalled();
-    });
-
-    it("should handle undefined window gracefully", async () => {
-      const { api } = await import("@/lib/api/client");
-      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-
-      // Mock getLessonSlugFromURL to simulate undefined window
-      jest.spyOn(manager as any, "getLessonSlugFromURL").mockReturnValue(null);
-
-      (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
-
-      // Run the code - should not throw
-      await expect(manager.runCode(mockCode, mockExercise)).resolves.not.toThrow();
-
-      // Verify API was NOT called (no lesson slug available)
-      expect(api.post).not.toHaveBeenCalled();
-
-      // Verify tests still ran
-      expect(runTests).toHaveBeenCalled();
+      expect(mockStore.getState().setHasSyntaxError).toHaveBeenCalledWith(false);
     });
   });
 
   describe("getFirstExpect", () => {
     it("should return first failing expect when available", () => {
+      const manager = buildManager();
       const failingExpect = { pass: false, description: "Should fail" };
       const passingExpect = { pass: true, description: "Should pass" };
-
-      mockStore.getState = jest.fn(() => ({
-        currentTest: {
-          expects: [passingExpect, failingExpect]
-        }
-      }));
-
-      const result = manager.getFirstExpect();
-      expect(result).toBe(failingExpect);
+      mockStore.getState = jest.fn(() => ({ currentTest: { expects: [passingExpect, failingExpect] } }));
+      expect(manager.getFirstExpect()).toBe(failingExpect);
     });
 
     it("should return first expect when no failures", () => {
+      const manager = buildManager();
       const expect1 = { pass: true, description: "First" };
       const expect2 = { pass: true, description: "Second" };
-
-      mockStore.getState = jest.fn(() => ({
-        currentTest: {
-          expects: [expect1, expect2]
-        }
-      }));
-
-      const result = manager.getFirstExpect();
-      expect(result).toBe(expect1);
+      mockStore.getState = jest.fn(() => ({ currentTest: { expects: [expect1, expect2] } }));
+      expect(manager.getFirstExpect()).toBe(expect1);
     });
 
     it("should return null when no current test", () => {
-      mockStore.getState = jest.fn(() => ({
-        currentTest: null
-      }));
-
-      const result = manager.getFirstExpect();
-      expect(result).toBeNull();
+      const manager = buildManager();
+      mockStore.getState = jest.fn(() => ({ currentTest: null }));
+      expect(manager.getFirstExpect()).toBeNull();
     });
 
     it("should return null when expects array is empty", () => {
-      mockStore.getState = jest.fn(() => ({
-        currentTest: {
-          expects: []
-        }
-      }));
-
-      const result = manager.getFirstExpect();
-      expect(result).toBeNull();
+      const manager = buildManager();
+      mockStore.getState = jest.fn(() => ({ currentTest: { expects: [] } }));
+      expect(manager.getFirstExpect()).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- `TestSuiteManager.submitExerciseFiles` lesson branch was parsing `window.location.pathname` for the lesson slug despite already having `this.context.slug` available. Replaced with the context value (matches the project branch). This also means submissions now work outside `/lesson/[slug]` routes (dev/test pages, future embeds).
- Added `submitLessonExercise` helper in `lib/api/lessons.ts` so the lesson and project branches both go through named API helpers instead of one inlining `api.post`.
- Generic `ApiError`s (e.g. 500/422) were being swallowed by `.catch(() => {})`, so a student would never know the server didn't record their attempt. Now those surface as a toast (deduped via toast id). Network/auth/rate-limit errors stay silent — they already have global UI treatment.
- Removed the dead outer `try`/`catch` that only wrapped dynamic `import()` calls.
- Rewrote `TestSuiteManager.test.ts` around the new flow: covers lesson submission, project submission, no-context guard, fire-and-forget non-blocking, ApiError toast, NetworkError/Auth/RateLimit silence, and the existing syntax-error paths.

Out of scope (deferred): the hardcoded `filename: "solution.js"` (wrong for non-JS languages) — separate pass.

## Test plan
- [x] `pnpm jest tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts` — 14 passing
- [x] Full app suite — 1621 passing
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm lint` — no new warnings
- [ ] Manual: run a lesson exercise, hit Run, confirm `/internal/lessons/<slug>/exercise_submissions` POST happens
- [ ] Manual: run a project exercise, hit Run, confirm `/internal/projects/<slug>/exercise_submissions` POST happens
- [ ] Manual: simulate a 500 response, confirm a single toast appears (and stays single across repeated runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)