### PR TITLE
Add scroll and syntax highlighting to IO test result table

### DIFF
--- a/app/components/coding-exercise/ui/test-results-view/HighlightedCode.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/HighlightedCode.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from "react";
+import hljs from "highlight.js/lib/core";
+import setupJikiscript from "@exercism/highlightjs-jikiscript";
+import setupJavascript from "@jiki/highlightjs-javascript";
+
+hljs.registerLanguage("jikiscript", setupJikiscript);
+hljs.registerLanguage("javascript", setupJavascript);
+
+interface HighlightedCodeProps {
+  code: string;
+  language: string;
+}
+
+export function HighlightedCode({ code, language }: HighlightedCodeProps) {
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+    delete ref.current.dataset.highlighted;
+    hljs.highlightElement(ref.current);
+  }, [code, language]);
+
+  return (
+    <pre className="!p-0 !m-0 !bg-transparent inline">
+      <code ref={ref} className={`language-${language} !p-0 !bg-transparent`}>
+        {code}
+      </code>
+    </pre>
+  );
+}

--- a/app/components/coding-exercise/ui/test-results-view/IOTestResultView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/IOTestResultView.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import type { Change } from "diff";
 import type { IOTestExpect } from "../../lib/test-results-types";
 import tableStyles from "./io/IOScenarioTable.module.css";
+import { HighlightedCode } from "./HighlightedCode";
 
 interface IOTestResultViewProps {
   expect: IOTestExpect;
+  language: string;
 }
 
