### PR TITLE
Show premium tick on Projects nav item for premium users

### DIFF
--- a/app/app/styles/components/navigation.css
+++ b/app/app/styles/components/navigation.css
@@ -81,6 +81,15 @@
         white-space: nowrap;
         opacity: 1;
         pointer-events: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .premium-pill-tick {
+        width: 10px;
+        height: 10px;
+        stroke-width: 3;
     }
 
     .nav-icon {

--- a/app/components/dashboard/projects-sidebar/projects-sidebar.module.css
+++ b/app/components/dashboard/projects-sidebar/projects-sidebar.module.css
@@ -91,11 +91,6 @@
     object-fit: contain;
 }
 
-.statCardEmoji img {
-    filter: brightness(0) saturate(100%) invert(47%) sepia(72%) saturate(1846%) hue-rotate(201deg) brightness(99%)
-        contrast(95%);
-}
-
 /* Project Card Title */
 .statCardTitle {
     font-size: 15px;

--- a/app/components/layout/sidebar/NavigationItem.tsx
+++ b/app/components/layout/sidebar/NavigationItem.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/navigation";
 import type { ComponentType } from "react";
+import TickCircleIcon from "@/icons/tick-circle.svg";
 
 interface NavigationItemProps {
   id: string;
@@ -8,9 +9,17 @@ interface NavigationItemProps {
   href?: string;
   icon?: ComponentType<{ className?: string }>;
   showPremiumPill?: boolean;
+  isUserPremium?: boolean;
 }
 
-export function NavigationItem({ label, isActive, href, icon: Icon, showPremiumPill }: NavigationItemProps) {
+export function NavigationItem({
+  label,
+  isActive,
+  href,
+  icon: Icon,
+  showPremiumPill,
+  isUserPremium
+}: NavigationItemProps) {
   const router = useRouter();
 
   const handleClick = (e: React.MouseEvent) => {
@@ -29,7 +38,12 @@ export function NavigationItem({ label, isActive, href, icon: Icon, showPremiumP
           </span>
         )}
         <span>{label}</span>
-        {showPremiumPill && <span className="premium-pill">Premium</span>}
+        {showPremiumPill && (
+          <span className="premium-pill">
+            Premium
+            {isUserPremium && <TickCircleIcon className="premium-pill-tick" />}
+          </span>
+        )}
       </a>
     </li>
   );

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -66,6 +66,7 @@ export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
               href={item.href}
               icon={item.icon}
               showPremiumPill={item.showPremiumPill}
+              isUserPremium={Boolean(isPremium)}
             />
           ))}
           <MoreMenu isActive={activeItem === "more"} />


### PR DESCRIPTION
## Summary
- Add a tick icon after the "Premium" pill label on the Projects sidebar nav item when the user is a premium member
- Remove the colour filter from the projects sidebar stat card emoji images

## Test plan
- [ ] As a premium user, the Projects nav item shows a tick after "Premium"
- [ ] As a free user, the Projects nav item shows the "Premium" pill with no tick
- [ ] Projects sidebar stat card emojis render without the blue colour filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)