### PR TITLE
Parallelize leaf concept content fetch

### DIFF
--- a/app/components/concepts/lib/useConceptDetailData.ts
+++ b/app/components/concepts/lib/useConceptDetailData.ts
@@ -71,12 +71,18 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
 
         setConcept(conceptData);
         setAncestors(ancestorData);
-        // Signal content is about to load (only relevant for leaf concepts)
-        if (!conceptData.category) {
-          setIsContentLoading(true);
-        }
         // Phase 1 done — correct layout renders with real title/breadcrumb
         setIsLoading(false);
+
+        // Kick off the leaf-concept content fetch in parallel with Phase 2 — it only
+        // depends on the slug + category flag from Phase 1, not on related/exercise data.
+        if (!conceptData.category) {
+          setIsContentLoading(true);
+          void getConceptContent(slug)
+            .then((contentHtml) => setContent(contentHtml))
+            .catch(() => setError("Failed to load concept. Please try again later."))
+            .finally(() => setIsContentLoading(false));
+        }
 
         // Phase 2: fetch the slower secondary data in the background.
         const [related, exercises] = await Promise.all([getRelatedConcepts(slug), getExercisesForConcept(slug)]);
@@ -135,12 +141,6 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
           }
         } else {
           setRelatedExercises(exercises);
-        }
-
-        if (!conceptData.category) {
-          const contentHtml = await getConceptContent(slug);
-          setContent(contentHtml);
-          setIsContentLoading(false);
         }
       } catch {
         setError("Failed to load concept. Please try again later.");

--- a/app/components/concepts/lib/useConceptDetailData.ts
+++ b/app/components/concepts/lib/useConceptDetailData.ts
@@ -51,6 +51,8 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
     const load = async () => {
       try {
         setError(null);
@@ -62,6 +64,9 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
         // This gives us the real title and breadcrumb immediately so the correct
         // skeleton renders without any intermediate wrong-layout flash.
         const [conceptData, ancestorData] = await Promise.all([getConcept(slug), getAncestors(slug)]);
+        if (cancelled) {
+          return;
+        }
 
         if (!conceptData) {
           setError("Concept not found.");
@@ -79,13 +84,29 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
         if (!conceptData.category) {
           setIsContentLoading(true);
           void getConceptContent(slug)
-            .then((contentHtml) => setContent(contentHtml))
-            .catch(() => setError("Failed to load concept. Please try again later."))
-            .finally(() => setIsContentLoading(false));
+            .then((contentHtml) => {
+              if (!cancelled) {
+                setContent(contentHtml);
+              }
+            })
+            .catch(() => {
+              if (!cancelled) {
+                setError("Failed to load concept. Please try again later.");
+              }
+            })
+            .finally(() => {
+              if (!cancelled) {
+                setIsContentLoading(false);
+              }
+            });
         }
 
         // Phase 2: fetch the slower secondary data in the background.
         const [related, exercises] = await Promise.all([getRelatedConcepts(slug), getExercisesForConcept(slug)]);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (cancelled) {
+          return;
+        }
 
         setRelatedConcepts(related);
 
@@ -95,6 +116,10 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
             fetchProjects({ per: 100 }).catch(() => ({ results: [] as ProjectData[] })),
             fetchConceptVideoData(slug)
           ]);
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (cancelled) {
+            return;
+          }
 
           // Split concept exercises into true exercises vs projects (matched by exercise_slug or slug).
           const projectByExerciseSlug = new Map<string, ProjectData>();
@@ -120,6 +145,10 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
             exerciseOnly.length > 0
               ? await fetchLessonStatusesBySlugs(exerciseOnly.map((e) => e.slug))
               : ({} as Record<string, LessonStatus>);
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (cancelled) {
+            return;
+          }
 
           const projStatuses: Record<string, ProjectStatus> = {};
           for (const project of projectsResponse.results) {
@@ -143,6 +172,9 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
           setRelatedExercises(exercises);
         }
       } catch {
+        if (cancelled) {
+          return;
+        }
         setError("Failed to load concept. Please try again later.");
         setIsLoading(false);
         setIsContentLoading(false);
@@ -150,6 +182,10 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
     };
 
     void load();
+
+    return () => {
+      cancelled = true;
+    };
   }, [slug, isAuthenticated, router]);
 
   const isConceptUnlocked = (conceptSlug: string) => !isAuthenticated || unlockedConceptSlugs.has(conceptSlug);


### PR DESCRIPTION
## Summary
- Leaf concept pages (`!conceptData.category`) used to fetch `getConceptContent(slug)` sequentially *after* Phase 2 (`getRelatedConcepts` + `getExercisesForConcept`) and the authenticated chain (`fetchUnlockedConceptSlugs` + `fetchProjects` + `fetchConceptVideoData`) all resolved — but it only depends on the slug + the `category` flag from Phase 1.
- Detach it as a `.then()` chain that fires the moment Phase 1 returns, so the article body loads alongside the related/exercise/video data instead of waiting for them.
- Same total call count per mount; just earlier and parallel. Inspired by the pattern in #509.

## Test plan
- [x] `pnpm typecheck` clean
- [x] Pre-commit hook ran the full unit suite (1556 passing, 125 suites)
- [ ] Manual: load a leaf concept page (authenticated) and confirm the three network groups now fire on the same tick after Phase 1; the prose appears without waiting for related/exercise/projects responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)