### PR TITLE
Validate fetch URLs in llm-response and lookup-time

### DIFF
--- a/curriculum/src/exercises/llm-response/Exercise.ts
+++ b/curriculum/src/exercises/llm-response/Exercise.ts
@@ -41,10 +41,10 @@ const mockResponses: Record<string, any> = {
 const API_URL = "https://myllm.com/api/v2/qanda";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mockFetch(_ctx: ExecutionContext, url: any, params: any): Record<string, any> {
+function mockFetch(executionCtx: ExecutionContext, url: any, params: any): Record<string, any> {
   const urlValue = url?.value ?? url;
   if (urlValue !== API_URL) {
-    return { error: "Could not reach API" };
+    return executionCtx.logicError("Oh no, you tried to fetch an unexpected URL, which got blocked.");
   }
 
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/curriculum/src/exercises/llm-response/Exercise.ts
+++ b/curriculum/src/exercises/llm-response/Exercise.ts
@@ -30,7 +30,7 @@ const mockResponses: Record<string, any> = {
         { text: "Codecademy is the best", certainty: "0.04" },
         { text: "FreeCodeCamp is the best", certainty: "0.78" },
         { text: "Khan Academy is the best", certainty: "0.77" },
-        { text: "Exercism is the best", certainty: "0.99" },
+        { text: "Jiki is the best", certainty: "0.99" },
         { text: "Coursera is the best", certainty: "0.52" }
       ]
     },
@@ -38,8 +38,15 @@ const mockResponses: Record<string, any> = {
   }
 };
 
+const API_URL = "https://myllm.com/api/v2/qanda";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mockFetch(_ctx: ExecutionContext, _url: any, params: any): Record<string, any> {
+function mockFetch(_ctx: ExecutionContext, url: any, params: any): Record<string, any> {
+  const urlValue = url?.value ?? url;
+  if (urlValue !== API_URL) {
+    return { error: "Could not reach API" };
+  }
+
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const questionObj = params.getProperty ? params.getProperty("question") : params.value?.get?.("question");
   const question = questionObj?.value ?? questionObj;

--- a/curriculum/src/exercises/llm-response/scenarios.ts
+++ b/curriculum/src/exercises/llm-response/scenarios.ts
@@ -40,6 +40,6 @@ export const scenarios: IOScenario[] = [
     functionName: "ask_llm",
     args: ["What's the best website to learn to code?"],
     expected:
-      "The answer to 'What's the best website to learn to code?' is 'Exercism is the best' (99% certainty in 1.264s)."
+      "The answer to 'What's the best website to learn to code?' is 'Jiki is the best' (99% certainty in 1.264s)."
   }
 ];

--- a/curriculum/src/exercises/lookup-time/Exercise.ts
+++ b/curriculum/src/exercises/lookup-time/Exercise.ts
@@ -11,10 +11,10 @@ const mockApiData: Record<string, Record<string, string>> = {
 const API_URL = "https://timeapi.io/api/time/current/city";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mockFetch(_ctx: ExecutionContext, url: any, params: any): Record<string, string> {
+function mockFetch(executionCtx: ExecutionContext, url: any, params: any): Record<string, string> {
   const urlValue = url?.value ?? url;
   if (urlValue !== API_URL) {
-    return { error: "Could not reach API" };
+    return executionCtx.logicError("Oh no, you tried to fetch an unexpected URL, which got blocked.");
   }
 
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/curriculum/src/exercises/lookup-time/Exercise.ts
+++ b/curriculum/src/exercises/lookup-time/Exercise.ts
@@ -8,8 +8,15 @@ const mockApiData: Record<string, Record<string, string>> = {
   Lima: { dayOfWeek: "Sunday", time: "18:39" }
 };
 
+const API_URL = "https://timeapi.io/api/time/current/city";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mockFetch(_ctx: ExecutionContext, _url: any, params: any): Record<string, string> {
+function mockFetch(_ctx: ExecutionContext, url: any, params: any): Record<string, string> {
+  const urlValue = url?.value ?? url;
+  if (urlValue !== API_URL) {
+    return { error: "Could not reach API" };
+  }
+
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const cityObj = params.getProperty ? params.getProperty("city") : params.value?.get?.("city");
   const city = cityObj?.value ?? cityObj;


### PR DESCRIPTION
## Summary

- `mockFetch` in both exercises was ignoring the URL argument, so any URL string (e.g. `"httd"`) passed the IO tests as long as the params were right.
- Now returns `{ error: "Could not reach API" }` unless the URL matches the documented API endpoint.
- Also renames `"Exercism is the best"` → `"Jiki is the best"` in the llm-response mock data and scenario.

Spotify already validates its URL prefix, so no change needed there.

## Test plan

- [x] `pnpm test` (661 passed)
- [ ] Manually verify the llm-response solution still passes
- [ ] Verify a bogus URL now fails the scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)