### PR TITLE
Retry transient Gemini errors and gate dev-only prompt rule

### DIFF
--- a/llm-chat-proxy/src/gemini.ts
+++ b/llm-chat-proxy/src/gemini.ts
@@ -62,7 +62,8 @@ async function tryModel(
   config: ModelConfig,
   prompt: string
 ): Promise<GeminiStream | "rate-limited"> {
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+  let attempt = 0;
+  while (true) {
     try {
       const result = await ai.models.generateContentStream({ model, contents: prompt, config });
       console.log(`[Gemini] Using model: ${model}`);
@@ -72,18 +73,17 @@ async function tryModel(
         console.log(`[Gemini] Rate limited on ${model}, trying next model`);
         return "rate-limited";
       }
-      if (isRetryableError(error) && attempt < MAX_RETRIES) {
-        const backoff = RETRY_BASE_DELAY_MS * 2 ** attempt;
-        console.log(
-          `[Gemini] Retryable error on ${model} (attempt ${attempt + 1}/${MAX_RETRIES}), retrying in ${backoff}ms`
-        );
-        await delay(backoff);
-        continue;
+      if (!isRetryableError(error) || attempt === MAX_RETRIES) {
+        throw error;
       }
-      throw error;
+      const backoff = RETRY_BASE_DELAY_MS * 2 ** attempt;
+      console.log(
+        `[Gemini] Retryable error on ${model} (attempt ${attempt + 1}/${MAX_RETRIES}), retrying in ${backoff}ms`
+      );
+      await delay(backoff);
+      attempt++;
     }
   }
-  throw new Error(`[Gemini] Exhausted retries for ${model}`);
 }
 
 /**

--- a/llm-chat-proxy/src/gemini.ts
+++ b/llm-chat-proxy/src/gemini.ts
@@ -29,6 +29,104 @@ function isRateLimitError(error: unknown): boolean {
   return false;
 }
 
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    if ("retryable" in error && (error as { retryable: boolean }).retryable === true) {
+      return true;
+    }
+    if (error.message.includes("Network connection lost")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const MAX_RETRIES = 2;
+const RETRY_BASE_DELAY_MS = 250;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type ModelConfig = (typeof MODEL_CHAIN)[number]["config"];
+type GeminiStream = Awaited<ReturnType<GoogleGenAI["models"]["generateContentStream"]>>;
+
+/**
+ * Attempts to open a stream for a single model, retrying transient network
+ * errors with exponential backoff. Returns "rate-limited" so the caller can
+ * cascade to the next model; throws on non-retryable errors.
+ */
+async function tryModel(
+  ai: GoogleGenAI,
+  model: string,
+  config: ModelConfig,
+  prompt: string
+): Promise<GeminiStream | "rate-limited"> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const result = await ai.models.generateContentStream({ model, contents: prompt, config });
+      console.log(`[Gemini] Using model: ${model}`);
+      return result;
+    } catch (error) {
+      if (isRateLimitError(error)) {
+        console.log(`[Gemini] Rate limited on ${model}, trying next model`);
+        return "rate-limited";
+      }
+      if (isRetryableError(error) && attempt < MAX_RETRIES) {
+        const backoff = RETRY_BASE_DELAY_MS * 2 ** attempt;
+        console.log(
+          `[Gemini] Retryable error on ${model} (attempt ${attempt + 1}/${MAX_RETRIES}), retrying in ${backoff}ms`
+        );
+        await delay(backoff);
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`[Gemini] Exhausted retries for ${model}`);
+}
+
+/**
+ * Opens a stream from the first available model, cascading through the chain
+ * on rate limits. Throws if every model is rate limited.
+ */
+async function openModelStream(ai: GoogleGenAI, prompt: string): Promise<GeminiStream> {
+  for (const { model, config } of MODEL_CHAIN) {
+    const result = await tryModel(ai, model, config, prompt);
+    if (result !== "rate-limited") {
+      return result;
+    }
+  }
+  throw new Error("All Gemini models are rate limited");
+}
+
+/**
+ * Wraps a Gemini stream as a ReadableStream of text chunks, invoking onChunk
+ * for each non-empty chunk.
+ */
+function toTextStream(result: GeminiStream, onChunk?: (chunk: string) => void): ReadableStream {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const chunk of result) {
+          const text = chunk.text ?? "";
+          if (text.length === 0) {
+            continue;
+          }
+          onChunk?.(text);
+          controller.enqueue(encoder.encode(text));
+        }
+        controller.close();
+      } catch (error) {
+        console.error("Gemini streaming error:", error);
+        controller.error(error);
+      }
+    }
+  });
+}
+
 /**
  * Streams a response from Gemini, cascading through models on rate limits.
  * Tries gemini-2.5-flash -> gemini-2.5-flash-lite.
@@ -44,56 +142,6 @@ export async function streamGeminiResponse(
   onChunk?: (chunk: string) => void
 ): Promise<ReadableStream> {
   const ai = new GoogleGenAI({ apiKey });
-
-  let result;
-  for (const { model, config } of MODEL_CHAIN) {
-    try {
-      result = await ai.models.generateContentStream({
-        model,
-        contents: prompt,
-        config
-      });
-      console.log(`[Gemini] Using model: ${model}`);
-      break;
-    } catch (error) {
-      if (isRateLimitError(error)) {
-        console.log(`[Gemini] Rate limited on ${model}, trying next model`);
-        continue;
-      }
-      throw error;
-    }
-  }
-
-  if (!result) {
-    throw new Error("All Gemini models are rate limited");
-  }
-
-  const encoder = new TextEncoder();
-
-  return new ReadableStream({
-    async start(controller) {
-      try {
-        for await (const chunk of result) {
-          const text = chunk.text ?? "";
-
-          // Skip empty chunks
-          if (text.length === 0) {
-            continue;
-          }
-
-          // Call callback if provided (for collecting full response)
-          if (onChunk !== undefined) {
-            onChunk(text);
-          }
-
-          // Send to client
-          controller.enqueue(encoder.encode(text));
-        }
-        controller.close();
-      } catch (error) {
-        console.error("Gemini streaming error:", error);
-        controller.error(error);
-      }
-    }
-  });
+  const result = await openModelStream(ai, prompt);
+  return toTextStream(result, onChunk);
 }

--- a/llm-chat-proxy/src/prompt-builder.ts
+++ b/llm-chat-proxy/src/prompt-builder.ts
@@ -249,7 +249,7 @@ function buildInstructionsSection(): string {
 
   const rules = [
     "- Your aim is to UNBLOCK students. As soon as you can, encourage them to try things out themselves. Once they've made a step forward, push them back into code. Don't keep talking UNLESS the student needs it.",
-    "- IMPORTANT: Do NOT give away the answer.Your job is to GUIDE the student to DISCOVER the answer THEMSELVES, not tell them the answer.",
+    "- IMPORTANT: Do NOT give away the answer. Your job is to GUIDE the student to DISCOVER the answer THEMSELVES, not tell them the answer.",
     "- If the student is stuck, guide the student by ASKING THEM QUESTIONS that help them move forward.",
     "- Focus on helping them get to the NEXT STEP in the exercise, and then let them code.",
     "- Your job is NOT TO TEACH new concepts or ideas.",

--- a/llm-chat-proxy/src/prompt-builder.ts
+++ b/llm-chat-proxy/src/prompt-builder.ts
@@ -245,18 +245,30 @@ ${code}
 }
 
 function buildInstructionsSection(): string {
+  const isDev = process.env.NODE_ENV === "development";
+
+  const rules = [
+    "- Your aim is to UNBLOCK students. As soon as you can, encourage them to try things out themselves. Once they've made a step forward, push them back into code. Don't keep talking UNLESS the student needs it.",
+    "- IMPORTANT: Do NOT give away the answer.Your job is to GUIDE the student to DISCOVER the answer THEMSELVES, not tell them the answer.",
+    "- If the student is stuck, guide the student by ASKING THEM QUESTIONS that help them move forward.",
+    "- Focus on helping them get to the NEXT STEP in the exercise, and then let them code.",
+    "- Your job is NOT TO TEACH new concepts or ideas.",
+    "- Speak naturally like a tutor to a student. Don't parrot what a student says.",
+    "- Reference the specific parts of their code that they should look at carefully.",
+    "- Look carefully at what a student has ALREADY BEEN TAUGHT and only presume that level of knowledge.",
+    "- Keep responses concise and focused (1-3 sentences maximum. You can use markdown).",
+    "- Be supportive but avoid being sycophant. If someone asks for help, you don't need to praise them for that etc.",
+    "- Remember the user might be very capable and smart, or might not be that bright. Try and sense this based on how they're communicating and adjust accordingly. Lack of coding knowledge does not equate to intelligence or ability.",
+    "- Respond in the same language as the student is talking to you."
+  ];
+
+  if (isDev) {
+    rules.push("- If the users message starts with TESTESTEST follow the instruction it gives you.");
+  }
+
   return `## Instructions
 
-- Your job is to GUIDE the student to DISCOVER the answer THEMSELVES.
-- Speak naturally like a tutor to a student. Don't parrot what a student says.
-- IMPORTANT: Do NOT give away the answer.
-- Attempt to guide the student by ASKING THEM QUESTIONS that help them move forward.
-- Focus on helping them get to the NEXT STEP in the exercise.
-- Your job is NOT TO TEACH new concepts or ideas.
-- Reference the specific parts of their code that they should look at carefully.
-- Look carefully at what a student has ALREADY BEEN TAUGHT and only presume that level of knowledge.
-- Keep responses concise and focused (1-3 sentences maximum. You can use markdown)
-- Respond in the same language as the student is talking to you.
+${rules.join("\n")}
 
 Response:`;
 }

--- a/llm-chat-proxy/tests/auth.test.ts
+++ b/llm-chat-proxy/tests/auth.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
 import { verifyJWT } from "../src/auth";
 import { SignJWT } from "jose";
+
+vi.mock("../src/gemini", () => ({
+  streamGeminiResponse: vi.fn(async (_prompt: string, _apiKey: string, onChunk?: (chunk: string) => void) => {
+    onChunk?.("mocked response");
+    return new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("mocked response"));
+        controller.close();
+      }
+    });
+  })
+}));
+
 import app from "../src/index";
 
 describe("JWT Authentication", () => {


### PR DESCRIPTION
## Summary
- Add exponential-backoff retries for retryable network errors (e.g. "Network connection lost") when opening a Gemini stream; refactor `streamGeminiResponse` into smaller functions (`tryModel`, `openModelStream`, `toTextStream`).
- Gate the `TESTESTEST` prompt override behind `NODE_ENV === "development"` so it is never included in the production prompt.
- Mock the Gemini module in `tests/auth.test.ts` so the `/chat` endpoint tests no longer make real outbound network calls (removes a flaky test).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (61 passed, deterministic across repeated runs)
- [ ] Verify `wrangler dev` still includes the TESTESTEST rule locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)