### PR TITLE
Rewrite visual exercise hints in Q&A format

### DIFF
--- a/curriculum/src/exercises/alien-detector/metadata.json
+++ b/curriculum/src/exercises/alien-detector/metadata.json
@@ -3,28 +3,24 @@
   "levelId": "lists",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Get all three rows of aliens at the start using getStartingAliensInRow()"
+      "question": "How do I know where the aliens are if `isAlienAbove()` is gone?",
+      "answer": "Call `getStartingAliensInRow(1)`, `getStartingAliensInRow(2)`, and `getStartingAliensInRow(3)` once at the start. Each returns a list of 11 booleans you can store in variables and read from later."
     },
     {
-      "question": "Hint",
-      "answer": "Track your position so you can index into the alien rows to check for aliens"
+      "question": "How do I work out which alien is above me right now?",
+      "answer": "Track your horizontal position in a variable, updating it each time you move. That position is the index into the row lists, so `row1[position]` tells you if there is an alien above you in row 1."
     },
     {
-      "question": "Hint",
-      "answer": "When you shoot an alien, mark it as false in the row array so you don't shoot it again"
+      "question": "How do I stop shooting the same alien twice?",
+      "answer": "After calling `shoot()`, set that index in the row to `false`. Next time round the loop the same position will report no alien there."
     },
     {
-      "question": "Hint",
-      "answer": "Only shoot the lowest alien in a column — check rows from bottom to top"
+      "question": "Which row should I shoot from when there are aliens stacked above me?",
+      "answer": "Check the rows from bottom to top. Shoot the lowest live alien in your column and stop checking further rows that iteration."
     },
     {
-      "question": "Hint",
-      "answer": "You might find it easier to think about the fireworks last and just get the alien tracking and shooting sorted first"
-    },
-    {
-      "question": "Hint",
-      "answer": "Write a helper function to check if all aliens are dead across all rows"
+      "question": "How do I know when to call `fireFireworks()`?",
+      "answer": "After shooting, scan all three row lists. If every entry is `false`, you have just downed the last alien, so call `fireFireworks()` in the same loop iteration. A small helper like `allAliensDead()` keeps the loop tidy."
     }
   ]
 }

--- a/curriculum/src/exercises/battle-procedures/metadata.json
+++ b/curriculum/src/exercises/battle-procedures/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "make-your-own-functions",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Define the function before the loop"
+      "question": "Where should I put the `shootIfAlienAbove` function?",
+      "answer": "Define it at the top of your code, before the loop. Once it is defined you can call it from inside the loop as many times as you like."
     },
     {
-      "question": "Hint",
-      "answer": "shootIfAlienAbove() needs to check isAlienAbove() before calling shoot()"
+      "question": "What goes inside `shootIfAlienAbove`?",
+      "answer": "Use an `if` statement that checks `isAlienAbove()`. When that returns `true`, call `shoot()`. That is the whole body of the function."
     },
     {
-      "question": "Hint",
-      "answer": "The movement and direction logic stays in the loop, just like scroll-and-shoot"
+      "question": "What stays in the loop?",
+      "answer": "All the movement logic stays in the loop, the same as in the scroll-and-shoot exercise. Each iteration: call `shootIfAlienAbove()`, then move the cannon, then flip direction at the boundaries."
     },
     {
-      "question": "Hint",
-      "answer": "Remember to track position and direction with variables"
+      "question": "How do I keep track of where the cannon is and which way it is going?",
+      "answer": "Use two variables that you update each iteration. For example, a `position` variable that goes up or down, and a `direction` variable that is `1` or `-1` and flips when you hit an edge."
     }
   ]
 }

--- a/curriculum/src/exercises/bouncer-dress-code/metadata.json
+++ b/curriculum/src/exercises/bouncer-dress-code/metadata.json
@@ -3,24 +3,24 @@
   "levelId": "complex-conditionals",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by storing the outfit in a variable, e.g. let outfit = getOutfit()"
+      "question": "How do I find out what the person is wearing?",
+      "answer": "Call `getOutfit()` and store the result in a variable, e.g. `let outfit = getOutfit()`. That way you can check it as many times as you need without calling the function again."
     },
     {
-      "question": "Hint",
-      "answer": "Use 'or' to check for multiple outfits in one condition"
+      "question": "How do I check for more than one outfit in a single condition?",
+      "answer": "Use `||` (or) inside an `if`. For the fancy group: `if (outfit === \"ballgown\" || outfit === \"tuxedo\")`."
     },
     {
-      "question": "Hint",
-      "answer": "For the fancy outfits: if outfit == \"ballgown\" or outfit == \"tuxedo\""
+      "question": "Fancy outfits need two things to happen. How do I do both?",
+      "answer": "Just call both functions inside the same `if` block: first `offerChampagne()`, then `letIn()`."
     },
     {
-      "question": "Hint",
-      "answer": "Remember to call both offerChampagne() and letIn() for fancy outfits"
+      "question": "How do I handle the smart outfits without re-checking the fancy ones?",
+      "answer": "Use `else if` for the smart group (`\"suit\"` or `\"dress\"`). That branch only runs when the fancy condition was false."
     },
     {
-      "question": "Hint",
-      "answer": "Use else at the end to turn away anyone not matching the dress code"
+      "question": "What about outfits that match nothing in the dress code?",
+      "answer": "Finish with a plain `else` that calls `turnAway()`. Anyone who did not match an earlier branch gets turned away automatically."
     }
   ]
 }

--- a/curriculum/src/exercises/bouncer-wristbands/metadata.json
+++ b/curriculum/src/exercises/bouncer-wristbands/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "conditionals",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by storing the age in a variable, e.g. let age = getAge()"
+      "question": "How do I get hold of the person's age?",
+      "answer": "Call `getAge()` and put the result in a variable, e.g. `let age = getAge()`. Then you can compare `age` to numbers in your conditions."
     },
     {
-      "question": "Hint",
-      "answer": "Use if/else if/else to check the age ranges in order"
+      "question": "Which structure do I use when there are several age ranges?",
+      "answer": "An `if` / `else if` / `else` chain. Each branch handles one wristband, and only one branch will run."
     },
     {
-      "question": "Hint",
-      "answer": "Check the youngest group first (age < 13), then work upwards"
+      "question": "Does the order of the branches matter?",
+      "answer": "Yes. Start with the youngest (`age < 13`), then `age < 18`, then `age < 65`. Because each branch only runs if the earlier ones failed, you do not need to write things like `age >= 13 && age < 18`."
     },
     {
-      "question": "Hint",
-      "answer": "The last group (seniors) doesn't need a condition — use else"
+      "question": "What about the seniors at the end?",
+      "answer": "You do not need a condition for them. A plain `else` that calls `seniorWristband()` catches everyone aged 65 and over."
     }
   ]
 }

