### PR TITLE
Disable next/image optimization on Cloudflare Workers

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
     reactCompiler: true
   },
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Summary
- The `/_next/image` optimizer endpoint isn't supported on the Cloudflare Workers runtime, so production requests like `/_next/image?url=/static/images/graphics/jiki-wakeup.png` return 404.
- Set `images.unoptimized: true` so `next/image` serves the source files directly from `/static/*`.

## Test plan
- [ ] Deploy and confirm `https://jiki.io/static/images/graphics/jiki-wakeup.png` loads via the `LoadingJiki` component (no `/_next/image` request)
- [ ] Spot-check other `next/image` usages still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)