### PR TITLE
Add /roadmap page with timeline and changelog

### DIFF
--- a/app/app/(hybrid)/roadmap/page.tsx
+++ b/app/app/(hybrid)/roadmap/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { RoadmapPage } from "@/components/roadmap/RoadmapPage";
+
+export const metadata: Metadata = {
+  title: "Roadmap - Jiki",
+  description:
+    "What we're building next on Jiki. A quarter-by-quarter look at upcoming courses, projects, and features."
+};
+
+export default function Page() {
+  return <RoadmapPage />;
+}

--- a/app/components/layout/ExternalFooter.tsx
+++ b/app/components/layout/ExternalFooter.tsx
@@ -20,6 +20,9 @@ export function ExternalFooter() {
             <Link href="/premium" className={styles.link}>
               Jiki Premium
             </Link>
+            <Link href="/roadmap" className={styles.link}>
+              Roadmap
+            </Link>
           </div>
         </div>
         <div className={styles.section}>

--- a/app/components/roadmap/RoadmapPage.module.css
+++ b/app/components/roadmap/RoadmapPage.module.css
@@ -100,7 +100,7 @@
     display: block;
     position: absolute;
     top: 50%;
-    left: -38px;
+    left: -44px;
     width: 14px;
     height: 14px;
     background: white;
@@ -353,20 +353,33 @@
         font-size: 38px;
     }
 