--- a/curriculum/src/exercises/boundaried-ball/metadata.json
+++ b/curriculum/src/exercises/boundaried-ball/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "everything",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Create a ball with `let ball = new Ball()`"
+      "question": "How do I get a ball to work with?",
+      "answer": "Use `new` to make one: `let ball = new Ball()`. Then pass `ball` to `moveBall(ball)` inside the loop to make it move."
     },
     {
-      "question": "Hint",
-      "answer": "Check if `ball.cx - ball.radius <= 0` to detect the left wall"
+      "question": "How do I tell when the ball has reached a wall?",
+      "answer": "The ball's edge is `radius` away from its centre. For the left wall, check `ball.cx - ball.radius <= 0`. For the right wall, `ball.cx + ball.radius >= 100`."
     },
     {
-      "question": "Hint",
-      "answer": "When the ball hits a wall, reverse the velocity (e.g., `ball.xVelocity = 1`)"
+      "question": "What should I do when the ball hits a wall?",
+      "answer": "Set the velocity so it moves the other way next step. At the left wall set `ball.xVelocity = 1`; at the right wall set it to `-1`. Use `=`, not `+=`, so the velocity stays exactly `1` or `-1`."
     },
     {
-      "question": "Hint",
-      "answer": "Check all four walls: left, right, top, and bottom"
+      "question": "Why does my ball still escape sometimes?",
+      "answer": "You probably only checked two walls. Add the same kind of check for the top (`ball.cy - ball.radius <= 0`) and bottom (`ball.cy + ball.radius >= 100`), flipping `yVelocity` instead of `xVelocity`."
     }
   ]
 }

--- a/curriculum/src/exercises/build-wall/metadata.json
+++ b/curriculum/src/exercises/build-wall/metadata.json
@@ -3,24 +3,24 @@
   "levelId": "conditionals-and-state",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Use nested loops: outer loop for rows, inner loop for bricks in each row"
+      "question": "I can only call `rectangle` once. How do I draw 55 bricks?",
+      "answer": "Put the single `rectangle` call inside a loop. Each iteration changes the x and y so a new brick is drawn in a new place."
     },
     {
-      "question": "Hint",
-      "answer": "Odd rows (0, 2, 4...) start at x=0 with 5 bricks"
+      "question": "How do I draw a whole grid rather than just one row?",
+      "answer": "Use nested loops. The outer loop steps through the rows (changing y), and the inner loop steps through the bricks in that row (changing x)."
     },
     {
-      "question": "Hint",
-      "answer": "Even rows (1, 3, 5...) start at x=-10 with 6 bricks"
+      "question": "How do I deal with the rows being offset differently?",
+      "answer": "Treat odd-numbered rows differently from even-numbered ones. Rows `0, 2, 4, ...` start at `x = 0` with 5 bricks; rows `1, 3, 5, ...` start at `x = -10` with 6 bricks (the extra brick hangs off-screen)."
     },
     {
-      "question": "Hint",
-      "answer": "Use modulo (%) to check if a row number is odd or even"
+      "question": "How do I tell if a row number is odd or even?",
+      "answer": "Use the `%` operator. `row % 2 === 0` is true for even rows, and false for odd rows. Use that inside an `if` to pick the starting x and brick count."
     },
     {
-      "question": "Hint",
-      "answer": "Each brick is 20 wide and 10 tall"
+      "question": "What sizes and spacings do I use?",
+      "answer": "Every brick is `20` wide and `10` tall, so x goes up by `20` between bricks in a row, and y goes up by `10` between rows."
     }
   ]
 }

--- a/curriculum/src/exercises/cloud-rain-sun/metadata.json
+++ b/curriculum/src/exercises/cloud-rain-sun/metadata.json
@@ -3,16 +3,20 @@
   "levelId": "strings-and-colors",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "The cloud is built from one rectangle and four circles along its edges."
+      "question": "How do I build the fluffy cloud shape from simple shapes?",
+      "answer": "The cloud is one rectangle (already drawn for you as the base) with `circle`s placed along its top edge to give it the bumpy outline."
     },
     {
-      "question": "Hint",
-      "answer": "Rain drops are ellipses that are taller than they are wide."
+      "question": "How do I make a raindrop with `ellipse`?",
+      "answer": "Raindrops are tall and thin, so the vertical radius is bigger than the horizontal one. The horizontal radius is `3` (the one number not divisible by 5)."
     },
     {
-      "question": "Hint",
-      "answer": "The sun should be drawn before the cloud so the cloud sits in front of it."
+      "question": "Why is my sun showing on top of the cloud?",
+      "answer": "Shapes drawn later sit in front of earlier ones. Draw the sun first, then the cloud on top, so the cloud appears to be in front of the sun."
+    },
+    {
+      "question": "Why isn't my drawing matching the template lines?",
+      "answer": "Your shapes should sit just inside the guide lines, not on top of them. Nearly every number you need is divisible by 5, so try the nearest multiple of 5 if a shape looks slightly off."
     }
   ]
 }

--- a/curriculum/src/exercises/emoji-collector/metadata.json
+++ b/curriculum/src/exercises/emoji-collector/metadata.json
@@ -3,20 +3,24 @@
   "levelId": "dictionaries",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Use look(\"down\") to check the emoji on the current square"
+      "question": "How do I see what is on the square I am standing on?",
+      "answer": "Use the new direction: `look(\"down\")`. It returns the emoji on your current square, which is the one you might want to pick up."
     },
     {
-      "question": "Hint",
-      "answer": "Use hasKey() to check if an emoji is already in your dictionary"
+      "question": "Which special emojis should I ignore?",
+      "answer": "Skip anything in the standard list: `\"star\"`, `\"flag\"`, `\"white square\"`, `\"fire\"`, `\"poop\"`, `\"brick\"`. Any other emoji is fair game to collect."
     },
     {
-      "question": "Hint",
-      "answer": "Use removeEmoji() after collecting an emoji from a square"
+      "question": "How do I count emojis using a dictionary?",
+      "answer": "Use `hasKey(dict, emoji)` to see if you have seen it before. If yes, add `1` to `dict[emoji]`. If no, set `dict[emoji] = 1` to start the count."
     },
     {
-      "question": "Hint",
-      "answer": "Call announceEmojis() with your dictionary after reaching the finish"
+      "question": "How do I stop picking up the same emoji every time I step on it?",
+      "answer": "Call `removeEmoji()` straight after counting it. The square becomes empty so it will not be counted again on a future pass."
+    },
+    {
+      "question": "What do I do once I reach the flag?",
+      "answer": "Call `announceEmojis(result)` with your dictionary as the argument. Do this once, after you have moved onto the finishing square."
     }
   ]
 }

