### PR TITLE
Fix invisible premium star gradient (SVGR id collision)

### DIFF
--- a/app/components/dashboard/projects-sidebar/ui/UserProfile.tsx
+++ b/app/components/dashboard/projects-sidebar/ui/UserProfile.tsx
@@ -4,8 +4,8 @@ import type { BadgeData } from "@/lib/api/badges";
 import { useDelayedLoading } from "@/lib/hooks/useDelayedLoading";
 import { showModal } from "@/lib/modal";
 import UserAvatar from "@/components/common/UserAvatar";
+import { Icon } from "@/components/ui-kit/Icon";
 import PencilIcon from "@/icons/pencil.svg";
-import PremiumStarIcon from "@/icons/premium-star.svg";
 import style from "./UserProfile.module.css";
 import { Badges } from "./UserProfile/Badges";
 import { Streak } from "./UserProfile/Streak";
@@ -62,7 +62,7 @@ export function UserProfile({ profile, badges, onBadgeRevealed, loading, isPremi
           {isPremium && (
             <div className={style.starBadge}>
               <div className={style.starTooltip}>Premium Member</div>
-              <PremiumStarIcon />
+              <Icon name="premium-star" size={17} />
             </div>
           )}
         </button>

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -53,7 +53,12 @@ const nextConfig: NextConfig = {
             loader: "@svgr/webpack",
             options: {
               svgoConfig: {
-                plugins: [{ name: "preset-default" }, { name: "removeUnusedNS" }, { name: "removeDimensions" }]
+                plugins: [
+                  { name: "preset-default", params: { overrides: { cleanupIds: false } } },
+                  { name: "prefixIds" },
+                  { name: "removeUnusedNS" },
+                  { name: "removeDimensions" }
+                ]
               }
             }
           }
@@ -103,7 +108,12 @@ const nextConfig: NextConfig = {
           loader: "@svgr/webpack",
           options: {
             svgoConfig: {
-              plugins: [{ name: "preset-default" }, { name: "removeUnusedNS" }, { name: "removeDimensions" }]
+              plugins: [
+                { name: "preset-default", params: { overrides: { cleanupIds: false } } },
+                { name: "prefixIds" },
+                { name: "removeUnusedNS" },
+                { name: "removeDimensions" }
+              ]
             }
           }
         }


### PR DESCRIPTION
## Summary
- The premium-star icon on the dashboard profile card rendered but its gradient was invisible.
- Cause: `svgo`'s `cleanupIds` (part of `preset-default`) minifies SVG IDs to short names like `a`. With multiple icons containing `<defs>` in the codebase (`globe.svg`, `jiki-logo.svg`, `jiki-logo-collapsed.svg`, `premium-star.svg`, `readonly-lock.svg`), the minified IDs collide once they're inlined into the same DOM, so `fill="url(#…)"` references resolve to the wrong element.
- Fix: disable `cleanupIds` minification and add `prefixIds` so each SVG's IDs are namespaced per source file.
- Drive-by: swap the inlined `<PremiumStarIcon />` in `UserProfile.tsx` for the standard `<Icon name="premium-star" size={17} />` for consistency.

## Test plan
- [ ] Restart the dev server (SVGR/SVGO config change).
- [ ] Visit the dashboard as a premium user — premium star should render with its purple→blue gradient.
- [ ] Visit `/dev/user-profile-card` — premium variant still renders correctly.
- [ ] Check other icons with `<defs>` (Jiki logo, collapsed logo, globe, readonly-lock) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)