+    .subheading {
+        font-size: 17px;
+    }
+
     .main-content {
-        padding: 10px 20px 40px;
+        padding: 10px 24px 40px;
     }
 
     .timeline::before {
-        left: 14px;
+        display: none;
     }
 
     .phase {
-        padding-left: 42px;
+        padding-left: 0;
+        margin-bottom: 40px;
+    }
+
+    .phase-band {
+        margin-left: 4px;
     }
 
     .phase-band::before {
-        left: -30px;
+        display: none;
+    }
+
+    .item-list {
+        gap: 12px;
     }
 
     .item {
@@ -374,7 +387,7 @@
     }
 
     .changelog-inner {
-        padding: 0 20px;
+        padding: 0 24px;
     }
 
     .changelog-item {

--- a/app/components/roadmap/RoadmapPage.module.css
+++ b/app/components/roadmap/RoadmapPage.module.css
@@ -1,0 +1,384 @@
+/* Roadmap page */
+
+.page-header {
+    position: relative;
+    z-index: 1;
+    padding: 56px 0 30px;
+    text-align: center;
+}
+
+.page-wrapper {
+    position: relative;
+    isolation: isolate;
+
+    &::before {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        z-index: -1;
+        height: 520px;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cg opacity='0.4'%3E%3Cline x1='14' y1='0' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3Cline x1='0' y1='14' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3C/g%3E%3C/svg%3E");
+        -webkit-mask-image: linear-gradient(to bottom, black 0%, black 65%, transparent 100%);
+        mask-image: linear-gradient(to bottom, black 0%, black 65%, transparent 100%);
+        pointer-events: none;
+        content: "";
+    }
+}
+
+.heading {
+    margin-bottom: 16px;
+    font-size: 52px;
+    font-weight: 700;
+    line-height: 1.15;
+    color: var(--color-gray-900);
+}
+
+.subheading {
+    max-width: 650px;
+    margin: 0 auto;
+    font-size: 20px;
+    line-height: 1.6;
+    color: var(--color-gray-500);
+}
+
+.main-content {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 10px 40px 60px;
+}
+
+/* Timeline spine */
+
+.timeline {
+    position: relative;
+    margin: 30px 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.timeline::before {
+    display: block;
+    position: absolute;
+    top: 12px;
+    bottom: 12px;
+    left: 22px;
+    width: 2px;
+    background: linear-gradient(
+        to bottom,
+        var(--color-purple-200) 0%,
+        var(--color-purple-200) 70%,
+        var(--color-gray-200) 100%
+    );
+    content: "";
+}
+
+.phase {
+    position: relative;
+    padding-left: 60px;
+    margin-bottom: 48px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.phase-band {
+    display: inline-flex;
+    position: relative;
+    align-items: baseline;
+    gap: 14px;
+    margin-bottom: 10px;
+    padding: 10px 24px;
+    background: var(--color-purple-700);
+    border-radius: 999px;
+    box-shadow: 0 4px 16px var(--color-purple-500-30, rgb(0 0 0 / 8%));
+}
+
+.phase-band::before {
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: -38px;
+    width: 14px;
+    height: 14px;
+    background: white;
+    border: 3px solid var(--color-purple-700);
+    border-radius: 50%;
+    transform: translateY(-50%);
+    content: "";
+}
+
+.phase-label {
+    font-size: 18px;
+    font-weight: 700;
+    color: white;
+}
+
+.phase-timeframe {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--color-purple-200);
+}
+
+.phase-summary {
+    margin: 0 0 18px;
+    font-size: 16px;
+    line-height: 1.5;
+    color: var(--color-gray-500);
+}
+
+/* Items */
+
+.item-list {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.item {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 18px 24px;
+    background: white;
+    border: 1.5px solid var(--color-gray-200);
+    border-radius: 20px;
+    box-shadow: 0 4px 16px var(--color-gray-500-10);
+    transition:
+        box-shadow 0.2s ease,
+        transform 0.2s ease;
+}
+
+.item:hover {
+    box-shadow: 0 6px 24px var(--color-gray-500-10);
+    transform: translateY(-1px);
+}
+
+.dot {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    margin-top: 6px;
+    border-radius: 50%;
+}
+
+.dot[data-status="shipped"] {
+    background: var(--color-green-500);
+    box-shadow: 0 0 0 4px var(--color-green-100);
+}
+
+.dot[data-status="in-progress"] {
+    background: var(--color-purple-500);
+    box-shadow: 0 0 0 4px var(--color-purple-100);
+}
+
+.dot[data-status="planned"] {
+    background: var(--color-gray-300);
+    box-shadow: 0 0 0 4px var(--color-gray-100);
+}
+
+.item-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.item-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 4px;
+    flex-wrap: wrap;
+}
+
+.item-title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--color-gray-900);
+}
+
+.item-desc {
+    margin: 0;
+    font-size: 16px;
+    line-height: 1.5;
+    color: var(--color-gray-500);
+}
+
+.badge {
+    display: inline-block;
+    padding: 3px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-radius: 999px;
+}
+
+.badge[data-status="shipped"] {
+    color: var(--color-green-700);
+    background: var(--color-green-100);
+}
+
+.badge[data-status="in-progress"] {
+    color: var(--color-purple-700);
+    background: var(--color-purple-100);
+}
+
+.badge[data-status="planned"] {
+    color: var(--color-gray-700);
+    background: var(--color-gray-100);
+}
+
+.disclaimer {
+    max-width: 720px;
+    margin: 48px auto 0;
+    padding: 18px 24px;
+    font-size: 15px;
+    line-height: 1.6;
+    text-align: center;
+    color: var(--color-gray-500);
+    background: var(--color-gray-50);
+    border: 1px dashed var(--color-gray-200);
+    border-radius: 12px;
+}
+
+/* Changelog */
+
+.changelog-wrapper {
+    position: relative;
+    isolation: isolate;
+    padding: 60px 0 80px;
+
+    &::before {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        z-index: -1;
+        height: 100%;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cg opacity='0.4'%3E%3Cline x1='14' y1='0' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3Cline x1='0' y1='14' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3C/g%3E%3C/svg%3E");
+        -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 20%, black 80%, transparent 100%);
+        mask-image: linear-gradient(to bottom, transparent 0%, black 20%, black 80%, transparent 100%);
+        pointer-events: none;
+        content: "";
+    }
+}
+
+.changelog-inner {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 40px;
+}
+
+.changelog-header {
+    margin-bottom: 24px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--color-gray-200);
+}
+
+.changelog-title {
+    margin: 0 0 6px;
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--color-gray-900);
+}
+
+.changelog-subtitle {
+    margin: 0;
+    font-size: 16px;
+    color: var(--color-gray-500);
+}
+
+.changelog-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.changelog-item {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    gap: 24px;
+    padding: 18px 0;
+    border-bottom: 1px solid var(--color-gray-100);
+
+    &:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+    }
+
+    &:first-child {
+        padding-top: 0;
+    }
+}
+
+.changelog-date {
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-gray-500);
+    padding-top: 2px;
+}
+
+.changelog-body {
+    min-width: 0;
+}
+
+.changelog-item-title {
+    margin: 0 0 4px;
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--color-gray-900);
+}
+
+.changelog-desc {
+    margin: 0;
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--color-gray-500);
+}
+
+/* Mobile */
+
+@media (width <= 640px) {
+    .heading {
+        font-size: 38px;
+    }
+
+    .main-content {
+        padding: 10px 20px 40px;
+    }
+
+    .timeline::before {
+        left: 14px;
+    }
+
+    .phase {
+        padding-left: 42px;
+    }
+
+    .phase-band::before {
+        left: -30px;
+    }
+
+    .item {
+        padding: 16px 18px;
+    }
+
+    .changelog-inner {
+        padding: 0 20px;
+    }
+
+    .changelog-item {
+        grid-template-columns: 1fr;
+        gap: 4px;
+    }
+}