--- a/curriculum/src/exercises/foxy-face/metadata.json
+++ b/curriculum/src/exercises/foxy-face/metadata.json
@@ -2,9 +2,25 @@
   "slug": "foxy-face",
   "levelId": "strings-and-colors",
   "hints": [
-    { "question": "Hint", "answer": "The triangle function takes 7 arguments: x1, y1, x2, y2, x3, y3, color" },
-    { "question": "Hint", "answer": "Draw the white cheeks first so they appear behind the face" },
-    { "question": "Hint", "answer": "The ears are a darker orange (brown) than the face (orange)" },
-    { "question": "Hint", "answer": "The nose is made of two dark triangles (charcoal)" }
+    {
+      "question": "How do I call the `triangle` function?",
+      "answer": "Pass 7 arguments in order: the three corner points (`x1, y1, x2, y2, x3, y3`) and then the color string, e.g. `triangle(50, 10, 30, 50, 70, 50, \"orange\")`."
+    },
+    {
+      "question": "What order should I draw the parts in so they overlap correctly?",
+      "answer": "Later shapes sit on top of earlier ones. Draw the white cheeks first so the orange face halves cover most of them, leaving just the cheek tips showing."
+    },
+    {
+      "question": "Which colors go where?",
+      "answer": "The ears are `\"brown\"`, the face halves are `\"orange\"`, the cheeks are `\"white\"`, and the nose is `\"charcoal\"`. Remember the colors are strings, so they need quotes."
+    },
+    {
+      "question": "How do I work out the coordinates on the right side without hovering?",
+      "answer": "The fox is symmetrical around the vertical middle. If a left-side point is at x=`30` and the centre is at x=`50`, the mirror point is at x=`70` (the same distance the other side of the centre). The y values stay the same."
+    },
+    {
+      "question": "Why aren't my coordinates working?",
+      "answer": "All the values you need are multiples of 5. If a corner looks slightly off, you have probably used a number like `12` or `38`. Snap it to the nearest multiple of 5 (`10`, `15`, `40`, etc)."
+    }
   ]
 }

--- a/curriculum/src/exercises/look-around/metadata.json
+++ b/curriculum/src/exercises/look-around/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "make-your-own-functions",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by creating canTurnLeft(), canTurnRight() and canMove() that just return false"
+      "question": "Where do I even start when the program won't run at all?",
+      "answer": "Define `canTurnLeft()`, `canTurnRight()`, and `canMove()` at the top of your code, each just returning `false` for now. The program will then run and you can replace the bodies one at a time."
     },
     {
-      "question": "Hint",
-      "answer": "Use look(\"ahead\") to check what's in front of you"
+      "question": "How do I find out what is in a given direction?",
+      "answer": "Use the new `look(direction)` function. Pass `\"left\"`, `\"right\"`, or `\"ahead\"` and it returns a string like `\"empty\"`, `\"wall\"`, `\"fire\"`, or `\"poop\"`."
     },
     {
-      "question": "Hint",
-      "answer": "A space is safe to move into if it's not \"fire\", \"wall\", or \"poop\""
+      "question": "Which results mean it is safe to go that way?",
+      "answer": "Anything that is not `\"wall\"`, `\"fire\"`, or `\"poop\"` is fine. So `look(\"ahead\") !== \"wall\" && look(\"ahead\") !== \"fire\" && look(\"ahead\") !== \"poop\"` is what `canMove` should return."
     },
     {
-      "question": "Hint",
-      "answer": "Consider writing a helper function like checkDirection(direction) that all three functions can use"
+      "question": "I am repeating the same logic in three functions. How do I avoid that?",
+      "answer": "Write one helper, e.g. `isSafe(direction)`, that does the `look` and the comparisons. Then `canMove` returns `isSafe(\"ahead\")`, `canTurnLeft` returns `isSafe(\"left\")`, and `canTurnRight` returns `isSafe(\"right\")`."
     }
   ]
 }

--- a/curriculum/src/exercises/maze-turn-around/metadata.json
+++ b/curriculum/src/exercises/maze-turn-around/metadata.json
@@ -3,16 +3,20 @@
   "levelId": "make-your-own-functions",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Define the function at the top of your code, before the loop"
+      "question": "How do I define a new function?",
+      "answer": "Use the `function` keyword followed by the name, parentheses for inputs, and a body in curly braces, e.g. `function turnAround() { ... }`."
     },
     {
-      "question": "Hint",
-      "answer": "The function just needs to call turnLeft() twice"
+      "question": "Where should I put the function definition?",
+      "answer": "Put it at the top of your code, before the loop. Functions must be defined before they're called."
     },
     {
-      "question": "Hint",
-      "answer": "Replace the two turnLeft() calls in the else block with a single turnAround() call"
+      "question": "What should go inside `turnAround()`?",
+      "answer": "Just two calls to `turnLeft()`. Two left turns add up to facing the opposite direction."
+    },
+    {
+      "question": "How do I use my new function in the maze solver?",
+      "answer": "Find the `else` block in your previous solution where you called `turnLeft()` twice and replace those two calls with a single `turnAround()` call."
     }
   ]
 }

--- a/curriculum/src/exercises/maze-walk/metadata.json
+++ b/curriculum/src/exercises/maze-walk/metadata.json
@@ -3,16 +3,20 @@
   "levelId": "make-your-own-functions",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Your function should be called walk and take one input called steps"