-export function IOTestResultView({ expect }: IOTestResultViewProps) {
+export function IOTestResultView({ expect, language }: IOTestResultViewProps) {
   if (expect.errorHtml) {
     return (
       <div className={tableStyles.wrapper}>
@@ -22,20 +24,28 @@ export function IOTestResultView({ expect }: IOTestResultViewProps) {
         <tbody>
           <tr>
             <th>Code run</th>
-            <td>{expect.codeRun}</td>
+            <td>
+              <div className={tableStyles.cellScroll}>
+                <HighlightedCode code={expect.codeRun ?? ""} language={language} />
+              </div>
+            </td>
           </tr>
           <tr>
             <th>Expected</th>
-            <td className="whitespace-pre-wrap">{renderExpected(expect.diff)}</td>
+            <td>
+              <div className={`${tableStyles.cellScroll} whitespace-pre-wrap`}>{renderExpected(expect.diff)}</div>
+            </td>
           </tr>
           <tr>
             <th>Actual</th>
-            <td className="whitespace-pre-wrap">
-              {expect.actual === undefined || expect.actual === null ? (
-                <span className={tableStyles.removedPart}>[Your function didn&apos;t return anything]</span>
-              ) : (
-                renderActual(expect.diff)
-              )}
+            <td>
+              <div className={`${tableStyles.cellScroll} whitespace-pre-wrap`}>
+                {expect.actual === undefined || expect.actual === null ? (
+                  <span className={tableStyles.removedPart}>[Your function didn&apos;t return anything]</span>
+                ) : (
+                  renderActual(expect.diff)
+                )}
+              </div>
             </td>
           </tr>
         </tbody>

--- a/app/components/coding-exercise/ui/test-results-view/io/IOInspectedView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/io/IOInspectedView.tsx
@@ -6,6 +6,7 @@ import { useOrchestratorStore } from "../../../lib/Orchestrator";
 import { useOrchestrator } from "../../../lib/OrchestratorContext";
 import type { IOTestExpect } from "../../../lib/test-results-types";
 import { IOTestResultView } from "../IOTestResultView";
+import { HighlightedCode } from "../HighlightedCode";
 import { ScenarioHeader } from "../ScenarioHeader";
 import CheckCircleIcon from "@/icons/check-circle.svg";
 import CrossCircleIcon from "@/icons/cross-circle.svg";
@@ -25,7 +26,7 @@ export function IOInspectedView() {
 
 function IOInspectedPreviewView() {
   const orchestrator = useOrchestrator();
-  const { currentTestIdx } = useOrchestratorStore(orchestrator);
+  const { currentTestIdx, language } = useOrchestratorStore(orchestrator);
   const exercise = orchestrator.getExercise() as IOExerciseDefinition;
   const scenario = exercise.scenarios[currentTestIdx];
 
@@ -42,15 +43,23 @@ function IOInspectedPreviewView() {
             <tbody>
               <tr>
                 <th>Code run</th>
-                <td>{codeRun}</td>
+                <td>
+                  <div className={tableStyles.cellScroll}>
+                    <HighlightedCode code={codeRun} language={language} />
+                  </div>
+                </td>
               </tr>
               <tr>
                 <th>Expected</th>
-                <td>{expectedStr}</td>
+                <td>
+                  <div className={tableStyles.cellScroll}>{expectedStr}</div>
+                </td>
               </tr>
               <tr>
                 <th>Actual</th>
-                <td className={tableStyles.pendingMessage}>Click &ldquo;Run Code&rdquo; to see what your code does.</td>
+                <td className={tableStyles.pendingMessage}>
+                  <div className={tableStyles.cellScroll}>Click &ldquo;Run Code&rdquo; to see what your code does.</div>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -62,7 +71,7 @@ function IOInspectedPreviewView() {
 
 function IOInspectedResultView() {
   const orchestrator = useOrchestrator();
-  const { currentTest, currentTestIdx } = useOrchestratorStore(orchestrator);
+  const { currentTest, currentTestIdx, language } = useOrchestratorStore(orchestrator);
   const exercise = orchestrator.getExercise() as IOExerciseDefinition;
   const scenario = exercise.scenarios[currentTestIdx];
 
@@ -97,7 +106,7 @@ function IOInspectedResultView() {
             </span>
           </div>
         )}
-        {firstExpect ? <IOTestResultView expect={firstExpect} /> : null}
+        {firstExpect ? <IOTestResultView expect={firstExpect} language={language} /> : null}
       </div>
     </div>
   );

--- a/app/components/coding-exercise/ui/test-results-view/io/IOScenarioTable.module.css
+++ b/app/components/coding-exercise/ui/test-results-view/io/IOScenarioTable.module.css
@@ -6,6 +6,7 @@
 
 .table {
     @apply w-full text-sm;
+    table-layout: fixed;
 }
 
 .table tr + tr {
@@ -22,8 +23,13 @@
 }
 
 .table td {
-    padding: 8px;
     @apply font-mono text-sm;
+}
+
+.cellScroll {
+    overflow-x: auto;
+    max-width: 100%;
+    padding: 8px;
 }
 
 .addedPart,

--- a/app/tests/unit/components/coding-exercise/ui/test-results-view/IOTestResultView.test.tsx
+++ b/app/tests/unit/components/coding-exercise/ui/test-results-view/IOTestResultView.test.tsx
@@ -16,7 +16,9 @@ function makeExpect(overrides: Partial<IOTestExpect> = {}): IOTestExpect {
 
 describe("IOTestResultView", () => {
   it("renders errorHtml when present and skips the table", () => {
-    const { container } = render(<IOTestResultView expect={makeExpect({ errorHtml: "<em>boom</em>" })} />);
+    const { container } = render(
+      <IOTestResultView expect={makeExpect({ errorHtml: "<em>boom</em>" })} language="jikiscript" />
+    );
 
     expect(container.querySelector("em")?.textContent).toBe("boom");
     expect(screen.queryByText("Code run")).not.toBeInTheDocument();
@@ -25,7 +27,7 @@ describe("IOTestResultView", () => {
   });
 
   it("renders Code run, Expected and Actual rows when no errorHtml", () => {
-    render(
+    const { container } = render(
       <IOTestResultView
         expect={makeExpect({
           codeRun: "even_or_odd(14)",
@@ -36,11 +38,12 @@ describe("IOTestResultView", () => {
             { value: "Odd", added: true }
           ] as any
         })}
+        language="jikiscript"
       />
     );
 
     expect(screen.getByText("Code run")).toBeInTheDocument();
-    expect(screen.getByText("even_or_odd(14)")).toBeInTheDocument();
+    expect(container.querySelector("code")?.textContent).toBe("even_or_odd(14)");
     expect(screen.getByText("Expected")).toBeInTheDocument();
     expect(screen.getByText("Actual")).toBeInTheDocument();
   });
@@ -54,6 +57,7 @@ describe("IOTestResultView", () => {
             { value: "Odd", added: true }
           ] as any
         })}
+        language="jikiscript"
       />
     );
 
@@ -73,6 +77,7 @@ describe("IOTestResultView", () => {
             { value: "Odd", added: true }
           ] as any
         })}
+        language="jikiscript"
       />
     );
 
@@ -94,6 +99,7 @@ describe("IOTestResultView", () => {
             { value: " suffix" }
           ] as any
         })}
+        language="jikiscript"
       />
     );
 
@@ -114,6 +120,7 @@ describe("IOTestResultView", () => {
         expect={makeExpect({
           diff: [{ value: "line1\nline2\nline3" }, { value: "x", removed: true }] as any
         })}
+        language="jikiscript"
       />
     );
 
@@ -122,8 +129,12 @@ describe("IOTestResultView", () => {
   });
 
   it("uses the shared IOScenarioTable wrapper styling regardless of pass/fail", () => {
-    const { container: passContainer } = render(<IOTestResultView expect={makeExpect({ pass: true })} />);
-    const { container: failContainer } = render(<IOTestResultView expect={makeExpect({ pass: false })} />);
+    const { container: passContainer } = render(
+      <IOTestResultView expect={makeExpect({ pass: true })} language="jikiscript" />
+    );
+    const { container: failContainer } = render(
+      <IOTestResultView expect={makeExpect({ pass: false })} language="jikiscript" />
+    );
 
     [passContainer, failContainer].forEach((c) => {
       const wrapper = c.firstChild as HTMLElement;


### PR DESCRIPTION
## Summary
- Wrap Code run / Expected / Actual cell contents in a scrollable div so long output overflows horizontally instead of stretching the table
- Highlight the Code run cell using the same hljs setup as the instructions panel
- `IOTestResultView` now takes a required `language` prop, passed through from `IOInspectedView`

## Test plan
- [ ] Open an IO exercise and verify the Code run cell is syntax-highlighted
- [ ] Trigger a failing test with long expected/actual output and confirm the cells scroll horizontally without stretching the table
- [ ] Confirm the pending preview (before Run Code) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)