### PR TITLE
Restyle test status icons and lint warning layout

### DIFF
--- a/app/components/coding-exercise/CodingExercise.module.css
+++ b/app/components/coding-exercise/CodingExercise.module.css
@@ -450,19 +450,24 @@
 }
 
 .testStatusIcon {
-    position: absolute;
-    top: 18px;
-    right: 16px;
     width: 24px;
     height: 24px;
+    flex-shrink: 0;
 }
 
 .testDescription.statePassed .testStatusIcon {
-    color: var(--color-green-300);
+    color: var(--color-green-600);
+    opacity: 0.5;
 }
 
 .testDescription.stateFailed .testStatusIcon {
-    color: var(--color-red-300);
+    color: var(--color-red-600);
+    opacity: 0.5;
+}
+
+.testDescription.stateLintWarning .testStatusIcon {
+    color: var(--color-orange-600);
+    opacity: 0.5;
 }
 
 .testDescription::-webkit-scrollbar {
@@ -491,11 +496,21 @@
 }
 
 .instructionLabel {
-    display: block;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     font-size: 17px;
     font-weight: 600;
     margin-bottom: 6px;
     color: var(--color-gray-700);
+}
+
+.instructionLabel > span:first-child {
+    margin-right: 20px;
+}
+
+.instructionLabel .testStatusIcon {
+    margin-left: auto;
 }
 
 /* Active State (Blue) */

--- a/app/components/coding-exercise/ui/test-results-view/ScenarioHeader.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/ScenarioHeader.tsx
@@ -1,10 +1,22 @@
+import type { ReactNode } from "react";
 import { marked } from "marked";
 import styles from "../../CodingExercise.module.css";
 
-export function ScenarioHeader({ name, description }: { name: string; description?: string }) {
+export function ScenarioHeader({
+  name,
+  description,
+  statusIcon
+}: {
+  name: string;
+  description?: string;
+  statusIcon?: ReactNode;
+}) {
   return (
     <>
-      <span className={styles.instructionLabel}>{name}</span>
+      <span className={styles.instructionLabel}>
+        <span>{name}</span>
+        {statusIcon}
+      </span>
       {description && (
         <div className="my-8">
           <div

--- a/app/components/coding-exercise/ui/test-results-view/io/IOInspectedView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/io/IOInspectedView.tsx
@@ -94,9 +94,6 @@ function IOInspectedResultView() {
   return (
     <div data-ci="inspected-test-result-view" className={styles.leftColumnContent}>
       <div className={assembleClassNames(styles.testDescription, statusClass)}>
-        {currentTest.status === "pass" && <CheckCircleIcon className={styles.testStatusIcon} />}
-        {currentTest.status === "fail" && <CrossCircleIcon className={styles.testStatusIcon} />}
-        <ScenarioHeader name={currentTest.name} description={scenario.description} />
         {currentTest.status === "lint_warning" && (
           <div className={tableStyles.lintWarningMessage}>
             <ExclamationCircleIcon className={tableStyles.lintWarningIcon} />
@@ -106,6 +103,19 @@ function IOInspectedResultView() {
             </span>
           </div>
         )}
+        <ScenarioHeader
+          name={currentTest.name}
+          description={scenario.description}
+          statusIcon={
+            currentTest.status === "pass" ? (
+              <CheckCircleIcon className={styles.testStatusIcon} />
+            ) : currentTest.status === "fail" ? (
+              <CrossCircleIcon className={styles.testStatusIcon} />
+            ) : currentTest.status === "lint_warning" ? (
+              <CheckCircleIcon className={styles.testStatusIcon} />
+            ) : null
+          }
+        />
         {firstExpect ? <IOTestResultView expect={firstExpect} language={language} /> : null}
       </div>
     </div>

--- a/app/components/coding-exercise/ui/test-results-view/io/IOScenarioTable.module.css
+++ b/app/components/coding-exercise/ui/test-results-view/io/IOScenarioTable.module.css
@@ -56,7 +56,6 @@
     display: inline-flex;
     align-items: flex-start;
     gap: 8px;
-    max-width: 470px;
     margin-bottom: 14px;
     border: 1px solid var(--color-orange-600);
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- Darken passed/failed test status icons (-600 colors at opacity 0.5)
- Add orange status icon for `lint_warning` state (reuses check icon)
- Move lint warning message above the scenario name
- Render the status icon inline within `instructionLabel` (flex row) instead of being absolutely positioned
- Remove `max-width` on lint warning message

## Test plan
- [ ] Visually verify passing test scenario shows muted green check icon next to title
- [ ] Visually verify failing scenario shows muted red cross icon next to title
- [ ] Visually verify lint_warning scenario shows orange check icon next to title and warning message above title
- [ ] Confirm icon aligns with title row across all states

🤖 Generated with [Claude Code](https://claude.com/claude-code)