+      "question": "How do I define a function that takes an input?",
+      "answer": "Put the input name in the parentheses, e.g. `function walk(steps) { ... }`. Then you can use `steps` inside the function body."
     },
     {
-      "question": "Hint",
-      "answer": "Use a loop with the steps input to move forward multiple times"
+      "question": "How do I move forward a number of times?",
+      "answer": "Use a loop that runs `steps` times, and call `move()` inside it."
     },
     {
-      "question": "Hint",
-      "answer": "The function should call move() inside the repeat loop"
+      "question": "What should happen if I call `walk(3)`?",
+      "answer": "The loop should run three times, calling `move()` on each iteration, so the character moves forward three squares."
+    },
+    {
+      "question": "Where should the function definition go?",
+      "answer": "At the top of your code, before any code that calls `walk(...)`. Functions must be defined before they're used."
     }
   ]
 }

--- a/curriculum/src/exercises/niche-named-party/metadata.json
+++ b/curriculum/src/exercises/niche-named-party/metadata.json
@@ -3,24 +3,24 @@
   "levelId": "multiple-functions",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by getting the name and the allowed start using the provided functions"
+      "question": "How do I get the name and the allowed start?",
+      "answer": "Call `askName()` and `getAllowedStart()` and store the results in variables so you can use them in your comparison."
     },
     {
-      "question": "Hint",
-      "answer": "Think about how to check each character of the allowed start against the corresponding character in the name"
+      "question": "How do I check that a name starts with certain letters?",
+      "answer": "Compare each character of the allowed start with the character at the same position in the name. If any character differs, the name doesn't match."
     },
     {
-      "question": "Hint",
-      "answer": "What happens if the allowed start is longer than the person's name? You'll need to handle that edge case"
+      "question": "How do I look at one character at a time?",
+      "answer": "Use a counter variable starting at `1` and step through each position with a loop, comparing `name` and `allowedStart` at that position."
     },
     {
-      "question": "Hint",
-      "answer": "You'll need to calculate the lengths of both words. Think back to what you did in Sign Painter Price."
+      "question": "How do I know when to stop comparing?",
+      "answer": "Stop when you've checked every character of the allowed start. You'll need its length for that, similar to what you did in Sign Painter Price."
     },
     {
-      "question": "Hint",
-      "answer": "Use a counter variable to track which position you're comparing"
+      "question": "What if the allowed start is longer than the name?",
+      "answer": "That person can't match, so they should be turned away. Check the lengths before you start comparing and handle that case."
     }
   ]
 }

--- a/curriculum/src/exercises/rainbow-ball/metadata.json
+++ b/curriculum/src/exercises/rainbow-ball/metadata.json
@@ -3,24 +3,24 @@
   "levelId": "conditionals-and-state",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "You need variables for position (x, y), direction (xDirection, yDirection), hue, and hueDirection"
+      "question": "What state do I need to track?",
+      "answer": "The ball's position (`x`, `y`), its movement direction (`xDirection`, `yDirection`), and the current `hue` along with its `hueDirection`."
     },
     {
-      "question": "Hint",
-      "answer": "Update x, y, and hue at the start of each loop iteration by adding the direction values"
+      "question": "How do I make the ball move each frame?",
+      "answer": "At the start of each loop iteration, add `xDirection` to `x`, `yDirection` to `y`, and `hueDirection` to `hue`."
     },
     {
-      "question": "Hint",
-      "answer": "When x goes below 0 or above 100, change xDirection to a random value in the opposite direction"
+      "question": "How do I make the ball bounce off the edges?",
+      "answer": "When `x` goes below `0` or above `100`, reverse `xDirection`. Do the same for `y` with `yDirection`."
     },
     {
-      "question": "Hint",
-      "answer": "Use randomNumber(1, 5) for positive directions and randomNumber(-5, -1) for negative directions"
+      "question": "How do I give the bounce a random new speed?",
+      "answer": "Use `randomNumber(1, 5)` for moving in the positive direction and `randomNumber(-5, -1)` for the negative direction, so each bounce gets a fresh speed."
     },
     {
-      "question": "Hint",
-      "answer": "When hue goes below 0, set hueDirection to 1; when above 360, set it to -1"
+      "question": "How do I cycle the hue through the rainbow?",
+      "answer": "When `hue` drops below `0`, set `hueDirection` to `1`; when it goes above `360`, set it to `-1`. That way the color sweeps back and forth across the spectrum."
     }
   ]
 }

--- a/curriculum/src/exercises/relational-snowman/metadata.json
+++ b/curriculum/src/exercises/relational-snowman/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "variables",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "The head radius is size * 2, the body radius is size * 3, the base radius is size * 4"
+      "question": "How do I get the three radii from `size`?",
+      "answer": "Multiply: `headRadius = size * 2`, `bodyRadius = size * 3`, `baseRadius = size * 4`."
     },
     {
-      "question": "Hint",
-      "answer": "Two circles touch when the distance between centers equals the sum of their radii"
+      "question": "How do I work out where the body should sit?",
+      "answer": "Two circles touch when the distance between their centers equals the sum of their radii. So `bodyY = headY + headRadius + bodyRadius`."
     },
     {
-      "question": "Hint",
-      "answer": "bodyY = headY + headRadius + bodyRadius"
+      "question": "How do I position the base in the same way?",
+      "answer": "Use the same idea relative to the body: `baseY = bodyY + bodyRadius + baseRadius`."
     },
     {
-      "question": "Hint",
-      "answer": "baseY = bodyY + bodyRadius + baseRadius"
+      "question": "Why can't I just hardcode the y positions?",
+      "answer": "The whole point is that changing `size` should scale the snowman. If you hardcode numbers, changing `size` would leave the circles overlapping or gapped."
     }
   ]
 }

--- a/curriculum/src/exercises/relational-sun/metadata.json
+++ b/curriculum/src/exercises/relational-sun/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "variables",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "The sun's x position should be inset from the right edge: canvasSize - gap - sunRadius"
+      "question": "How do I work out the sun's x position?",
+      "answer": "Start from the right edge of the canvas and step inward by the gap and the radius: `sunX = canvasSize - gap - radius`."
     },
     {
-      "question": "Hint",
-      "answer": "The sun's y position should be inset from the top edge: gap + sunRadius"
+      "question": "How do I work out the sun's y position?",
+      "answer": "Start from the top edge and step down by the gap and the radius: `sunY = gap + radius`."
     },
     {
-      "question": "Hint",
-      "answer": "Use the skyColor and sunColor variables for the colors"
+      "question": "How do I draw the sky?",
+      "answer": "Draw a rectangle that covers the whole canvas, e.g. `rectangle(0, 0, canvasSize, canvasSize, skyColor)`."
     },
     {
-      "question": "Hint",
-      "answer": "The sky rectangle covers the whole canvas: rectangle(0, 0, canvasSize, canvasSize, skyColor)"
+      "question": "What order should I draw things in?",
+      "answer": "Draw the sky first, then the sun on top. Later drawings cover earlier ones, so the sun needs to come last."
     }
   ]
 }