--- a/app/components/roadmap/RoadmapPage.tsx
+++ b/app/components/roadmap/RoadmapPage.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import HeaderLayout from "../layout/HeaderLayout";
+import styles from "./RoadmapPage.module.css";
+import {
+  changelog,
+  phases,
+  type ChangelogEntry,
+  type ItemStatus,
+  type RoadmapItem,
+  type RoadmapPhase
+} from "./roadmap.data";
+
+const statusLabels: Record<ItemStatus, string> = {
+  shipped: "Shipped",
+  "in-progress": "In progress",
+  planned: "Planned"
+};
+
+export function RoadmapPage() {
+  return (
+    <HeaderLayout>
+      <div className={styles["page-wrapper"]}>
+        <header className={styles["page-header"]}>
+          <h1 className={styles.heading}>Roadmap</h1>
+          <p className={styles.subheading}>
+            Where Jiki is heading. A quarter-by-quarter view of what we&apos;re shipping, what&apos;s next, and what
+            we&apos;re still dreaming up.
+          </p>
+        </header>
+
+        <div className={styles["main-content"]}>
+          <ol className={styles.timeline}>
+            {phases.map((phase) => (
+              <PhaseBlock key={phase.label} phase={phase} />
+            ))}
+          </ol>
+
+          <p className={styles.disclaimer}>
+            This roadmap is a snapshot of our current plans. Priorities shift as we learn from our community, so dates
+            and scope may change.
+          </p>
+        </div>
+      </div>
+
+      <div className={styles["changelog-wrapper"]}>
+        <div className={styles["changelog-inner"]}>
+          <section aria-labelledby="changelog-heading">
+            <header className={styles["changelog-header"]}>
+              <h2 id="changelog-heading" className={styles["changelog-title"]}>
+                Changelog
+              </h2>
+              <p className={styles["changelog-subtitle"]}>Recent improvements we&apos;ve shipped to Jiki.</p>
+            </header>
+            <ul className={styles["changelog-list"]}>
+              {changelog.map((entry, i) => (
+                <ChangelogRow key={i} entry={entry} />
+              ))}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </HeaderLayout>
+  );
+}
+
+function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
+  return (
+    <li className={styles["changelog-item"]}>
+      <span className={styles["changelog-date"]}>{entry.date}</span>
+      <div className={styles["changelog-body"]}>
+        <h3 className={styles["changelog-item-title"]}>{entry.title}</h3>
+        <p className={styles["changelog-desc"]}>{entry.description}</p>
+      </div>
+    </li>
+  );
+}
+
+function PhaseBlock({ phase }: { phase: RoadmapPhase }) {
+  return (
+    <li className={styles.phase}>
+      <div className={styles["phase-band"]}>
+        <span className={styles["phase-label"]}>{phase.label}</span>
+        <span className={styles["phase-timeframe"]}>{phase.timeframe}</span>
+      </div>
+      {phase.summary && <p className={styles["phase-summary"]}>{phase.summary}</p>}
+      <ul className={styles["item-list"]}>
+        {phase.items.map((item) => (
+          <ItemCard key={item.title} item={item} />
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+function ItemCard({ item }: { item: RoadmapItem }) {
+  return (
+    <li className={styles.item}>
+      <span className={styles.dot} data-status={item.status} aria-hidden="true" />
+      <div className={styles["item-body"]}>
+        <div className={styles["item-head"]}>
+          <h3 className={styles["item-title"]}>{item.title}</h3>
+          <span className={styles.badge} data-status={item.status}>
+            {statusLabels[item.status]}
+          </span>
+        </div>
+        <p className={styles["item-desc"]}>{item.description}</p>
+      </div>
+    </li>
+  );
+}

--- a/app/components/roadmap/roadmap.data.ts
+++ b/app/components/roadmap/roadmap.data.ts
@@ -1,0 +1,117 @@
+export type ItemStatus = "shipped" | "in-progress" | "planned";
+
+export interface RoadmapItem {
+  title: string;
+  description: string;
+  status: ItemStatus;
+}
+
+export interface RoadmapPhase {
+  label: string;
+  timeframe: string;
+  summary?: string;
+  items: RoadmapItem[];
+}
+
+export interface ChangelogEntry {
+  date: string;
+  title: string;
+  description: string;
+}
+
+export const changelog: ChangelogEntry[] = [
+  {
+    date: "May 2026",
+    title: "Premium tick on Projects nav",
+    description: "Premium learners now see a badge on the Projects nav item, signalling their access at a glance."
+  },
+  {
+    date: "May 2026",
+    title: "Project page aligned with lesson flow",
+    description: "Project pages now match the polished loading and submission experience of the lesson player."
+  },
+  {
+    date: "May 2026",
+    title: "Context-aware chat for projects",
+    description: "The CodingExercise chat now understands which project you're on, giving more relevant guidance."
+  },
+  {
+    date: "April 2026",
+    title: "Surface lesson submission errors",
+    description: "Errors from the lesson submission API are now shown directly in the UI instead of failing silently."
+  },
+  {
+    date: "April 2026",
+    title: "Faster project page load",
+    description: "Project pages now match the lesson loading flow, with skeleton states and parallel data fetching."
+  }
+];
+
+export const phases: RoadmapPhase[] = [
+  {
+    label: "Now",
+    timeframe: "Q2 2026",
+    summary: "What we're actively building right now.",
+    items: [
+      {
+        title: "Project-based learning flow",
+        description: "Full project pages with context-aware AI chat, lesson-style submission, and progress tracking.",
+        status: "in-progress"
+      },
+      {
+        title: "Premium tier rollout",
+        description: "Unlimited AI support, full course library, and the new project library for Premium users.",
+        status: "in-progress"
+      },
+      {
+        title: "JikiScript exercises expansion",
+        description: "Doubling the number of exercises in the foundational JikiScript course.",
+        status: "shipped"
+      }
+    ]
+  },
+  {
+    label: "Next",
+    timeframe: "Q3 2026",
+    summary: "Designed and queued up.",
+    items: [
+      {
+        title: "Python course (beta)",
+        description: "First fully-fledged Python track, mirroring the JavaScript curriculum's depth.",
+        status: "planned"
+      },
+      {
+        title: "Achievements and streaks",
+        description: "Daily streaks, badges, and shareable milestones to keep learners coming back.",
+        status: "planned"
+      },
+      {
+        title: "Mobile-first lesson player",
+        description: "A redesigned exercise UI that works well on phones and tablets.",
+        status: "planned"
+      }
+    ]
+  },
+  {
+    label: "Later",
+    timeframe: "Q4 2026 +",
+    summary: "On the horizon. Subject to change as we learn.",
+    items: [
+      {
+        title: "Community projects",
+        description: "Let learners share their solutions, fork others' work, and get peer feedback.",
+        status: "planned"
+      },
+      {
+        title: "Classroom mode",
+        description: "Tools for teachers to assign exercises, monitor progress, and review submissions.",
+        status: "planned"
+      },
+      {
+        title: "Native desktop app",
+        description: "An offline-capable desktop client for learners with patchy internet.",
+        status: "planned"
+      }
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- Adds a new public `/roadmap` route with a vertical timeline grouped into Now/Next/Later phases, each item carrying a Shipped/In progress/Planned status.
- Appends a "Changelog" section below the timeline (visually disconnected, with its own faded diagonal-line backdrop) listing recently shipped improvements.
- Adds a "Roadmap" link to the About column of the external footer.

Phase data and changelog entries live in `components/roadmap/roadmap.data.ts` — easy to edit without touching markup.

## Test plan
- [ ] Visit `/roadmap` while logged out and confirm the external header/footer render around the page.
- [ ] Visit `/roadmap` while logged in and confirm the internal header renders.
- [ ] Resize to ≤640px and confirm the timeline rail/changelog rows collapse cleanly.
- [ ] Click the new "Roadmap" link in the footer from any external page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)