### PR TITLE
Make CodingExercise chat context-aware for projects

### DIFF
--- a/app/app/dev/llm-chat/page.tsx
+++ b/app/app/dev/llm-chat/page.tsx
@@ -195,7 +195,7 @@ export default function LLMChatTestPage() {
       let token = chatToken;
       if (!token) {
         addDebugEvent("request", { type: "fetch_token", lessonSlug: selectedExercise });
-        token = await fetchChatToken({ lessonSlug: selectedExercise });
+        token = await fetchChatToken({ context: { type: "lesson", slug: selectedExercise } });
         setChatToken(token);
         addDebugEvent("response", { type: "token_received" });
       }
@@ -207,7 +207,7 @@ export default function LLMChatTestPage() {
         if (err instanceof ChatTokenExpiredError) {
           addDebugEvent("sse", { type: "token_expired", retrying: true });
           setChatToken(null);
-          const newToken = await fetchChatToken({ lessonSlug: selectedExercise });
+          const newToken = await fetchChatToken({ context: { type: "lesson", slug: selectedExercise } });
           setChatToken(newToken);
           await performRequest(newToken);
         } else {

--- a/app/components/coding-exercise/lib/chatTokenApi.ts
+++ b/app/components/coding-exercise/lib/chatTokenApi.ts
@@ -1,4 +1,5 @@
 import { getApiUrl } from "@/lib/api/config";
+import type { ExerciseContext } from "./types";
 
 export class ChatTokenError extends Error {
   constructor(
@@ -12,7 +13,7 @@ export class ChatTokenError extends Error {
 }
 
 export interface FetchChatTokenParams {
-  lessonSlug: string;
+  context: ExerciseContext;
 }
 
 export interface ChatTokenResponse {
@@ -20,15 +21,16 @@ export interface ChatTokenResponse {
 }
 
 export async function fetchChatToken(params: FetchChatTokenParams): Promise<string> {
+  const { context } = params;
+  const body = context.type === "project" ? { project_slug: context.slug } : { lesson_slug: context.slug };
+
   const response = await fetch(getApiUrl("/internal/assistant_conversations"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json"
     },
     credentials: "include",
-    body: JSON.stringify({
-      lesson_slug: params.lessonSlug
-    })
+    body: JSON.stringify(body)
   });
 
   if (!response.ok) {

--- a/app/components/coding-exercise/lib/conversationApi.ts
+++ b/app/components/coding-exercise/lib/conversationApi.ts
@@ -1,8 +1,9 @@
 import { getApiUrl } from "@/lib/api/config";
 import type { SignatureData } from "./chat-types";
+import type { ExerciseContext } from "./types";
 
 export async function saveConversation(
-  contextSlug: string,
+  context: ExerciseContext,
   userMessage: string,
   assistantMessage: string,
   signature: SignatureData
@@ -14,16 +15,16 @@ export async function saveConversation(
 
     // Save user message
     await saveUserMessage({
-      context_type: "lesson",
-      context_identifier: contextSlug,
+      context_type: context.type,
+      context_identifier: context.slug,
       content: userMessage,
       tokens: userMessageTokens
     });
 
     // Save assistant message with signature
     await saveAssistantMessage({
-      context_type: "lesson",
-      context_identifier: contextSlug,
+      context_type: context.type,
+      context_identifier: context.slug,
       content: assistantMessage,
       tokens: assistantMessageTokens,
       timestamp: signature.timestamp,

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -26,7 +26,7 @@ export function useChat(orchestrator: Orchestrator) {
 
     // Fetch new token
     tokenFetchInProgress.current = fetchChatToken({
-      lessonSlug: context.contextSlug
+      context: context.context
     });
 
     try {
@@ -36,7 +36,7 @@ export function useChat(orchestrator: Orchestrator) {
     } finally {
       tokenFetchInProgress.current = null;
     }
-  }, [chatState, context.contextSlug]);
+  }, [chatState, context.context]);
 
   // Perform the actual chat request with a given token
   const performChatRequest = useCallback(
@@ -68,7 +68,7 @@ export function useChat(orchestrator: Orchestrator) {
 
               if (signature) {
                 chatState.setSignature(signature);
-                void saveConversation(context.contextSlug, message, fullResponse, signature);
+                void saveConversation(context.context, message, fullResponse, signature);
               }
 
               chatState.setStatus("typing");

--- a/app/components/coding-exercise/lib/useChatContext.ts
+++ b/app/components/coding-exercise/lib/useChatContext.ts
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 import type Orchestrator from "./Orchestrator";
+import type { ExerciseContext } from "./types";
 
 export interface ChatContext {
   exerciseSlug: string;
-  contextSlug: string; // The slug used for backend API calls (lessonSlug or projectSlug)
+  context: ExerciseContext; // Lesson/project context used for backend API calls
   exerciseTitle: string;
   exerciseInstructions: string;
   currentTaskId: string | null;
@@ -21,7 +22,7 @@ export function useChatContext(orchestrator: Orchestrator): ChatContext {
 
     return {
       exerciseSlug: exercise.slug,
-      contextSlug: storeState.context.slug,
+      context: storeState.context,
       exerciseTitle: orchestrator.getExerciseTitle(),
       exerciseInstructions: orchestrator.getExerciseInstructions(),
       currentTaskId: storeState.currentTaskId,

--- a/app/components/coding-exercise/lib/useConversationLoader.ts
+++ b/app/components/coding-exercise/lib/useConversationLoader.ts
@@ -36,7 +36,6 @@ export function useConversationLoader(context: ExerciseContext) {
   // Depend on the primitive type/slug rather than the context object, whose
   // identity changes every render and would otherwise re-trigger the effect.
   const { type, slug } = context;
-  const cacheKey = `${type}:${slug}`;
 
   const loadConversation = useCallback(
     async (forceReload = false) => {
@@ -44,6 +43,8 @@ export function useConversationLoader(context: ExerciseContext) {
         setState((prev) => ({ ...prev, isLoading: false }));
         return;
       }
+
+      const cacheKey = `${type}:${slug}`;
 
       // Check cache first unless forcing reload
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -107,7 +108,7 @@ export function useConversationLoader(context: ExerciseContext) {
         });
       }
     },
-    [type, slug, cacheKey]
+    [type, slug]
   );
 
   // Load conversation data on mount - async data fetching pattern

--- a/app/components/coding-exercise/lib/useConversationLoader.ts
+++ b/app/components/coding-exercise/lib/useConversationLoader.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { fetchUserLesson } from "@/lib/api/lessons";
+import { fetchUserProject } from "@/lib/api/projects";
+import { NotFoundError } from "@/lib/api/client";
 import type { ChatMessage } from "./chat-types";
+import type { ExerciseContext } from "./types";
 
 interface CachedData {
   conversation: ChatMessage[];
@@ -14,7 +17,11 @@ export interface ConversationLoaderState {
   error: string | null;
 }
 
-export function useConversationLoader(contextSlug: string) {
+async function fetchConversationData(type: ExerciseContext["type"], slug: string) {
+  return type === "project" ? fetchUserProject(slug) : fetchUserLesson(slug);
+}
+
+export function useConversationLoader(context: ExerciseContext) {
   const [state, setState] = useState<ConversationLoaderState>({
     conversation: [],
     conversationAllowed: true,
@@ -26,17 +33,22 @@ export function useConversationLoader(contextSlug: string) {
   const cacheRef = useRef<Record<string, CachedData>>({});
   const loadedRef = useRef<string | null>(null);
 
+  // Depend on the primitive type/slug rather than the context object, whose
+  // identity changes every render and would otherwise re-trigger the effect.
+  const { type, slug } = context;
+  const cacheKey = `${type}:${slug}`;
+
   const loadConversation = useCallback(
     async (forceReload = false) => {
-      if (!contextSlug) {
+      if (!slug) {
         setState((prev) => ({ ...prev, isLoading: false }));
         return;
       }
 
       // Check cache first unless forcing reload
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (!forceReload && cacheRef.current[contextSlug] && loadedRef.current === contextSlug) {
-        const cached = cacheRef.current[contextSlug];
+      if (!forceReload && cacheRef.current[cacheKey] && loadedRef.current === cacheKey) {
+        const cached = cacheRef.current[cacheKey];
         setState({
           conversation: cached.conversation,
           conversationAllowed: cached.conversationAllowed,
@@ -49,17 +61,18 @@ export function useConversationLoader(contextSlug: string) {
       try {
         setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
-        const userLessonData = await fetchUserLesson(contextSlug);
+        const userContextData = await fetchConversationData(type, slug);
 
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- API response may not match TypeScript types
-        const conversation = userLessonData.conversation || [];
+        const conversation = userContextData.conversation || [];
 
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- API response may not match TypeScript types
-        const conversationAllowed = userLessonData.conversation_allowed ?? true;
+        // Fail-closed: an existing user record with no explicit flag is treated as
+        // not allowed, so the gated UI renders rather than silently permitting chat.
+        const conversationAllowed = Boolean(userContextData.conversation_allowed);
 
         // Cache the result
-        cacheRef.current[contextSlug] = { conversation, conversationAllowed };
-        loadedRef.current = contextSlug;
+        cacheRef.current[cacheKey] = { conversation, conversationAllowed };
+        loadedRef.current = cacheKey;
 
         setState({
           conversation,
@@ -68,22 +81,20 @@ export function useConversationLoader(contextSlug: string) {
           error: null
         });
       } catch (error) {
-        // Handle specific error cases gracefully
-        if (error instanceof Error) {
-          // If user lesson doesn't exist yet, that's okay - start with empty conversation
-          if (error.message.includes("User lesson not found")) {
-            const emptyData: CachedData = { conversation: [], conversationAllowed: true };
-            cacheRef.current[contextSlug] = emptyData;
-            loadedRef.current = contextSlug;
+        // No user record yet - that's okay, start with an empty conversation.
+        // The user hasn't started this context, so they're allowed to begin.
+        if (error instanceof NotFoundError) {
+          const emptyData: CachedData = { conversation: [], conversationAllowed: true };
+          cacheRef.current[cacheKey] = emptyData;
+          loadedRef.current = cacheKey;
 
-            setState({
-              conversation: [],
-              conversationAllowed: true,
-              isLoading: false,
-              error: null
-            });
-            return;
-          }
+          setState({
+            conversation: [],
+            conversationAllowed: true,
+            isLoading: false,
+            error: null
+          });
+          return;
         }
 
         // Other errors should be logged but not break the UI
@@ -96,7 +107,7 @@ export function useConversationLoader(contextSlug: string) {
         });
       }
     },
-    [contextSlug]
+    [type, slug, cacheKey]
   );
 
   // Load conversation data on mount - async data fetching pattern

--- a/app/components/coding-exercise/lib/useMockChat.ts
+++ b/app/components/coding-exercise/lib/useMockChat.ts
@@ -73,7 +73,8 @@ export function useMockChat() {
     isDisabled: false,
     canRetry: false,
     context: {
-      exerciseSlug: "mock-exercise"
+      exerciseSlug: "mock-exercise",
+      context: { type: "lesson" as const, slug: "mock-lesson" }
     }
   };
 }

--- a/app/components/coding-exercise/ui/ChatPanel.tsx
+++ b/app/components/coding-exercise/ui/ChatPanel.tsx
@@ -54,7 +54,7 @@ function ChatPanelContent({ orchestrator }: { orchestrator: Orchestrator }) {
   const mockChat = useMockChat();
   const chat = useMockMode ? mockChat : realChat;
 
-  const conversationLoader = useConversationLoader(chat.context.exerciseSlug);
+  const conversationLoader = useConversationLoader(chat.context.context);
   const hasLoadedConversationRef = useRef(false);
 
   const conversationAllowed = conversationLoader.conversationAllowed;

--- a/app/lib/api/client.ts
+++ b/app/lib/api/client.ts
@@ -31,6 +31,13 @@ export class AuthenticationError extends ApiError {
   }
 }
 
+export class NotFoundError extends ApiError {
+  constructor(statusText: string, data?: unknown) {
+    super(404, statusText, data);
+    this.name = "NotFoundError";
+  }
+}
+
 export class NetworkError extends Error {
   constructor(
     message: string,
@@ -245,6 +252,11 @@ async function executeRequest<T>(url: URL, requestOptions: RequestInit, useRetri
       // Handle 401 Unauthorized - session invalid, needs re-login
       if (response.status === 401) {
         throw new AuthenticationError(response.statusText, data);
+      }
+
+      // Handle 404 Not Found - resource (or user-scoped record) doesn't exist
+      if (response.status === 404) {
+        throw new NotFoundError(response.statusText, data);
       }
 
       throw new ApiError(response.status, response.statusText, data);

--- a/app/lib/api/lessons.ts
+++ b/app/lib/api/lessons.ts
@@ -1,4 +1,4 @@
-import { api, ApiError } from "./client";
+import { api, NotFoundError } from "./client";
 import type { LessonWithData } from "@/types/lesson";
 import type { UserConversationData } from "./types/conversation";
 
@@ -81,7 +81,7 @@ export async function fetchLatestExerciseSubmission(lessonSlug: string): Promise
     );
     return response.data.submission;
   } catch (error) {
-    if (error instanceof ApiError && error.status === 404) {
+    if (error instanceof NotFoundError) {
       return null;
     }
     console.warn("Failed to fetch latest exercise submission:", error);

--- a/app/lib/api/lessons.ts
+++ b/app/lib/api/lessons.ts
@@ -1,16 +1,13 @@
 import { api, ApiError } from "./client";
-import type { ChatMessage } from "@/components/coding-exercise/lib/chat-types";
 import type { LessonWithData } from "@/types/lesson";
+import type { UserConversationData } from "./types/conversation";
 
 export interface LessonResponse {
   lesson: LessonWithData;
 }
 
-export interface UserLessonData {
+export interface UserLessonData extends UserConversationData {
   lesson_slug: string;
-  status: "started" | "completed";
-  conversation: ChatMessage[];
-  conversation_allowed: boolean;
   data: any;
 }
 
@@ -117,28 +114,10 @@ export async function updateWalkthroughVideoPercentage(slug: string, percentage:
 }
 
 /**
- * Fetch user lesson data including conversation history
+ * Fetch user lesson data including conversation history.
+ * Throws NotFoundError if the user lesson (or underlying lesson) doesn't exist.
  */
 export async function fetchUserLesson(slug: string): Promise<UserLessonData> {
-  try {
-    const response = await api.get<UserLessonResponse>(`/internal/user_lessons/${slug}`);
-    return response.data.user_lesson;
-  } catch (error) {
-    // Enhance error messages for better debugging and frontend handling
-    if (error instanceof Error) {
-      // If the API returns a server error (500), check if it's a database schema issue
-      if (error.message.includes("500")) {
-        throw new Error(
-          "Server error occurred while fetching user lesson data. This may be due to a database schema issue."
-        );
-      }
-
-      // If the API returns 404, it's likely the user lesson doesn't exist
-      if (error.message.includes("404")) {
-        throw new Error("User lesson not found");
-      }
-    }
-
-    throw error;
-  }
+  const response = await api.get<UserLessonResponse>(`/internal/user_lessons/${slug}`);
+  return response.data.user_lesson;
 }

--- a/app/lib/api/projects.ts
+++ b/app/lib/api/projects.ts
@@ -1,6 +1,15 @@
 import { api } from "./client";
+import type { UserConversationData } from "./types/conversation";
 
 export type ProjectStatus = "locked" | "unlocked" | "started" | "completed";
+
+export interface UserProjectData extends UserConversationData {
+  project_slug: string;
+}
+
+interface UserProjectResponse {
+  user_project: UserProjectData;
+}
 
 export interface ProjectData {
   slug: string;
@@ -72,4 +81,13 @@ export function startProject(slug: string): void {
 export async function markProjectComplete(slug: string): Promise<{ meta?: { events?: unknown[] } }> {
   const response = await api.patch<{ meta?: { events?: unknown[] } }>(`/internal/user_projects/${slug}/complete`);
   return response.data;
+}
+
+/**
+ * Fetch user project data including conversation history.
+ * Throws NotFoundError if the user project (or underlying project) doesn't exist.
+ */
+export async function fetchUserProject(slug: string): Promise<UserProjectData> {
+  const response = await api.get<UserProjectResponse>(`/internal/user_projects/${slug}`);
+  return response.data.user_project;
 }

--- a/app/lib/api/types/conversation.ts
+++ b/app/lib/api/types/conversation.ts
@@ -1,0 +1,12 @@
+import type { ChatMessage } from "@/components/coding-exercise/lib/chat-types";
+
+/**
+ * Per-user conversation data shared by the user-lesson and user-project
+ * endpoints. Both `/internal/user_lessons/{slug}` and
+ * `/internal/user_projects/{slug}` return this shape.
+ */
+export interface UserConversationData {
+  status: "started" | "completed";
+  conversation: ChatMessage[];
+  conversation_allowed: boolean;
+}

--- a/app/tests/unit/components/coding-exercise/chatTokenApi.test.ts
+++ b/app/tests/unit/components/coding-exercise/chatTokenApi.test.ts
@@ -27,7 +27,7 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ token: mockToken })
       });
 
-      const result = await fetchChatToken({ lessonSlug: "test-exercise" });
+      const result = await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } });
 
       expect(result).toBe(mockToken);
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -47,10 +47,22 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ token: mockToken })
       });
 
-      await fetchChatToken({ lessonSlug: "my-exercise-slug" });
+      await fetchChatToken({ context: { type: "lesson", slug: "my-exercise-slug" } });
 
       const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(requestBody).toEqual({ lesson_slug: "my-exercise-slug" });
+    });
+
+    it("should send project_slug for project context", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ token: mockToken })
+      });
+
+      await fetchChatToken({ context: { type: "project", slug: "my-project-slug" } });
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(requestBody).toEqual({ project_slug: "my-project-slug" });
     });
 
     it("should throw ChatTokenError on 401 errors", async () => {
@@ -62,7 +74,9 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ error: "unauthorized" })
       });
 
-      await expect(fetchChatToken({ lessonSlug: "test-exercise" })).rejects.toThrow(ChatTokenError);
+      await expect(fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } })).rejects.toThrow(
+        ChatTokenError
+      );
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -75,7 +89,9 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ error: "server_error", message: "Database connection failed" })
       });
 
-      await expect(fetchChatToken({ lessonSlug: "test-exercise" })).rejects.toThrow(ChatTokenError);
+      await expect(fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } })).rejects.toThrow(
+        ChatTokenError
+      );
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -90,7 +106,7 @@ describe("chatTokenApi", () => {
       });
 
       try {
-        await fetchChatToken({ lessonSlug: "nonexistent" });
+        await fetchChatToken({ context: { type: "lesson", slug: "nonexistent" } });
         fail("Expected ChatTokenError to be thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);
@@ -111,7 +127,7 @@ describe("chatTokenApi", () => {
       });
 
       try {
-        await fetchChatToken({ lessonSlug: "test-exercise" });
+        await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } });
         fail("Expected ChatTokenError to be thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);
@@ -131,7 +147,7 @@ describe("chatTokenApi", () => {
       });
 
       try {
-        await fetchChatToken({ lessonSlug: "test-exercise" });
+        await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } });
         fail("Expected ChatTokenError to be thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);

--- a/app/tests/unit/components/coding-exercise/useChat-token.test.tsx
+++ b/app/tests/unit/components/coding-exercise/useChat-token.test.tsx
@@ -49,7 +49,7 @@ describe("useChat token management", () => {
     // Set up default mock for useChatContext
     mockUseChatContext.mockReturnValue({
       exerciseSlug: "test-exercise",
-      contextSlug: "test-lesson",
+      context: { type: "lesson", slug: "test-lesson" },
       currentCode: "console.log('test');",
       currentTaskId: "task-1",
       language: "javascript",
@@ -79,7 +79,7 @@ describe("useChat token management", () => {
       });
 
       expect(mockFetchChatToken).toHaveBeenCalledTimes(1);
-      expect(mockFetchChatToken).toHaveBeenCalledWith({ lessonSlug: "test-lesson" });
+      expect(mockFetchChatToken).toHaveBeenCalledWith({ context: { type: "lesson", slug: "test-lesson" } });
       expect(mockSendChatMessage).toHaveBeenCalledTimes(1);
     });
 

--- a/app/tests/unit/components/coding-exercise/useConversationLoader.test.tsx
+++ b/app/tests/unit/components/coding-exercise/useConversationLoader.test.tsx
@@ -1,15 +1,23 @@
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { useConversationLoader } from "@/components/coding-exercise/lib/useConversationLoader";
 import { fetchUserLesson } from "@/lib/api/lessons";
+import { fetchUserProject } from "@/lib/api/projects";
+import { NotFoundError } from "@/lib/api/client";
 import type { ChatMessage } from "@/components/coding-exercise/lib/chat-types";
+import type { ExerciseContext } from "@/components/coding-exercise/lib/types";
 
-// Mock the API
 jest.mock("@/lib/api/lessons");
+jest.mock("@/lib/api/projects");
 const mockFetchUserLesson = fetchUserLesson as jest.MockedFunction<typeof fetchUserLesson>;
+const mockFetchUserProject = fetchUserProject as jest.MockedFunction<typeof fetchUserProject>;
+
+const lessonContext: ExerciseContext = { type: "lesson", slug: "test-exercise" };
+const projectContext: ExerciseContext = { type: "project", slug: "test-project" };
 
 describe("useConversationLoader", () => {
   beforeEach(() => {
     mockFetchUserLesson.mockClear();
+    mockFetchUserProject.mockClear();
     // Clear console.warn to avoid cluttering test output
     jest.spyOn(console, "warn").mockImplementation(() => {});
   });
@@ -32,7 +40,7 @@ describe("useConversationLoader", () => {
       data: {}
     });
 
-    const { result } = renderHook(() => useConversationLoader("test-exercise"));
+    const { result } = renderHook(() => useConversationLoader(lessonContext));
 
     // Initially should be loading
     expect(result.current.isLoading).toBe(true);
@@ -45,27 +53,85 @@ describe("useConversationLoader", () => {
     });
 
     expect(result.current.conversation).toEqual(mockConversation);
+    expect(result.current.conversationAllowed).toBe(true);
     expect(result.current.error).toBeNull();
     expect(mockFetchUserLesson).toHaveBeenCalledWith("test-exercise");
   });
 
-  it("should handle user lesson not found gracefully", async () => {
-    mockFetchUserLesson.mockRejectedValue(new Error("User lesson not found"));
+  it("should load project conversations via fetchUserProject", async () => {
+    const mockConversation: ChatMessage[] = [{ role: "user", content: "Project question" }];
 
-    const { result } = renderHook(() => useConversationLoader("new-exercise"));
+    mockFetchUserProject.mockResolvedValue({
+      project_slug: "test-project",
+      status: "started",
+      conversation: mockConversation,
+      conversation_allowed: true
+    });
+
+    const { result } = renderHook(() => useConversationLoader(projectContext));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.conversation).toEqual(mockConversation);
+    expect(mockFetchUserProject).toHaveBeenCalledWith("test-project");
+    expect(mockFetchUserLesson).not.toHaveBeenCalled();
+  });
+
+  it("should treat NotFoundError as a fresh, empty, allowed conversation", async () => {
+    mockFetchUserLesson.mockRejectedValue(new NotFoundError("Not Found"));
+
+    const { result } = renderHook(() => useConversationLoader({ type: "lesson", slug: "new-exercise" }));
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
 
     expect(result.current.conversation).toEqual([]);
+    expect(result.current.conversationAllowed).toBe(true);
     expect(result.current.error).toBeNull();
+  });
+
+  it("should fail closed when an existing record has conversation_allowed false", async () => {
+    mockFetchUserLesson.mockResolvedValue({
+      lesson_slug: "test-exercise",
+      status: "started",
+      conversation: [],
+      conversation_allowed: false,
+      data: {}
+    });
+
+    const { result } = renderHook(() => useConversationLoader(lessonContext));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.conversationAllowed).toBe(false);
+  });
+
+  it("should fail closed when an existing record omits conversation_allowed", async () => {
+    mockFetchUserLesson.mockResolvedValue({
+      lesson_slug: "test-exercise",
+      status: "started",
+      conversation: []
+      // conversation_allowed intentionally omitted (backend may not emit it yet)
+    } as never);
+
+    const { result } = renderHook(() => useConversationLoader(lessonContext));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.conversationAllowed).toBe(false);
   });
 
   it("should handle API errors", async () => {
     mockFetchUserLesson.mockRejectedValue(new Error("Network error"));
 
-    const { result } = renderHook(() => useConversationLoader("test-exercise"));
+    const { result } = renderHook(() => useConversationLoader(lessonContext));
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -75,8 +141,8 @@ describe("useConversationLoader", () => {
     expect(result.current.error).toBe("Network error");
   });
 
-  it("should handle empty exercise slug", async () => {
-    const { result } = renderHook(() => useConversationLoader(""));
+  it("should handle empty context slug", async () => {
+    const { result } = renderHook(() => useConversationLoader({ type: "lesson", slug: "" }));
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -98,8 +164,9 @@ describe("useConversationLoader", () => {
       data: {}
     });
 
-    const { result, rerender } = renderHook(({ slug }) => useConversationLoader(slug), {
-      initialProps: { slug: "cached-exercise" }
+    const cachedContext: ExerciseContext = { type: "lesson", slug: "cached-exercise" };
+    const { result, rerender } = renderHook(({ context }) => useConversationLoader(context), {
+      initialProps: { context: cachedContext }
     });
 
     // Wait for initial load
@@ -109,15 +176,51 @@ describe("useConversationLoader", () => {
 
     expect(mockFetchUserLesson).toHaveBeenCalledTimes(1);
 
-    // Rerender with same slug
-    rerender({ slug: "cached-exercise" });
+    // Rerender with an equivalent context (same type + slug)
+    rerender({ context: { type: "lesson", slug: "cached-exercise" } });
 
     // Should not call API again
     expect(mockFetchUserLesson).toHaveBeenCalledTimes(1);
     expect(result.current.conversation).toEqual(mockConversation);
   });
 
-  it("should reload when different exercise slug is provided", async () => {
+  it("should keep lesson and project caches separate even with the same slug", async () => {
+    const lessonConversation: ChatMessage[] = [{ role: "user", content: "Lesson message" }];
+    const projectConversation: ChatMessage[] = [{ role: "user", content: "Project message" }];
+
+    mockFetchUserLesson.mockResolvedValue({
+      lesson_slug: "shared-slug",
+      status: "started",
+      conversation: lessonConversation,
+      conversation_allowed: true,
+      data: {}
+    });
+    mockFetchUserProject.mockResolvedValue({
+      project_slug: "shared-slug",
+      status: "started",
+      conversation: projectConversation,
+      conversation_allowed: true
+    });
+
+    const { result, rerender } = renderHook(({ context }) => useConversationLoader(context), {
+      initialProps: { context: { type: "lesson", slug: "shared-slug" } as ExerciseContext }
+    });
+
+    await waitFor(() => {
+      expect(result.current.conversation).toEqual(lessonConversation);
+    });
+
+    rerender({ context: { type: "project", slug: "shared-slug" } as ExerciseContext });
+
+    await waitFor(() => {
+      expect(result.current.conversation).toEqual(projectConversation);
+    });
+
+    expect(mockFetchUserLesson).toHaveBeenCalledTimes(1);
+    expect(mockFetchUserProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reload when a different context slug is provided", async () => {
     const mockConversation1: ChatMessage[] = [{ role: "user", content: "Exercise 1 message" }];
     const mockConversation2: ChatMessage[] = [{ role: "user", content: "Exercise 2 message" }];
 
@@ -137,8 +240,8 @@ describe("useConversationLoader", () => {
         data: {}
       });
 
-    const { result, rerender } = renderHook(({ slug }) => useConversationLoader(slug), {
-      initialProps: { slug: "exercise-1" }
+    const { result, rerender } = renderHook(({ context }) => useConversationLoader(context), {
+      initialProps: { context: { type: "lesson", slug: "exercise-1" } as ExerciseContext }
     });
 
     // Wait for first load
@@ -149,7 +252,7 @@ describe("useConversationLoader", () => {
     expect(result.current.conversation).toEqual(mockConversation1);
 
     // Change to different exercise
-    rerender({ slug: "exercise-2" });
+    rerender({ context: { type: "lesson", slug: "exercise-2" } as ExerciseContext });
 
     // Should load again
     await waitFor(() => {
@@ -168,7 +271,7 @@ describe("useConversationLoader", () => {
       data: {}
     });
 
-    const { result } = renderHook(() => useConversationLoader("retry-exercise"));
+    const { result } = renderHook(() => useConversationLoader({ type: "lesson", slug: "retry-exercise" }));
 
     // Wait for initial error
     await waitFor(() => {


### PR DESCRIPTION
## Summary

`CodingExercise` is shared between `/lesson/[slug]` and `/projects/[slug]`, and the `Orchestrator` already carries a discriminated `ExerciseContext` (`lesson` | `project`). The chat sub-system didn't respect it — every chat API call was hardcoded to the lesson endpoint/field names, so chat never worked when `CodingExercise` was rendered under a project.

This threads the full `ExerciseContext` through the chat layer and dispatches on `context.type`.

- **`fetchUserProject`** added (`GET /internal/user_projects/{slug}`), plus a typed **`NotFoundError`** thrown by the API client on any 404 — replaces brittle error-message string matching.
- **`useConversationLoader`** now takes `ExerciseContext`, dispatches to `fetchUserLesson`/`fetchUserProject`, caches by `type:slug`, and branches on `NotFoundError`. It also **fails closed** on `conversation_allowed`: an existing user record with a missing/false flag is now treated as `false` (previously `?? true` silently allowed chat, so free-user limit enforcement never fired). A `NotFound` (no record yet) still defaults to allowed so users can start fresh.
- **`fetchChatToken`** sends `lesson_slug` or `project_slug` based on context.
- **`saveConversation`** sends `context_type` from the context instead of hardcoded `"lesson"`.
- **`ChatPanel`** now passes the lesson/project context to `useConversationLoader` instead of the exercise slug (pre-existing latent bug — the two keys differ for lessons whose slug ≠ exercise slug).
- Shared `UserConversationData` type extracted; `useChatContext` exposes the full `context`.

### Backend dependency

With fail-closed behaviour, the `UserLesson` / `UserProject` serializers **must** emit `conversation_allowed` — an omitted field now renders the gated chat UI. Backend support for `project_slug` / `context_type: "project"` / `GET /internal/user_projects/{slug}` is already in place.

## Test plan

- [x] `pnpm typecheck` clean
- [x] Full app suite green (1626 tests) — `chatTokenApi`, `useConversationLoader`, `useChat-token` updated with project variants + fail-closed coverage
- [ ] Manual: lesson chat regression (token body `lesson_slug`, `context_type: "lesson"`, conversation reloads)
- [ ] Manual: project chat (`GET /internal/user_projects/{slug}` 200, token body `project_slug`, `context_type: "project"`, conversation reloads)
- [ ] Manual: lesson where lesson-slug ≠ exercise-slug loads conversation correctly
- [ ] Manual: `conversation_allowed: false` renders the gated states on both lesson and project

🤖 Generated with [Claude Code](https://claude.com/claude-code)