### PR TITLE
Suffix authentication cookie name with NODE_ENV

### DIFF
--- a/app/lib/auth/cookie-config.ts
+++ b/app/lib/auth/cookie-config.ts
@@ -1,4 +1,7 @@
 // Cookie name for authenticated users (set by Rails on login)
 // This cookie is only present for logged-in users, not a generic session cookie
 // Suffixed with the environment to avoid collisions between envs sharing a domain.
-export const AUTHENTICATION_COOKIE_NAME = `jiki_user_id_${process.env.NODE_ENV}`;
+// All non-production envs (development, test) resolve to "development" so the
+// Playwright test process and the dev server it runs against agree on the name.
+const env = process.env.NODE_ENV === "production" ? "production" : "development";
+export const AUTHENTICATION_COOKIE_NAME = `jiki_user_id_${env}`;

--- a/app/lib/auth/cookie-config.ts
+++ b/app/lib/auth/cookie-config.ts
@@ -1,3 +1,4 @@
 // Cookie name for authenticated users (set by Rails on login)
 // This cookie is only present for logged-in users, not a generic session cookie
-export const AUTHENTICATION_COOKIE_NAME = "jiki_user_id";
+// Suffixed with the environment to avoid collisions between envs sharing a domain.
+export const AUTHENTICATION_COOKIE_NAME = `jiki_user_id_${process.env.NODE_ENV}`;


### PR DESCRIPTION
## Summary
- Suffix `AUTHENTICATION_COOKIE_NAME` with `process.env.NODE_ENV` to prevent cookie collisions between environments that share a domain.

## Test plan
- [ ] Verify logged-in users still authenticate correctly in each environment
- [ ] Confirm Rails sets the matching env-suffixed cookie name on login