### PR TITLE
Use Jiki logo SVG on auth page RHS

### DIFF
--- a/app/components/ui/AuthLayout.module.css
+++ b/app/components/ui/AuthLayout.module.css
@@ -15,12 +15,12 @@
 }
 
 .logoLarge {
-    font-size: 72px;
-    font-weight: 500;
+    height: 96px;
+    width: auto;
+    color: white;
     z-index: var(--z-index-base);
-    text-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+    filter: drop-shadow(0 4px 20px rgba(0, 0, 0, 0.2));
     margin-bottom: 40px;
-    line-height: 1;
 }
 
 .tagline {
@@ -74,7 +74,7 @@
     }
 
     .logoLarge {
-        font-size: 48px;
+        height: 64px;
     }
 
     .tagline {

--- a/app/components/ui/AuthLayout.tsx
+++ b/app/components/ui/AuthLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import JikiLogo from "@/icons/jiki-logo.svg";
 import styles from "./AuthLayout.module.css";
 
 interface AuthLayoutProps {
@@ -14,7 +15,7 @@ export function AuthLayout({ children }: AuthLayoutProps) {
 
       {/* Right Side - Gradient Background */}
       <div className={styles.rightSide}>
-        <div className={styles.logoLarge}>Jiki</div>
+        <JikiLogo className={styles.logoLarge} />
         <h1 className={styles.tagline}>Your coding journey starts here</h1>
         <p className={styles.description}>
           Join millions of learners transforming their careers through hands-on coding practice.


### PR DESCRIPTION
## Summary
- Replace the plain "Jiki" text on the auth pages' right-side panel with the `JikiLogo` SVG.
- Logo renders in white via `currentColor`; purple accent is preserved.

## Test plan
- [ ] Visit `/auth/login`, `/auth/signup`, etc. and confirm the RHS shows the Jiki logo in white.
- [ ] Check mobile breakpoint (≤968px) — logo scales down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)