--- a/curriculum/src/exercises/relational-traffic-lights/metadata.json
+++ b/curriculum/src/exercises/relational-traffic-lights/metadata.json
@@ -3,20 +3,24 @@
   "levelId": "variables",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "The centerX is radius * 5 to position the traffic light on the canvas"
+      "question": "How do I work out where the lights sit horizontally?",
+      "answer": "Pick a center based on `radius`, e.g. `centerX = radius * 5`. All three lights share this `centerX`."
     },
     {
-      "question": "Hint",
-      "answer": "The lights are spaced 2 radii apart: redY = radius * 3, yellowY = radius * 5, greenY = radius * 7"
+      "question": "How do I space the three lights vertically?",
+      "answer": "Place them two radii apart so they sit neatly: `redY = radius * 3`, `yellowY = radius * 5`, `greenY = radius * 7`."
     },
     {
-      "question": "Hint",
-      "answer": "The housing starts 2 radii left of center and 2 radii above the top light"
+      "question": "Where does the housing rectangle start?",
+      "answer": "Step `2 * radius` left of `centerX` and `2 * radius` above `redY` to get `housingX` and `housingY`."
     },
     {
-      "question": "Hint",
-      "answer": "The housing width is radius * 4 and height is radius * 8"
+      "question": "How big should the housing be?",
+      "answer": "Width is `radius * 4` (one radius padding either side of the light). Height is `radius * 8` to wrap all three lights with padding."
+    },
+    {
+      "question": "Why must everything be a multiple of `radius`?",
+      "answer": "If you hardcode a number, changing `radius` will leave the housing the wrong size for the lights. Using `radius * something` keeps the whole drawing in proportion."
     }
   ]
 }

--- a/curriculum/src/exercises/rock-paper-scissors-determine-winner/metadata.json
+++ b/curriculum/src/exercises/rock-paper-scissors-determine-winner/metadata.json
@@ -3,20 +3,24 @@
   "levelId": "complex-conditionals",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by getting both players' choices and storing them in variables"
+      "question": "How do I start?",
+      "answer": "Get both players' choices using the provided functions and store them in variables so you can compare them."
     },
     {
-      "question": "Hint",
-      "answer": "Check if the choices are equal first — that's always a tie"
+      "question": "What's the simplest case to handle first?",
+      "answer": "A tie. If both choices are equal, you can announce a tie straight away and skip the rest."
     },
     {
-      "question": "Hint",
-      "answer": "Use `and` to combine two conditions, e.g. player 1 chose rock AND player 2 chose scissors"
+      "question": "How do I check a specific winning combination?",
+      "answer": "Use `and` to combine two conditions, e.g. \"player 1 chose rock AND player 2 chose scissors\" means player 1 wins."
     },
     {
-      "question": "Hint",
-      "answer": "You can default the result to one value, then only check for the other cases"
+      "question": "I'm ending up with loads of `if` statements. Is there a shorter way?",
+      "answer": "Default the result to one player winning, then only check the three combinations where the other player wins. That cuts the cases roughly in half."
+    },
+    {
+      "question": "What if a player enters something other than rock, paper or scissors?",
+      "answer": "You don't need to worry about that here. The provided functions only ever return one of the three valid choices."
     }
   ]
 }

--- a/curriculum/src/exercises/scroll-and-shoot/metadata.json
+++ b/curriculum/src/exercises/scroll-and-shoot/metadata.json
@@ -3,28 +3,24 @@
   "levelId": "conditionals-and-state",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Break the exercise down into steps - get the laser moving from side to side first"
+      "question": "Where do I start? This feels like a lot.",
+      "answer": "Break it down. Get the laser moving from side to side first, ignoring the shooting. Once movement works, add the shooting logic."
     },
     {
-      "question": "Hint",
-      "answer": "Track your position with a variable so you know where you are"
+      "question": "How do I track where the laser is?",
+      "answer": "Keep a variable for the laser's position. Update it each loop iteration as you call `moveLeft()` or `moveRight()`."
     },
     {
-      "question": "Hint",
-      "answer": "Keep track of which direction you're moving (left or right)"
+      "question": "How do I know when to turn around?",
+      "answer": "Track a direction variable (e.g. `1` for right, `-1` for left). When the position hits the left or right boundary, flip the direction. This is the same bounce pattern from Rainbow Ball."
     },
     {
-      "question": "Hint",
-      "answer": "Use boundaries to know when to turn around"
+      "question": "When should I call `shoot()`?",
+      "answer": "Before calling `shoot()`, check `isAlienAbove()`. Only shoot if it returns `true`, otherwise you'll waste ammo and lose."
     },
     {
-      "question": "Hint",
-      "answer": "Check for aliens above before shooting"
-    },
-    {
-      "question": "Hint",
-      "answer": "The logic is similar to the rainbow ball exercise - you need to bounce back and forth"
+      "question": "The laser keeps overheating. What do I do?",
+      "answer": "Don't shoot every iteration. Move at least once between shots so the canon has time to cool down."
     }
   ]
 }

--- a/curriculum/src/exercises/smashing-blocks/metadata.json
+++ b/curriculum/src/exercises/smashing-blocks/metadata.json
@@ -3,28 +3,24 @@
   "levelId": "everything",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Create blocks in a loop: `for (let x = 1; x <= 5; x++) { ... }`"
