### PR TITLE
Parallelize dashboard sidebar fetches and pad with completed projects

### DIFF
--- a/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
+++ b/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
@@ -47,41 +47,28 @@ function ProjectsSidebar({ onProjectClick, onViewAllProjectsClick, onUpgradeClic
   }, [user, profileData]);
 
   useEffect(() => {
-    async function loadData() {
-      try {
-        setProfileLoading(true);
-        const profileResponse = await fetchProfile();
-        setProfileData(profileResponse.profile);
-      } catch (error) {
-        console.error("Failed to load profile:", error);
-      } finally {
-        setProfileLoading(false);
-      }
-
-      if (isPremium) {
-        try {
-          setProjectsLoading(true);
-          const projectResponse = await fetchProjects({ per: 100 });
-          setProjects(projectResponse.results);
-        } catch (error) {
-          console.error("Failed to load projects:", error);
-        } finally {
-          setProjectsLoading(false);
-        }
-      }
-
-      try {
-        setBadgesLoading(true);
-        const badgeResponse = await fetchBadges();
-        setBadges(badgeResponse.badges);
-      } catch (error) {
-        console.error("Failed to load badges:", error);
-      } finally {
-        setBadgesLoading(false);
-      }
+    setProfileLoading(true);
+    setBadgesLoading(true);
+    if (isPremium) {
+      setProjectsLoading(true);
     }
 
-    void loadData();
+    void fetchProfile()
+      .then((res) => setProfileData(res.profile))
+      .catch((error) => console.error("Failed to load profile:", error))
+      .finally(() => setProfileLoading(false));
+
+    void fetchBadges()
+      .then((res) => setBadges(res.badges))
+      .catch((error) => console.error("Failed to load badges:", error))
+      .finally(() => setBadgesLoading(false));
+
+    if (isPremium) {
+      void fetchProjects({ per: 100 })
+        .then((res) => setProjects(res.results))
+        .catch((error) => console.error("Failed to load projects:", error))
+        .finally(() => setProjectsLoading(false));
+    }
   }, [user, isPremium]);
 
   // Filter to get recent/in-progress projects, padded to 3 with locked projects - only computed for premium users
@@ -90,12 +77,18 @@ function ProjectsSidebar({ onProjectClick, onViewAllProjectsClick, onUpgradeClic
       return [];
     }
     const active = projects.filter((p) => p.status === "started" || p.status === "unlocked").slice(0, 3);
-    if (active.length < 3) {
-      const activeSlugs = new Set(active.map((p) => p.slug));
-      const locked = projects.filter((p) => p.status === "locked" && !activeSlugs.has(p.slug));
-      return [...active, ...locked.slice(0, 3 - active.length)];
+    if (active.length >= 3) {
+      return active;
     }
-    return active;
+    const usedSlugs = new Set(active.map((p) => p.slug));
+    const locked = projects.filter((p) => p.status === "locked" && !usedSlugs.has(p.slug));
+    const withLocked = [...active, ...locked.slice(0, 3 - active.length)];
+    if (withLocked.length >= 3) {
+      return withLocked;
+    }
+    withLocked.forEach((p) => usedSlugs.add(p.slug));
+    const completed = projects.filter((p) => p.status === "completed" && !usedSlugs.has(p.slug));
+    return [...withLocked, ...completed.slice(0, 3 - withLocked.length)];
   }, [isPremium, projects]);
 
   // Count unlocked projects - only computed for premium users

--- a/app/tests/unit/components/dashboard/projects-sidebar/ProjectsSidebar.test.tsx
+++ b/app/tests/unit/components/dashboard/projects-sidebar/ProjectsSidebar.test.tsx
@@ -1,0 +1,208 @@
+import ProjectsSidebar from "@/components/dashboard/projects-sidebar/ProjectsSidebar";
+import { fetchBadges } from "@/lib/api/badges";
+import { fetchProfile } from "@/lib/api/profile";
+import { fetchProjects, type ProjectData, type ProjectStatus } from "@/lib/api/projects";
+import { createMockUser } from "@/tests/mocks/user";
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("@/lib/api/profile", () => ({ fetchProfile: jest.fn() }));
+jest.mock("@/lib/api/projects", () => ({ fetchProjects: jest.fn() }));
+jest.mock("@/lib/api/badges", () => ({ fetchBadges: jest.fn() }));
+
+jest.mock("@/lib/auth/authStore", () => {
+  const { createMockUser: makeUser } = jest.requireActual("@/tests/mocks/user");
+  let state = { user: makeUser({ membership_type: "premium" }) };
+  return {
+    useAuthStore: jest.fn((selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state)),
+    __setUser: (user: unknown) => {
+      state = { user: user as ReturnType<typeof makeUser> };
+    }
+  };
+});
+
+jest.mock("@/components/dashboard/projects-sidebar/ui/UserProfile", () => ({
+  UserProfile: ({ profile }: { profile: { name: string } | null }) => (
+    <div data-testid="user-profile">{profile?.name ?? "loading"}</div>
+  )
+}));
+
+jest.mock("@/components/dashboard/projects-sidebar/ui/ProjectsUpsellCard", () => ({
+  ProjectsUpsellCard: () => <div data-testid="upsell-card">upsell</div>
+}));
+
+jest.mock("@/components/dashboard/projects-sidebar/ui/RecentProjects", () => ({
+  RecentProjects: ({ projects, unlockedCount }: { projects: ProjectData[]; unlockedCount: number }) => (
+    <div data-testid="recent-projects" data-unlocked={unlockedCount}>
+      {projects.map((p) => (
+        <div key={p.slug} data-testid={`project-${p.slug}`} data-status={p.status}>
+          {p.title}
+        </div>
+      ))}
+    </div>
+  )
+}));
+
+const mockFetchProfile = fetchProfile as jest.MockedFunction<typeof fetchProfile>;
+const mockFetchProjects = fetchProjects as jest.MockedFunction<typeof fetchProjects>;
+const mockFetchBadges = fetchBadges as jest.MockedFunction<typeof fetchBadges>;
+
+const authStoreMock = jest.requireMock("@/lib/auth/authStore");
+
+function makeProject(slug: string, status: ProjectStatus): ProjectData {
+  return { slug, title: slug, description: `${slug} desc`, status };
+}
+
+function mockProjects(list: ProjectData[]) {
+  mockFetchProjects.mockResolvedValue({
+    results: list,
+    meta: { current_page: 1, total_count: list.length, total_pages: 1 }
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authStoreMock.__setUser(createMockUser({ membership_type: "premium" }));
+  mockFetchProfile.mockResolvedValue({
+    profile: { avatar_url: "", icon: "", streaks_enabled: false, total_active_days: 0 }
+  });
+  mockFetchBadges.mockResolvedValue({ badges: [], num_locked_secret_badges: 0 });
+  mockProjects([]);
+});
+
+describe("ProjectsSidebar", () => {
+  describe("non-premium users", () => {
+    it("renders the upsell card and does not call fetchProjects", async () => {
+      authStoreMock.__setUser(createMockUser({ membership_type: "standard" }));
+
+      render(<ProjectsSidebar />);
+
+      await waitFor(() => expect(mockFetchProfile).toHaveBeenCalled());
+      expect(screen.getByTestId("upsell-card")).toBeInTheDocument();
+      expect(mockFetchProjects).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("premium users", () => {
+    it("fires profile, badges, and projects requests in parallel on mount", async () => {
+      let resolveProfile: () => void = () => {};
+      mockFetchProfile.mockReturnValue(
+        new Promise((resolve) => {
+          resolveProfile = () =>
+            resolve({
+              profile: { avatar_url: "", icon: "", streaks_enabled: false, total_active_days: 0 }
+            });
+        })
+      );
+
+      render(<ProjectsSidebar />);
+
+      // All three fire on mount, regardless of profile resolving
+      expect(mockFetchProfile).toHaveBeenCalledTimes(1);
+      expect(mockFetchBadges).toHaveBeenCalledTimes(1);
+      expect(mockFetchProjects).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveProfile();
+        await Promise.resolve();
+      });
+    });
+
+    it("passes the count of non-locked projects as unlockedCount", async () => {
+      mockProjects([
+        makeProject("a", "started"),
+        makeProject("b", "unlocked"),
+        makeProject("c", "completed"),
+        makeProject("d", "locked"),
+        makeProject("e", "locked")
+      ]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-a");
+      const recent = screen.getByTestId("recent-projects");
+      expect(recent.getAttribute("data-unlocked")).toBe("3");
+    });
+  });
+
+  describe("recentProjects padding", () => {
+    it("returns up to 3 active (started/unlocked) projects when available", async () => {
+      mockProjects([
+        makeProject("s1", "started"),
+        makeProject("s2", "started"),
+        makeProject("u1", "unlocked"),
+        makeProject("u2", "unlocked"),
+        makeProject("l1", "locked"),
+        makeProject("c1", "completed")
+      ]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-s1");
+      expect(screen.getByTestId("project-s2")).toBeInTheDocument();
+      expect(screen.getByTestId("project-u1")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-u2")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("project-l1")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("project-c1")).not.toBeInTheDocument();
+    });
+
+    it("pads with locked projects after active ones", async () => {
+      mockProjects([
+        makeProject("s1", "started"),
+        makeProject("l1", "locked"),
+        makeProject("l2", "locked"),
+        makeProject("l3", "locked"),
+        makeProject("c1", "completed")
+      ]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-s1");
+      expect(screen.getByTestId("project-l1")).toBeInTheDocument();
+      expect(screen.getByTestId("project-l2")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-l3")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("project-c1")).not.toBeInTheDocument();
+    });
+
+    it("pads with completed projects after locked when fewer than 3 active+locked exist", async () => {
+      mockProjects([
+        makeProject("s1", "started"),
+        makeProject("l1", "locked"),
+        makeProject("c1", "completed"),
+        makeProject("c2", "completed")
+      ]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-s1");
+      expect(screen.getByTestId("project-l1")).toBeInTheDocument();
+      expect(screen.getByTestId("project-c1")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-c2")).not.toBeInTheDocument();
+    });
+
+    it("falls back to completed projects only when nothing else exists", async () => {
+      mockProjects([
+        makeProject("c1", "completed"),
+        makeProject("c2", "completed"),
+        makeProject("c3", "completed"),
+        makeProject("c4", "completed")
+      ]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-c1");
+      expect(screen.getByTestId("project-c2")).toBeInTheDocument();
+      expect(screen.getByTestId("project-c3")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-c4")).not.toBeInTheDocument();
+    });
+
+    it("returns fewer than 3 if there aren't enough projects of any status", async () => {
+      mockProjects([makeProject("s1", "started"), makeProject("c1", "completed")]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-s1");
+      expect(screen.getByTestId("project-c1")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-l1")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fire profile, badges, and projects API calls in parallel on mount in `ProjectsSidebar` instead of awaiting them sequentially. Combined with the levels calls already fired by `ExercisePath`, all 5 dashboard requests now go out on the same tick.
- Pad the Recent Projects list with `completed` projects after `locked` ones, so users who have finished everything still see meaningful content (previously the sidebar collapsed to the generic empty state).
- Add unit tests for `ProjectsSidebar` covering the parallel fetch behavior, premium gating, `unlockedCount` math, and the active → locked → completed padding fallback.

## Test plan
- [x] `pnpm jest tests/unit/components/dashboard/projects-sidebar/ProjectsSidebar.test.tsx` (8 passing)
- [x] Full unit suite via pre-commit hook (1556 passing)
- [x] `pnpm typecheck`
- [ ] Manual: load `/dashboard` as a premium user with mixed project statuses; verify recent-projects list and that network panel shows the three sidebar calls firing in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)