+      "question": "How do I create the five blocks?",
+      "answer": "Use a `for` loop, e.g. `for (let x = 1; x <= 5; x++) { ... }`, and call `new Block(left, top)` inside it."
     },
     {
-      "question": "Hint",
-      "answer": "Each block's left position is `8 + ((x - 1) * 17)` — that's 16 width plus 1 gap"
+      "question": "How do I work out each block's `left` position?",
+      "answer": "The first sits at `8`, and each block is `16` wide with a `1` gap, so the left is `8 + ((x - 1) * 17)`."
     },
     {
-      "question": "Hint",
-      "answer": "To detect a collision, check if the ball's top edge equals the block's bottom edge (`block.top + block.height`)"
+      "question": "How do I detect the ball hitting a block?",
+      "answer": "Check if the ball's top edge equals the block's bottom edge (`block.top + block.height`), and that the ball is horizontally aligned with the block."
     },
     {
-      "question": "Hint",
-      "answer": "Also check that the ball is horizontally aligned with the block"
+      "question": "How do I skip blocks that are already smashed?",
+      "answer": "Inside your loop, check `block.smashed` and use `continue` to jump to the next block if it's already true."
     },
     {
-      "question": "Hint",
-      "answer": "Use `continue` to skip blocks that are already smashed"
-    },
-    {
-      "question": "Hint",
-      "answer": "Write a function to check if all blocks are smashed, and use `break` to exit the loop when they are"
+      "question": "How do I stop the ball when every block is gone?",
+      "answer": "Write a small function that returns true when all blocks have `smashed === true`. When it returns true, `break` out of the main loop."
     }
   ]
 }

--- a/curriculum/src/exercises/snowman-basic/metadata.json
+++ b/curriculum/src/exercises/snowman-basic/metadata.json
@@ -2,8 +2,21 @@
   "slug": "snowman-basic",
   "levelId": "using-functions",
   "hints": [
-    { "question": "Hint", "answer": "The snowman is centered horizontally at x = 50" },
-    { "question": "Hint", "answer": "The base is the largest circle, near the bottom" },
-    { "question": "Hint", "answer": "Each circle gets smaller as you go up" }
+    {
+      "question": "How do I draw a circle on the canvas?",
+      "answer": "Call `circle(cx, cy, radius)` where `cx` and `cy` are the center coordinates, and `radius` is how big it is."
+    },
+    {
+      "question": "Where should the circles be positioned horizontally?",
+      "answer": "All three circles share the same horizontal center, so `cx` is `50` for each (the canvas is `100` wide)."
+    },
+    {
+      "question": "How do I stack the three circles?",
+      "answer": "The base circle is the largest and sits near the bottom (high `cy`). Each circle above has a smaller `cy` and a smaller `radius`."
+    },
+    {
+      "question": "What numbers should I use for the radii?",
+      "answer": "All numbers in this exercise are divisible by `5`. Try a base radius around `20`, a body around `15`, and a head around `10`, adjusting until they line up with the target."
+    }
   ]
 }

--- a/curriculum/src/exercises/space-invaders-conditional/metadata.json
+++ b/curriculum/src/exercises/space-invaders-conditional/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "conditionals",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "You need to check each column as you move across"
+      "question": "How do I decide whether to shoot or not?",
+      "answer": "Use an `if` statement that checks `isAlienAbove()`. Only call `shoot()` when it returns `true`."
     },
     {
-      "question": "Hint",
-      "answer": "Use isAlienAbove() to check before shooting"
+      "question": "What does `isAlienAbove()` give me back?",
+      "answer": "It returns `true` if there's an alien directly above your cannon, and `false` otherwise. You can put it straight into an `if` condition."
     },
     {
-      "question": "Hint",
-      "answer": "Use an if statement to check isAlienAbove() and then shoot()"
+      "question": "How do I check every column without writing the same code over and over?",
+      "answer": "Wrap your check-and-maybe-shoot logic in a `repeat` loop, calling `move()` at the end of each iteration to slide to the next column."
     },
     {
-      "question": "Hint",
-      "answer": "Wrap everything in a repeat loop to move across all columns"
+      "question": "I keep shooting empty columns and losing. What's wrong?",
+      "answer": "Make sure `shoot()` is inside the `if` block, not after it. The call should only happen when `isAlienAbove()` is `true`."
     }
   ]
 }

--- a/curriculum/src/exercises/space-invaders-repeat/metadata.json
+++ b/curriculum/src/exercises/space-invaders-repeat/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "repeat-loop",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Look at the pattern - the aliens are in every other column"
+      "question": "How can I avoid writing `move()` and `shoot()` over and over?",
+      "answer": "Use a `repeat` loop. `repeat(n) { ... }` runs the same block of code `n` times."
     },
     {
-      "question": "Hint",
-      "answer": "What actions do you repeat for each group of aliens?"
+      "question": "What's the repeating pattern in the alien positions?",
+      "answer": "The aliens are in every other column, so the pattern is: `shoot`, `move`, `move`. That three-step group is what you want to repeat."
     },
     {
-      "question": "Hint",
-      "answer": "Use repeat(n) { ... } to run the same code multiple times"
+      "question": "How many times should I repeat the pattern?",
+      "answer": "Count the groups of aliens across the screen and use that number as the argument to `repeat`."
     },
     {
-      "question": "Hint",
-      "answer": "Count how many groups of aliens there are"
+      "question": "Why does the target ask for only 7 lines?",
+      "answer": "One line for the `repeat` header, the repeating actions inside, the closing brace, and one or two actions outside is plenty. If you're writing more, you're probably not using the loop yet."
     }
   ]
 }

--- a/curriculum/src/exercises/sprouting-flower/metadata.json
+++ b/curriculum/src/exercises/sprouting-flower/metadata.json
@@ -3,36 +3,24 @@
   "levelId": "basic-state",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Set up variables for flowerCenterX, flowerCenterY, and flowerRadius before the loop"
+      "question": "How do I make the flower grow and rise over time?",
+      "answer": "Create variables like `flowerCenterY` and `flowerRadius` before the loop, then update them on each iteration before drawing."
     },
     {
-      "question": "Hint",
-      "answer": "On each iteration, decrease flowerCenterY by 1 and increase flowerRadius by 0.4"
+      "question": "What should change on each iteration of the loop?",
+      "answer": "Decrease `flowerCenterY` by `1` (so the flower moves up) and increase `flowerRadius` by `0.4` (so it grows). Update the pistil radius by `0.1` too."
     },
     {
-      "question": "Hint",
-      "answer": "Calculate all other measurements based on the flower center and radius"
+      "question": "How do I keep the stem and leaves attached to the flower?",
+      "answer": "Don't hardcode their positions. Derive them from the flower variables. For example, the stem height is `groundTop - flowerCenterY`, and the stem width is `stemHeight / 10`."
     },
     {
-      "question": "Hint",
-      "answer": "The stem height is groundTop - flowerCenterY"
+      "question": "What size should the leaves be relative to the flower?",
+      "answer": "The leaves' `xRadius` is `flowerRadius * 0.5` and the `yRadius` is `flowerRadius * 0.2`. They sit halfway down the stem, flush against the stalk on each side."
     },
     {
-      "question": "Hint",
-      "answer": "The stem width is stemHeight / 10"
-    },
-    {
-      "question": "Hint",
-      "answer": "The leaves' xRadius is flowerRadius * 0.5"
-    },
-    {
-      "question": "Hint",
-      "answer": "The leaves' yRadius is flowerRadius * 0.2"
-    },
-    {
-      "question": "Hint",
-      "answer": "Remember to update all variables before drawing each frame"
+      "question": "My flower draws once and never changes. What's going on?",
+      "answer": "Make sure you're updating the variables inside the loop before each draw, not just before the loop starts. The loop body needs to mutate the state every iteration."
     }
   ]
 }

--- a/curriculum/src/exercises/structured-house/metadata.json
+++ b/curriculum/src/exercises/structured-house/metadata.json
@@ -3,24 +3,24 @@
   "levelId": "variables",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by defining houseLeft and houseTop, then derive other positions from those"
+      "question": "How do I make the whole house move when I change one variable?",
+      "answer": "Pick `houseLeft` and `houseTop` as your anchor variables, then derive every other position from them using arithmetic."
     },
     {
-      "question": "Hint",
-      "answer": "The roof overhangs the house by 4 on each side: roofLeft = houseLeft - 4"
+      "question": "How do I position the roof so it overhangs the frame?",
+      "answer": "The roof overhangs by `4` on each side, so `roofLeft = houseLeft - 4` and the roof width is `houseWidth + 8`."
     },
     {
-      "question": "Hint",
-      "answer": "Window positions can be calculated from houseLeft: window1Left = houseLeft + 10"
+      "question": "How do I place the windows and door relative to the house?",
+      "answer": "Express each as an offset from `houseLeft` and `houseTop`. For the door to be centered, use `doorLeft = houseLeft + (houseWidth - doorWidth) / 2`."
     },
     {
-      "question": "Hint",
-      "answer": "The door is centered: doorLeft = houseLeft + (houseWidth - doorWidth) / 2"
+      "question": "How do I put the door knob in the right spot?",
+      "answer": "Inset it `1` from the right of the door and vertically center it. So `knobX = doorLeft + doorWidth - knobRadius - 1` and `knobY = doorTop + doorHeight / 2`."
     },
     {
-      "question": "Hint",
-      "answer": "The door knob x = doorLeft + doorWidth - knobRadius - 1"
+      "question": "My layout looks right but changing `houseLeft` breaks it. Why?",
+      "answer": "You've probably hardcoded a position somewhere instead of deriving it. Look through your code for any literal number that should really be `houseLeft + something`."
     }
   ]
 }

--- a/curriculum/src/exercises/tic-tac-toe/metadata.json
+++ b/curriculum/src/exercises/tic-tac-toe/metadata.json
@@ -3,28 +3,24 @@
   "levelId": "lists",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by drawing the grid - a rectangle and four lines"
+      "question": "Where should I start with such a big exercise?",
+      "answer": "Break it up. First draw the empty grid (one rectangle plus four lines). Then write helper functions for drawing an `o` and an `x`. Build the game logic on top of those."
     },
     {
-      "question": "Hint",
-      "answer": "Create helper functions for drawing crosses and circles"
+      "question": "How do I keep track of which squares are taken?",
+      "answer": "Use a 2D list (a list of three lists, each with three entries) where each cell holds `\"o\"`, `\"x\"`, or an empty marker. Update it every time a move is made."
     },
     {
-      "question": "Hint",
-      "answer": "Use a 2D list (list of lists) to track which squares are occupied"
+      "question": "How do I know whose turn it is?",
+      "answer": "The first move is always `\"o\"`, then it alternates. Track the move number, or flip a variable between `\"o\"` and `\"x\"` after each placement."
     },
     {
-      "question": "Hint",
-      "answer": "Remember the first move is always 'o', alternating after that"
+      "question": "How do I detect a win?",
+      "answer": "After each move, check all 8 winning lines: 3 rows, 3 columns, and 2 diagonals. For each, check whether all three cells contain the same non-empty symbol."
     },
     {
-      "question": "Hint",
-      "answer": "Check for wins after each move by examining all 8 possible winning lines (3 rows, 3 columns, 2 diagonals)"
-    },
-    {
-      "question": "Hint",
-      "answer": "For AI moves, first check if you can win, then check if you need to block, then pick any open square"
+      "question": "How does the AI decide what to do for a `\"?\"` move?",
+      "answer": "Try the rules in order: first see if there's a move that wins immediately, then see if there's one that blocks the opponent's win, otherwise pick any empty square."
     }
   ]
 }

--- a/curriculum/src/exercises/weather-symbols-part-2/metadata.json
+++ b/curriculum/src/exercises/weather-symbols-part-2/metadata.json
@@ -3,20 +3,24 @@
   "levelId": "lists",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by drawing the sky background covering the whole canvas"
+      "question": "How do I draw each element from the list?",
+      "answer": "Use a `for...of` loop to iterate through `elements`. For each value, decide which shapes to draw."
     },
     {
-      "question": "Hint",
-      "answer": "You'll need to check if \"cloud\" is in the elements list to decide the sun size"
+      "question": "How do I check whether a particular element is in the list?",
+      "answer": "Use `indexOf` or `includes` style logic on the list. You need this to choose between the large sun (no cloud) and the small sun (with cloud)."
     },
     {
-      "question": "Hint",
-      "answer": "Use a for-each loop to iterate through the elements and draw each one"
+      "question": "What should I always draw first?",
+      "answer": "The sky background, before anything else. Otherwise it will paint over your sun, clouds, rain, and snow."
     },
     {
-      "question": "Hint",
-      "answer": "Use helper functions like drawSky(), drawSun(size), drawCloud(), drawRain(), drawSnow() to keep your code organized"
+      "question": "How do I keep my code from becoming a mess?",
+      "answer": "Write small helper functions like `drawSky()`, `drawSun(size)`, `drawCloud()`, `drawRain()`, and `drawSnow()`. Your main loop then just calls them."
+    },
+    {
+      "question": "The sun is always small even when there's no cloud. What's wrong?",
+      "answer": "Decide the sun's size by inspecting the whole list before (or independently of) the loop. If you decide inside the loop based only on the current item, you'll miss a cloud that appears later."
     }
   ]
 }

--- a/curriculum/src/exercises/wordle-process-game/metadata.json
+++ b/curriculum/src/exercises/wordle-process-game/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "everything",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Reuse your processGuess logic from the previous exercise"
+      "question": "How do I reuse my work from `processGuess`?",
+      "answer": "The logic that turns one guess into a list of states is the same. Pull it into a helper function (or copy it) and call it for each guess in the list."
     },
     {
-      "question": "Hint",
-      "answer": "Use a loop to iterate through the guesses with an index for the row number"
+      "question": "How do I track which row each guess belongs to?",
+      "answer": "Loop through the guesses with an index. The row number is the index plus `1` (since `colorRow` expects rows numbered `1-6`)."
     },
     {
-      "question": "Hint",
-      "answer": "Call colorRow(idx, states) for each guess"
+      "question": "How do I actually colour each row?",
+      "answer": "Once you have the `states` list for a guess, call `colorRow(rowNumber, states)`."
     },
     {
-      "question": "Hint",
-      "answer": "The row index should match colorRow's expected row numbers"
+      "question": "What if the player has made fewer than 6 guesses?",
+      "answer": "Only colour rows for the guesses that exist. The list length tells you how many to process, so you naturally stop at the right point."
     }
   ]
 }

--- a/curriculum/src/exercises/wordle-process-guess/metadata.json
+++ b/curriculum/src/exercises/wordle-process-guess/metadata.json
@@ -3,24 +3,24 @@
   "levelId": "lists",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Iterate through each letter of the guess with a loop that tracks position"
+      "question": "How do I compare each letter of the guess to the target?",
+      "answer": "Loop through the positions `0` to `4`. For each position, compare `guess[i]` with `target[i]`."
     },
     {
-      "question": "Hint",
-      "answer": "Compare each letter to the same position in the target word for 'correct'"
+      "question": "When is a letter `\"correct\"` vs `\"present\"` vs `\"absent\"`?",
+      "answer": "If `guess[i]` equals `target[i]`, it's `\"correct\"`. Otherwise, if the letter exists somewhere in `target`, it's `\"present\"`. If not, it's `\"absent\"`."
     },
     {
-      "question": "Hint",
-      "answer": "Check if the letter exists anywhere in the word for 'present'"
+      "question": "How do I build up the list of states?",
+      "answer": "Start with an empty list, then use `push(states, value)` inside the loop to append each state in order."
     },
     {
-      "question": "Hint",
-      "answer": "Use push() to build up the states list"
+      "question": "How can I check if a letter appears anywhere in the target word?",
+      "answer": "Write a small helper that loops through the target's letters and returns `true` if it finds a match. It keeps your main code clean."
     },
     {
-      "question": "Hint",
-      "answer": "A helper function to check if a letter is contained in a word is very useful"
+      "question": "Where does the finished list go?",
+      "answer": "Pass it to `colorRow(1, states)` to colour the first row of the board with your computed states."
     }
   ]
 }

--- a/curriculum/src/exercises/wordle-solver/metadata.json
+++ b/curriculum/src/exercises/wordle-solver/metadata.json
@@ -3,24 +3,24 @@
   "levelId": "everything",
   "hints": [
     {
-      "question": "Hint",
-      "answer": "Start by always guessing the first word from commonWords()"
+      "question": "Where do I even start?",
+      "answer": "Begin by always guessing the first word from `commonWords()`. Get the loop that adds a guess and checks the target working before worrying about being smart."
     },
     {
-      "question": "Hint",
-      "answer": "Build a knowledge dictionary to track what you learn from each guess"
+      "question": "How do I generate the states for each guess?",
+      "answer": "Compare the guess letter-by-letter to `getTargetWord()`, exactly like in the previous Wordle exercises: `\"correct\"`, `\"present\"`, or `\"absent\"`."
     },
     {
-      "question": "Hint",
-      "answer": "Track which letters are absent, which are present, and which positions are correct"
+      "question": "How do I remember what I've learned across guesses?",
+      "answer": "Keep a knowledge structure outside the loop: a list of letters known to be absent, a list of `(letter, position)` pairs that were correct, and per-position lists of letters known NOT to be there."
     },
     {
-      "question": "Hint",
-      "answer": "For each position, track which letters are definitely NOT there"
+      "question": "How do I pick the next guess?",
+      "answer": "Filter `commonWords()`: keep only words that have all the correct letters in the right slots, contain every present letter (but not in positions you've ruled out), and contain none of the absent letters. Pick the first match."
     },
     {
-      "question": "Hint",
-      "answer": "Filter the word list based on your accumulated knowledge"
+      "question": "When do I stop?",
+      "answer": "Stop as soon as the guess equals the target word, or after `6` guesses. Otherwise you'll keep guessing past the end of the board."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Reformats hints across 30 visual exercises from generic `"Hint"` labels to specific learner-voiced questions ("How do I...?", "Why doesn't X work?", "What if...?")
- Hints are ordered conceptual → mechanical → edge-cases, preempting common sticking points without giving the answer away in one step
- Follows the pattern established for IO exercises in #457

Covers: alien-detector, battle-procedures, bouncer-dress-code, bouncer-wristbands, boundaried-ball, build-wall, cloud-rain-sun, emoji-collector, foxy-face, look-around, maze-turn-around, maze-walk, niche-named-party, rainbow-ball, relational-snowman, relational-sun, relational-traffic-lights, rock-paper-scissors-determine-winner, scroll-and-shoot, smashing-blocks, snowman-basic, space-invaders-conditional, space-invaders-repeat, sprouting-flower, structured-house, tic-tac-toe, weather-symbols-part-2, wordle-process-game, wordle-process-guess, wordle-solver.

## Test plan
- [ ] Skim hint Q&A flow for a few exercises (foxy-face, wordle-solver, maze-walk are good examples)
- [ ] Confirm no `"question": "Hint"` placeholders remain in any IO or visual exercise
- [ ] Verify no em dashes in new hint content

🤖 Generated with [Claude Code](https://claude.com/claude-code)