### PR TITLE
Add product analytics for premium funnel

### DIFF
--- a/app/app/(app)/build/[slug]/EpisodeCard.tsx
+++ b/app/app/(app)/build/[slug]/EpisodeCard.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import Link from "next/link";
 import LockIcon from "@/icons/lock.svg";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
@@ -54,7 +53,7 @@ export function EpisodeCard({ series, episode, watchedPercentage }: EpisodeCardP
         type="button"
         className={`${styles.card} ${styles.cardPremium}`}
         onClick={() =>
-          showPremiumUpgradeModal(MODAL_TRIGGERS.LOCKED_EPISODE, {
+          showPremiumUpgradeModal("locked_episode", {
             contextType: "Episode",
             contextId: episode.slug
           })

--- a/app/app/(app)/build/[slug]/EpisodeCard.tsx
+++ b/app/app/(app)/build/[slug]/EpisodeCard.tsx
@@ -55,7 +55,7 @@ export function EpisodeCard({ series, episode, watchedPercentage }: EpisodeCardP
         onClick={() =>
           showPremiumUpgradeModal("locked_episode", {
             contextType: "episode",
-            contextSlug: episode.uuid
+            contextUuid: episode.uuid
           })
         }
       >

--- a/app/app/(app)/build/[slug]/EpisodeCard.tsx
+++ b/app/app/(app)/build/[slug]/EpisodeCard.tsx
@@ -3,9 +3,9 @@
 import Image from "next/image";
 import Link from "next/link";
 import LockIcon from "@/icons/lock.svg";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
 import type { BuildEpisodeMeta, BuildSeriesMeta } from "@/lib/content/types";
 import styles from "./SeriesPage.module.css";
@@ -54,12 +54,10 @@ export function EpisodeCard({ series, episode, watchedPercentage }: EpisodeCardP
         type="button"
         className={`${styles.card} ${styles.cardPremium}`}
         onClick={() =>
-          showModal(
-            "premium-upgrade-modal",
-            {},
-            premiumModalStyles.premiumModalOverlay,
-            premiumModalStyles.premiumModalWidth
-          )
+          showPremiumUpgradeModal(MODAL_TRIGGERS.LOCKED_EPISODE, {
+            contextType: "Episode",
+            contextId: episode.slug
+          })
         }
       >
         {inner}

--- a/app/app/(app)/build/[slug]/EpisodeCard.tsx
+++ b/app/app/(app)/build/[slug]/EpisodeCard.tsx
@@ -54,8 +54,8 @@ export function EpisodeCard({ series, episode, watchedPercentage }: EpisodeCardP
         className={`${styles.card} ${styles.cardPremium}`}
         onClick={() =>
           showPremiumUpgradeModal("locked_episode", {
-            contextType: "Episode",
-            contextId: episode.slug
+            contextType: "episode",
+            contextSlug: episode.uuid
           })
         }
       >

--- a/app/app/(app)/build/[slug]/SeriesPage.tsx
+++ b/app/app/(app)/build/[slug]/SeriesPage.tsx
@@ -3,9 +3,14 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { fetchUserVideos } from "@/lib/api/user-videos";
+import { BLOCKED_FEATURES, trackEvent } from "@/lib/analytics";
+import { useAuthStore } from "@/lib/auth/authStore";
+import { tierIncludes } from "@/lib/pricing";
 import type { BuildEpisodeMeta, BuildSeriesMeta } from "@/lib/content/types";
 import { EpisodeCard } from "./EpisodeCard";
 import styles from "./SeriesPage.module.css";
+
+const WATCHED_THRESHOLD = 95;
 
 interface SeriesPageProps {
   series: BuildSeriesMeta;
@@ -15,6 +20,9 @@ interface SeriesPageProps {
 export function SeriesPage({ series, episodes }: SeriesPageProps) {
   const sorted = [...episodes].sort((a, b) => a.order - b.order);
   const [progressByUuid, setProgressByUuid] = useState<Record<string, number>>({});
+  const [progressLoaded, setProgressLoaded] = useState(false);
+  const user = useAuthStore((state) => state.user);
+  const userIsPremium = !!user && tierIncludes(user.membership_type, "premium");
 
   useEffect(() => {
     let cancelled = false;
@@ -27,11 +35,32 @@ export function SeriesPage({ series, episodes }: SeriesPageProps) {
         map[video.uuid] = video.watched_percentage;
       }
       setProgressByUuid(map);
+      setProgressLoaded(true);
     });
     return () => {
       cancelled = true;
     };
   }, []);
+
+  // If a free user has watched all the free episodes in this series and only
+  // premium ones remain, the page is effectively a paywall for them. Wait for
+  // progress to load so we don't false-positive before we know what's watched.
+  useEffect(() => {
+    if (!progressLoaded || userIsPremium) return;
+    const remainingFree = episodes.filter(
+      (ep) => !ep.premium && (progressByUuid[ep.uuid] ?? 0) < WATCHED_THRESHOLD
+    );
+    const remainingPremium = episodes.filter(
+      (ep) => ep.premium && (progressByUuid[ep.uuid] ?? 0) < WATCHED_THRESHOLD
+    );
+    if (remainingFree.length === 0 && remainingPremium.length > 0) {
+      trackEvent("premium_feature_blocked", {
+        feature: BLOCKED_FEATURES.BUILD_PAGE_ALL_LOCKED,
+        context_type: "BuildSeries",
+        context_id: series.slug
+      });
+    }
+  }, [progressLoaded, userIsPremium, episodes, progressByUuid, series.slug]);
 
   return (
     <div className={styles.wrapper}>

--- a/app/app/(app)/build/[slug]/SeriesPage.tsx
+++ b/app/app/(app)/build/[slug]/SeriesPage.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { fetchUserVideos } from "@/lib/api/user-videos";
-import { BLOCKED_FEATURES, trackEvent } from "@/lib/analytics";
+import { trackEvent } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { tierIncludes } from "@/lib/pricing";
 import type { BuildEpisodeMeta, BuildSeriesMeta } from "@/lib/content/types";
@@ -55,7 +55,7 @@ export function SeriesPage({ series, episodes }: SeriesPageProps) {
     );
     if (remainingFree.length === 0 && remainingPremium.length > 0) {
       trackEvent("premium_feature_blocked", {
-        feature: BLOCKED_FEATURES.BUILD_PAGE_ALL_LOCKED,
+        feature: "build_page_all_locked",
         context_type: "BuildSeries",
         context_id: series.slug
       });

--- a/app/app/(app)/build/[slug]/SeriesPage.tsx
+++ b/app/app/(app)/build/[slug]/SeriesPage.tsx
@@ -56,8 +56,8 @@ export function SeriesPage({ series, episodes }: SeriesPageProps) {
     if (remainingFree.length === 0 && remainingPremium.length > 0) {
       trackEvent("premium_feature_blocked", {
         feature: "build_page_all_locked",
-        context_type: "BuildSeries",
-        context_id: series.slug
+        context_type: "build_series",
+        context_slug: series.slug
       });
     }
   }, [progressLoaded, userIsPremium, episodes, progressByUuid, series.slug]);

--- a/app/app/(app)/projects/PremiumProjectCard.tsx
+++ b/app/app/(app)/projects/PremiumProjectCard.tsx
@@ -1,8 +1,8 @@
 import { type ProjectData } from "@/lib/api/projects";
 import { ProjectIcon } from "@/components/icons/ProjectIcon";
 import LockIcon from "@/icons/lock.svg";
-import { showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./ProjectCard.module.css";
 
 interface PremiumProjectCardProps {
@@ -14,12 +14,10 @@ interface PremiumProjectCardProps {
 
 export function PremiumProjectCard({ project }: PremiumProjectCardProps) {
   const handleClick = () => {
-    showModal(
-      "premium-upgrade-modal",
-      {},
-      premiumModalStyles.premiumModalOverlay,
-      premiumModalStyles.premiumModalWidth
-    );
+    showPremiumUpgradeModal(MODAL_TRIGGERS.LOCKED_PROJECT, {
+      contextType: "Project",
+      contextId: project.slug
+    });
   };
 
   return (

--- a/app/app/(app)/projects/PremiumProjectCard.tsx
+++ b/app/app/(app)/projects/PremiumProjectCard.tsx
@@ -1,7 +1,6 @@
 import { type ProjectData } from "@/lib/api/projects";
 import { ProjectIcon } from "@/components/icons/ProjectIcon";
 import LockIcon from "@/icons/lock.svg";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./ProjectCard.module.css";
 
@@ -14,7 +13,7 @@ interface PremiumProjectCardProps {
 
 export function PremiumProjectCard({ project }: PremiumProjectCardProps) {
   const handleClick = () => {
-    showPremiumUpgradeModal(MODAL_TRIGGERS.LOCKED_PROJECT, {
+    showPremiumUpgradeModal("locked_project", {
       contextType: "Project",
       contextId: project.slug
     });

--- a/app/app/(app)/projects/PremiumProjectCard.tsx
+++ b/app/app/(app)/projects/PremiumProjectCard.tsx
@@ -14,8 +14,8 @@ interface PremiumProjectCardProps {
 export function PremiumProjectCard({ project }: PremiumProjectCardProps) {
   const handleClick = () => {
     showPremiumUpgradeModal("locked_project", {
-      contextType: "Project",
-      contextId: project.slug
+      contextType: "project",
+      contextSlug: project.slug
     });
   };
 

--- a/app/app/(app)/projects/ProjectsContent.tsx
+++ b/app/app/(app)/projects/ProjectsContent.tsx
@@ -18,7 +18,7 @@ import { ProjectCardsLoadingSkeleton } from "./ProjectCardSkeleton";
 import { useDelayedLoading } from "@/lib/hooks/useDelayedLoading";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { tierIncludes } from "@/lib/pricing";
-import { BLOCKED_FEATURES, trackEvent } from "@/lib/analytics";
+import { trackEvent } from "@/lib/analytics";
 
 const tabs: TabItem[] = [
   { id: "all", label: "All", icon: <AllIcon />, color: "blue" },
@@ -82,7 +82,7 @@ export function ProjectsContent() {
   // we can measure passive exposure to the paywall, not just clicks.
   useEffect(() => {
     if (projectsLoading || projectsError || isPremium || projects.length === 0) return;
-    trackEvent("premium_feature_blocked", { feature: BLOCKED_FEATURES.PROJECTS_PAGE });
+    trackEvent("premium_feature_blocked", { feature: "projects_page" });
   }, [projectsLoading, projectsError, isPremium, projects.length]);
 
   const renderContent = () => {

--- a/app/app/(app)/projects/ProjectsContent.tsx
+++ b/app/app/(app)/projects/ProjectsContent.tsx
@@ -18,6 +18,7 @@ import { ProjectCardsLoadingSkeleton } from "./ProjectCardSkeleton";
 import { useDelayedLoading } from "@/lib/hooks/useDelayedLoading";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { tierIncludes } from "@/lib/pricing";
+import { BLOCKED_FEATURES, trackEvent } from "@/lib/analytics";
 
 const tabs: TabItem[] = [
   { id: "all", label: "All", icon: <AllIcon />, color: "blue" },
@@ -75,6 +76,14 @@ export function ProjectsContent() {
 
     void loadProjects();
   }, []);
+
+  // Free users see the projects page as a wall of locked premium cards.
+  // Fire premium_feature_blocked once per page view (after data loads) so
+  // we can measure passive exposure to the paywall, not just clicks.
+  useEffect(() => {
+    if (projectsLoading || projectsError || isPremium || projects.length === 0) return;
+    trackEvent("premium_feature_blocked", { feature: BLOCKED_FEATURES.PROJECTS_PAGE });
+  }, [projectsLoading, projectsError, isPremium, projects.length]);
 
   const renderContent = () => {
     if (showSkeleton) {

--- a/app/app/dev/premium-upgrade-modal-test/page.tsx
+++ b/app/app/dev/premium-upgrade-modal-test/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 
 export default function PremiumUpgradeModalTest() {
   const handleShowModal = () => {
-    showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_NAV, {
+    showPremiumUpgradeModal("upgrade_cta_nav", {
       onSuccess: () => {
         console.debug("Upgrade successful");
       },

--- a/app/app/dev/premium-upgrade-modal-test/page.tsx
+++ b/app/app/dev/premium-upgrade-modal-test/page.tsx
@@ -1,23 +1,18 @@
 "use client";
 
-import { showModal } from "@/lib/modal";
-import styles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 
 export default function PremiumUpgradeModalTest() {
   const handleShowModal = () => {
-    showModal(
-      "premium-upgrade-modal",
-      {
-        onSuccess: () => {
-          console.debug("Upgrade successful");
-        },
-        onCancel: () => {
-          console.debug("Upgrade cancelled");
-        }
+    showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_NAV, {
+      onSuccess: () => {
+        console.debug("Upgrade successful");
       },
-      styles.premiumModalOverlay,
-      styles.premiumModalWidth
-    );
+      onCancel: () => {
+        console.debug("Upgrade cancelled");
+      }
+    });
   };
 
   return (

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,3 +1,4 @@
+import { AttributionCapture } from "@/components/AttributionCapture";
 import { CheckoutReturnHandler } from "@/components/checkout/CheckoutReturnHandler";
 import { GlobalErrorHandler } from "@/components/GlobalErrorHandler";
 import { ToasterProvider } from "@/components/toaster-config";
@@ -41,6 +42,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${poppins.variable} ${sourceCodePro.variable} ${baloo2.variable} antialiased ui-body`}>
         <GlobalErrorHandler />
+        <AttributionCapture />
         <ServerAuthProvider>
           <ThemeProvider>
             <main className="w-full">{children}</main>

--- a/app/components/AttributionCapture.tsx
+++ b/app/components/AttributionCapture.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { captureAttribution } from "@/lib/attribution";
+
+/**
+ * Mount-only side effect: records first-touch attribution.
+ * Must run before any OAuth redirect (Google clobbers document.referrer),
+ * so this lives in the root layout to fire on the very first page mount.
+ */
+export function AttributionCapture() {
+  useEffect(() => {
+    captureAttribution();
+  }, []);
+  return null;
+}

--- a/app/components/auth/SignupForm.tsx
+++ b/app/components/auth/SignupForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ApiError } from "@/lib/api/client";
+import { readAttribution } from "@/lib/attribution";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { useAuth } from "@/lib/auth/useAuth";
 import { buildUrlWithReturnTo } from "@/lib/auth/return-to";
@@ -56,7 +57,8 @@ export function SignupForm() {
       const user = await signup({
         email,
         password,
-        password_confirmation: password
+        password_confirmation: password,
+        attribution: readAttribution()
       });
 
       if (user.email_confirmed) {

--- a/app/components/build-episode/BuildEpisodeVideo.tsx
+++ b/app/components/build-episode/BuildEpisodeVideo.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { CloseButton } from "@/components/ui-kit";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
 import type { BuildVideoProvider } from "@/lib/content/types";
-import { showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
 import MuxPlayer from "@mux/mux-player-react";
 import { useRouter } from "next/navigation";
@@ -38,14 +38,12 @@ export default function BuildEpisodeVideo({
     if (isAuthLoading || !isLocked) {
       return;
     }
-    showModal(
-      "premium-upgrade-modal",
-      {},
-      premiumModalStyles.premiumModalOverlay,
-      premiumModalStyles.premiumModalWidth
-    );
+    showPremiumUpgradeModal(MODAL_TRIGGERS.LOCKED_EPISODE_VIDEO, {
+      contextType: "Episode",
+      contextId: uuid
+    });
     router.replace(`/build/${seriesSlug}`);
-  }, [isAuthLoading, isLocked, router, seriesSlug]);
+  }, [isAuthLoading, isLocked, router, seriesSlug, uuid]);
 
   const [isReady, setIsReady] = useState(false);
   const {

--- a/app/components/build-episode/BuildEpisodeVideo.tsx
+++ b/app/components/build-episode/BuildEpisodeVideo.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { CloseButton } from "@/components/ui-kit";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
 import type { BuildVideoProvider } from "@/lib/content/types";
 import { showPremiumUpgradeModal } from "@/lib/modal";
@@ -38,7 +37,7 @@ export default function BuildEpisodeVideo({
     if (isAuthLoading || !isLocked) {
       return;
     }
-    showPremiumUpgradeModal(MODAL_TRIGGERS.LOCKED_EPISODE_VIDEO, {
+    showPremiumUpgradeModal("locked_episode_video", {
       contextType: "Episode",
       contextId: uuid
     });

--- a/app/components/build-episode/BuildEpisodeVideo.tsx
+++ b/app/components/build-episode/BuildEpisodeVideo.tsx
@@ -39,7 +39,7 @@ export default function BuildEpisodeVideo({
     }
     showPremiumUpgradeModal("locked_episode_video", {
       contextType: "episode",
-      contextSlug: uuid
+      contextUuid: uuid
     });
     router.replace(`/build/${seriesSlug}`);
   }, [isAuthLoading, isLocked, router, seriesSlug, uuid]);

--- a/app/components/build-episode/BuildEpisodeVideo.tsx
+++ b/app/components/build-episode/BuildEpisodeVideo.tsx
@@ -38,8 +38,8 @@ export default function BuildEpisodeVideo({
       return;
     }
     showPremiumUpgradeModal("locked_episode_video", {
-      contextType: "Episode",
-      contextId: uuid
+      contextType: "episode",
+      contextSlug: uuid
     });
     router.replace(`/build/${seriesSlug}`);
   }, [isAuthLoading, isLocked, router, seriesSlug, uuid]);

--- a/app/components/coding-exercise/lib/chatErrorHandler.ts
+++ b/app/components/coding-exercise/lib/chatErrorHandler.ts
@@ -1,10 +1,16 @@
 import { ChatApiError, ChatTokenExpiredError } from "./chatApi";
-import { ChatTokenError } from "./chatTokenApi";
+import { ChatTokenError, ChatTokenInvalidCaptchaError } from "./chatTokenApi";
 
 export function formatChatError(error: unknown): string {
   // ChatTokenExpiredError should rarely show (auto-retry handles it)
   if (error instanceof ChatTokenExpiredError) {
     return "Session expired. Please try again.";
+  }
+
+  // Captcha failure — distinct from access-denied so the user is told to
+  // retry rather than nudged to upgrade.
+  if (error instanceof ChatTokenInvalidCaptchaError) {
+    return "Verification failed. Please try again.";
   }
 
   // ChatTokenError - errors fetching the token

--- a/app/components/coding-exercise/lib/chatTokenApi.ts
+++ b/app/components/coding-exercise/lib/chatTokenApi.ts
@@ -12,6 +12,26 @@ export class ChatTokenError extends Error {
   }
 }
 
+// 403 with error.type === "access_denied": user isn't entitled to chat
+// (free user past their free conversation, premium past fair-use, etc.).
+// Distinct from ChatTokenInvalidCaptchaError so analytics/UX can branch.
+export class ChatTokenAccessDeniedError extends ChatTokenError {
+  constructor(message: string, data?: unknown) {
+    super(message, 403, data);
+    this.name = "ChatTokenAccessDeniedError";
+  }
+}
+
+// 403 with error.type === "invalid_captcha": Cloudflare Turnstile token
+// failed verification. Infra failure, not a product event — never fire
+// premium_modal_shown on this path or the funnel data is corrupted.
+export class ChatTokenInvalidCaptchaError extends ChatTokenError {
+  constructor(message: string, data?: unknown) {
+    super(message, 403, data);
+    this.name = "ChatTokenInvalidCaptchaError";
+  }
+}
+
 export interface FetchChatTokenParams {
   context: ExerciseContext;
 }
@@ -46,9 +66,36 @@ export async function fetchChatToken(params: FetchChatTokenParams): Promise<stri
       errorData = { error: "unknown", message: "Failed to parse error response" };
     }
 
+    if (response.status === 403) {
+      const errorType = extractErrorType(errorData);
+      const message = extractErrorMessage(errorData) ?? `HTTP 403: ${response.statusText}`;
+      if (errorType === "access_denied") {
+        throw new ChatTokenAccessDeniedError(message, errorData);
+      }
+      if (errorType === "invalid_captcha") {
+        throw new ChatTokenInvalidCaptchaError(message, errorData);
+      }
+    }
+
     throw new ChatTokenError(`HTTP ${response.status}: ${response.statusText}`, response.status, errorData);
   }
 
   const data = (await response.json()) as ChatTokenResponse;
   return data.token;
+}
+
+function extractErrorType(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const errorField = (data as { error?: unknown }).error;
+  if (typeof errorField !== "object" || errorField === null) return undefined;
+  const type = (errorField as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+function extractErrorMessage(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const errorField = (data as { error?: unknown }).error;
+  if (typeof errorField !== "object" || errorField === null) return undefined;
+  const message = (errorField as { message?: unknown }).message;
+  return typeof message === "string" ? message : undefined;
 }

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -1,5 +1,4 @@
 import { useCallback, useRef } from "react";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import { useChatState } from "./useChatState";
 import { useChatContext } from "./useChatContext";
@@ -121,7 +120,7 @@ export function useChat(orchestrator: Orchestrator) {
         // open the upgrade modal. invalid_captcha is an infra failure and
         // must NOT fire the analytics event (would pollute the funnel).
         if (error instanceof ChatTokenAccessDeniedError) {
-          showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_SEND_MESSAGE, {
+          showPremiumUpgradeModal("assistant_send_message", {
             contextType: context.context.type === "project" ? "Project" : "Lesson",
             contextId: context.context.slug
           });

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -121,8 +121,8 @@ export function useChat(orchestrator: Orchestrator) {
         // must NOT fire the analytics event (would pollute the funnel).
         if (error instanceof ChatTokenAccessDeniedError) {
           showPremiumUpgradeModal("assistant_send_message", {
-            contextType: context.context.type === "project" ? "Project" : "Lesson",
-            contextId: context.context.slug
+            contextType: context.context.type,
+            contextSlug: context.context.slug
           });
           chatState.setStatus("idle");
           return;

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -1,9 +1,11 @@
 import { useCallback, useRef } from "react";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import { useChatState } from "./useChatState";
 import { useChatContext } from "./useChatContext";
 import { sendChatMessage, ChatTokenExpiredError } from "./chatApi";
 import { saveConversation } from "./conversationApi";
-import { fetchChatToken } from "./chatTokenApi";
+import { ChatTokenAccessDeniedError, fetchChatToken } from "./chatTokenApi";
 import { formatChatError } from "./chatErrorHandler";
 import type Orchestrator from "./Orchestrator";
 
@@ -114,12 +116,25 @@ export function useChat(orchestrator: Orchestrator) {
           }
         }
       } catch (error) {
+        // 403 access_denied: user clicked send while not entitled to chat.
+        // This is the high-intent moment — fire premium_modal_shown and
+        // open the upgrade modal. invalid_captcha is an infra failure and
+        // must NOT fire the analytics event (would pollute the funnel).
+        if (error instanceof ChatTokenAccessDeniedError) {
+          showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_SEND_MESSAGE, {
+            contextType: context.context.type === "project" ? "Project" : "Lesson",
+            contextId: context.context.slug
+          });
+          chatState.setStatus("idle");
+          return;
+        }
+
         const errorMessage = formatChatError(error);
         chatState.setError(errorMessage);
         chatState.setStatus("error");
       }
     },
-    [chatState, ensureValidToken, performChatRequest]
+    [chatState, ensureValidToken, performChatRequest, context.context.type, context.context.slug]
   );
 
   const clearConversation = useCallback(() => {

--- a/app/components/coding-exercise/ui/ChatPanelStates.tsx
+++ b/app/components/coding-exercise/ui/ChatPanelStates.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useEffect } from "react";
+import { BLOCKED_FEATURES, trackEvent } from "@/lib/analytics";
 import type { ChatMessage } from "../lib/chat-types";
 import {
   FreeUserCanStart,
@@ -24,7 +28,22 @@ interface ChatPanelStatesProps {
 
 // Each state component renders its own heading/intro, so no shared ChatHeader here
 // (that belongs to the in-progress conversation view).
+const BLOCKED_FREE_STATES = new Set<ChatPanelState>([
+  "free-user-can-start",
+  "free-user-limit-reached",
+  "free-user-limit-reached-with-history"
+]);
+
 export function ChatPanelStates({ chatState, conversation, onSendMessage, onStartChat }: ChatPanelStatesProps) {
+  // Fire `premium_feature_blocked` when a free user lands on the assistant
+  // tab in any blocked state. Re-fires if they transition between blocked
+  // states (e.g. start chat → exhaust limit) — that's a distinct paywall view.
+  useEffect(() => {
+    if (BLOCKED_FREE_STATES.has(chatState)) {
+      trackEvent("premium_feature_blocked", { feature: BLOCKED_FEATURES.ASSISTANT_TAB });
+    }
+  }, [chatState]);
+
   switch (chatState) {
     case "free-user-can-start":
       return <FreeUserCanStart onStartChat={onStartChat} />;

--- a/app/components/coding-exercise/ui/ChatPanelStates.tsx
+++ b/app/components/coding-exercise/ui/ChatPanelStates.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { BLOCKED_FEATURES, trackEvent } from "@/lib/analytics";
+import { trackEvent } from "@/lib/analytics";
 import type { ChatMessage } from "../lib/chat-types";
 import {
   FreeUserCanStart,
@@ -40,7 +40,7 @@ export function ChatPanelStates({ chatState, conversation, onSendMessage, onStar
   // states (e.g. start chat → exhaust limit) — that's a distinct paywall view.
   useEffect(() => {
     if (BLOCKED_FREE_STATES.has(chatState)) {
-      trackEvent("premium_feature_blocked", { feature: BLOCKED_FEATURES.ASSISTANT_TAB });
+      trackEvent("premium_feature_blocked", { feature: "assistant_tab" });
     }
   }, [chatState]);
 

--- a/app/components/coding-exercise/ui/chat-panel-states/FreeUserCanStart.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/FreeUserCanStart.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import ChatBubbleIcon from "@/icons/chat-bubble.svg";
 import CheckCircleFilledIcon from "@/icons/check-circle-filled.svg";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { showConfirmation, showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./FreeUserCanStart.module.css";
 
@@ -24,7 +23,7 @@ export default function FreeUserCanStart({ onStartChat }: FreeUserCanStartProps)
   };
 
   const handleUpgradeClick = () => {
-    showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_TAB_OPENED);
+    showPremiumUpgradeModal("assistant_tab_opened");
   };
 
   return (

--- a/app/components/coding-exercise/ui/chat-panel-states/FreeUserCanStart.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/FreeUserCanStart.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import ChatBubbleIcon from "@/icons/chat-bubble.svg";
 import CheckCircleFilledIcon from "@/icons/check-circle-filled.svg";
-import { showConfirmation, showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
+import { showConfirmation, showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./FreeUserCanStart.module.css";
 
 interface FreeUserCanStartProps {
@@ -24,12 +24,7 @@ export default function FreeUserCanStart({ onStartChat }: FreeUserCanStartProps)
   };
 
   const handleUpgradeClick = () => {
-    showModal(
-      "premium-upgrade-modal",
-      {},
-      premiumModalStyles.premiumModalOverlay,
-      premiumModalStyles.premiumModalWidth
-    );
+    showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_TAB_OPENED);
   };
 
   return (

--- a/app/components/coding-exercise/ui/chat-panel-states/FreeUserLimitReached.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/FreeUserLimitReached.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import ChatBubbleIcon from "@/icons/chat-bubble.svg";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./FreeUserCanStart.module.css";
 
@@ -8,7 +7,7 @@ import styles from "./FreeUserCanStart.module.css";
 // They've used their free conversation limit
 export default function FreeUserLimitReached() {
   const handleUpgradeClick = () => {
-    showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_LIMIT_REACHED);
+    showPremiumUpgradeModal("assistant_limit_reached");
   };
 
   return (

--- a/app/components/coding-exercise/ui/chat-panel-states/FreeUserLimitReached.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/FreeUserLimitReached.tsx
@@ -1,19 +1,14 @@
 import Image from "next/image";
 import ChatBubbleIcon from "@/icons/chat-bubble.svg";
-import { showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./FreeUserCanStart.module.css";
 
 // Non-premium user, conversation not allowed, no existing conversation
 // They've used their free conversation limit
 export default function FreeUserLimitReached() {
   const handleUpgradeClick = () => {
-    showModal(
-      "premium-upgrade-modal",
-      {},
-      premiumModalStyles.premiumModalOverlay,
-      premiumModalStyles.premiumModalWidth
-    );
+    showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_LIMIT_REACHED);
   };
 
   return (

--- a/app/components/coding-exercise/ui/chat-panel-states/LockedFooter.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/LockedFooter.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./LockedFooter.module.css";
 
 type LockedFooterVariant = "free-limit-reached" | "premium-blocked";
@@ -16,12 +16,7 @@ interface LockedFooterProps {
 // - premium-blocked: premium user who hit fair use limits
 export function LockedFooter({ variant }: LockedFooterProps) {
   const handleUpgradeClick = () => {
-    showModal(
-      "premium-upgrade-modal",
-      {},
-      premiumModalStyles.premiumModalOverlay,
-      premiumModalStyles.premiumModalWidth
-    );
+    showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_LIMIT_REACHED);
   };
 
   return (

--- a/app/components/coding-exercise/ui/chat-panel-states/LockedFooter.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/LockedFooter.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./LockedFooter.module.css";
 
@@ -16,7 +15,7 @@ interface LockedFooterProps {
 // - premium-blocked: premium user who hit fair use limits
 export function LockedFooter({ variant }: LockedFooterProps) {
   const handleUpgradeClick = () => {
-    showPremiumUpgradeModal(MODAL_TRIGGERS.ASSISTANT_LIMIT_REACHED);
+    showPremiumUpgradeModal("assistant_limit_reached");
   };
 
   return (

--- a/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
+++ b/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
@@ -3,7 +3,6 @@
 import { fetchBadges, type BadgeData } from "@/lib/api/badges";
 import { fetchProfile, type ProfileData } from "@/lib/api/profile";
 import { fetchProjects, type ProjectData } from "@/lib/api/projects";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
@@ -103,7 +102,7 @@ function ProjectsSidebar({ onProjectClick, onViewAllProjectsClick, onUpgradeClic
     if (onUpgradeClick) {
       onUpgradeClick();
     } else {
-      showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_PROJECTS_SIDEBAR);
+      showPremiumUpgradeModal("upgrade_cta_projects_sidebar");
     }
   };
 

--- a/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
+++ b/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
@@ -3,9 +3,9 @@
 import { fetchBadges, type BadgeData } from "@/lib/api/badges";
 import { fetchProfile, type ProfileData } from "@/lib/api/profile";
 import { fetchProjects, type ProjectData } from "@/lib/api/projects";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
 import { useEffect, useMemo, useState } from "react";
 import styles from "./projects-sidebar.module.css";
@@ -103,12 +103,7 @@ function ProjectsSidebar({ onProjectClick, onViewAllProjectsClick, onUpgradeClic
     if (onUpgradeClick) {
       onUpgradeClick();
     } else {
-      showModal(
-        "premium-upgrade-modal",
-        {},
-        premiumModalStyles.premiumModalOverlay,
-        premiumModalStyles.premiumModalWidth
-      );
+      showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_PROJECTS_SIDEBAR);
     }
   };
 

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -8,9 +8,9 @@ import MedalIcon from "@/icons/medal.svg";
 import ProjectsIcon from "@/icons/projects.svg";
 import SettingsIcon from "@/icons/settings.svg";
 import type { ComponentType } from "react";
+import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showModal } from "@/lib/modal";
-import premiumModalStyles from "@/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
 import rocket from "@/components/landing-page/rocketLaunch.module.css";
 import { useRocketLaunch } from "@/components/landing-page/hooks/useRocketLaunch";
@@ -40,16 +40,9 @@ const navigationItems: Array<{
 export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
   const user = useAuthStore((state) => state.user);
   const isPremium = user && tierIncludes(user.membership_type, "premium");
-  const { launching, handleClick } = useRocketLaunch(
-    () =>
-      showModal(
-        "premium-upgrade-modal",
-        {},
-        premiumModalStyles.premiumModalOverlay,
-        premiumModalStyles.premiumModalWidth
-      ),
-    { resetAfterLaunch: true }
-  );
+  const { launching, handleClick } = useRocketLaunch(() => showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_NAV), {
+    resetAfterLaunch: true
+  });
 
   return (
     <aside className="ui-lhs-menu" id="sidebar" data-testid="sidebar">

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -8,7 +8,6 @@ import MedalIcon from "@/icons/medal.svg";
 import ProjectsIcon from "@/icons/projects.svg";
 import SettingsIcon from "@/icons/settings.svg";
 import type { ComponentType } from "react";
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
@@ -40,7 +39,7 @@ const navigationItems: Array<{
 export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
   const user = useAuthStore((state) => state.user);
   const isPremium = user && tierIncludes(user.membership_type, "premium");
-  const { launching, handleClick } = useRocketLaunch(() => showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_NAV), {
+  const { launching, handleClick } = useRocketLaunch(() => showPremiumUpgradeModal("upgrade_cta_nav"), {
     resetAfterLaunch: true
   });
 

--- a/app/components/premium/CtaSection.tsx
+++ b/app/components/premium/CtaSection.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./PremiumPage.module.css";
 
 export default function CtaSection() {
@@ -27,7 +28,7 @@ export default function CtaSection() {
           <p className={styles["cta-desc"]}>Upgrade to Premium and unlock everything Jiki has to offer.</p>
           <button
             className="ui-btn ui-btn-large ui-btn-white w-[260px] font-semibold"
-            onClick={() => showModal("premium-upgrade-modal")}
+            onClick={() => showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_PREMIUM_PAGE)}
           >
             Upgrade to Premium
           </button>

--- a/app/components/premium/CtaSection.tsx
+++ b/app/components/premium/CtaSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { MODAL_TRIGGERS } from "@/lib/analytics";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import styles from "./PremiumPage.module.css";
@@ -28,7 +27,7 @@ export default function CtaSection() {
           <p className={styles["cta-desc"]}>Upgrade to Premium and unlock everything Jiki has to offer.</p>
           <button
             className="ui-btn ui-btn-large ui-btn-white w-[260px] font-semibold"
-            onClick={() => showPremiumUpgradeModal(MODAL_TRIGGERS.UPGRADE_CTA_PREMIUM_PAGE)}
+            onClick={() => showPremiumUpgradeModal("upgrade_cta_premium_page")}
           >
             Upgrade to Premium
           </button>

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -3,35 +3,26 @@
 import { getApiUrl } from "@/lib/api/config";
 
 /**
- * Trigger values for `premium_modal_shown`.
- * Single source of truth — never hardcode these strings at call sites,
- * inconsistent values fragment the funnel data permanently.
+ * Trigger values for `premium_modal_shown`. The type constrains call
+ * sites to a fixed vocabulary — inconsistent values fragment the funnel
+ * data permanently, so any new trigger must be added here first.
  */
-export const MODAL_TRIGGERS = {
-  LOCKED_PROJECT: "locked_project",
-  LOCKED_EPISODE: "locked_episode",
-  LOCKED_EPISODE_VIDEO: "locked_episode_video",
-  ASSISTANT_SEND_MESSAGE: "assistant_send_message",
-  ASSISTANT_TAB_OPENED: "assistant_tab_opened",
-  ASSISTANT_LIMIT_REACHED: "assistant_limit_reached",
-  UPGRADE_CTA_NAV: "upgrade_cta_nav",
-  UPGRADE_CTA_PROJECTS_SIDEBAR: "upgrade_cta_projects_sidebar",
-  UPGRADE_CTA_PREMIUM_PAGE: "upgrade_cta_premium_page"
-} as const;
-
-export type ModalTrigger = (typeof MODAL_TRIGGERS)[keyof typeof MODAL_TRIGGERS];
+export type ModalTrigger =
+  | "locked_project"
+  | "locked_episode"
+  | "locked_episode_video"
+  | "assistant_send_message"
+  | "assistant_tab_opened"
+  | "assistant_limit_reached"
+  | "upgrade_cta_nav"
+  | "upgrade_cta_projects_sidebar"
+  | "upgrade_cta_premium_page";
 
 /**
  * Feature values for `premium_feature_blocked` — fired when a locked
  * surface renders (passive view, no click required).
  */
-export const BLOCKED_FEATURES = {
-  PROJECTS_PAGE: "projects_page",
-  ASSISTANT_TAB: "assistant_tab",
-  BUILD_PAGE_ALL_LOCKED: "build_page_all_locked"
-} as const;
-
-export type BlockedFeature = (typeof BLOCKED_FEATURES)[keyof typeof BLOCKED_FEATURES];
+export type BlockedFeature = "projects_page" | "assistant_tab" | "build_page_all_locked";
 
 /**
  * Fire-and-forget event tracking. Analytics failures must never break

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { getApiUrl } from "@/lib/api/config";
+
+/**
+ * Trigger values for `premium_modal_shown`.
+ * Single source of truth — never hardcode these strings at call sites,
+ * inconsistent values fragment the funnel data permanently.
+ */
+export const MODAL_TRIGGERS = {
+  LOCKED_PROJECT: "locked_project",
+  LOCKED_EPISODE: "locked_episode",
+  LOCKED_EPISODE_VIDEO: "locked_episode_video",
+  ASSISTANT_SEND_MESSAGE: "assistant_send_message",
+  ASSISTANT_TAB_OPENED: "assistant_tab_opened",
+  ASSISTANT_LIMIT_REACHED: "assistant_limit_reached",
+  UPGRADE_CTA_NAV: "upgrade_cta_nav",
+  UPGRADE_CTA_PROJECTS_SIDEBAR: "upgrade_cta_projects_sidebar",
+  UPGRADE_CTA_PREMIUM_PAGE: "upgrade_cta_premium_page"
+} as const;
+
+export type ModalTrigger = (typeof MODAL_TRIGGERS)[keyof typeof MODAL_TRIGGERS];
+
+/**
+ * Feature values for `premium_feature_blocked` — fired when a locked
+ * surface renders (passive view, no click required).
+ */
+export const BLOCKED_FEATURES = {
+  PROJECTS_PAGE: "projects_page",
+  ASSISTANT_TAB: "assistant_tab",
+  BUILD_PAGE_ALL_LOCKED: "build_page_all_locked"
+} as const;
+
+export type BlockedFeature = (typeof BLOCKED_FEATURES)[keyof typeof BLOCKED_FEATURES];
+
+/**
+ * Fire-and-forget event tracking. Analytics failures must never break
+ * the app, so errors are swallowed silently. `keepalive: true` ensures
+ * the request completes even if the user navigates away (important for
+ * "click upgrade" events that often precede a route change).
+ *
+ * Don't await this at call sites — it returns void by design.
+ */
+export function trackEvent(event: string, properties: Record<string, unknown> = {}): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    void fetch(getApiUrl("/internal/events"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event, properties }),
+      credentials: "include",
+      keepalive: true
+    }).catch(() => {});
+  } catch {
+    // swallow synchronous fetch construction errors (e.g. malformed URL)
+  }
+}

--- a/app/lib/attribution.ts
+++ b/app/lib/attribution.ts
@@ -4,7 +4,7 @@ const STORAGE_KEY = "jiki_attribution";
 
 export interface Attribution {
   referrer: string | null;
-  landing_url: string;
+  landing_path: string;
   utm_source: string | null;
   utm_medium: string | null;
   utm_campaign: string | null;
@@ -26,10 +26,15 @@ export function captureAttribution(): void {
   try {
     if (window.localStorage.getItem(STORAGE_KEY)) return;
 
+    // Store the pathname only — never the full URL. A user's first visit may
+    // be a link with sensitive query params (OAuth `?code=`, email
+    // `?confirmation_token=`, password `?reset_password_token=`, etc.), and
+    // we don't want those captured or shipped with the signup payload. UTMs
+    // are extracted into their own fields below so attribution is preserved.
     const params = new URLSearchParams(window.location.search);
     const data: Attribution = {
       referrer: document.referrer || null,
-      landing_url: window.location.href,
+      landing_path: window.location.pathname,
       utm_source: params.get("utm_source"),
       utm_medium: params.get("utm_medium"),
       utm_campaign: params.get("utm_campaign"),

--- a/app/lib/attribution.ts
+++ b/app/lib/attribution.ts
@@ -1,0 +1,52 @@
+"use client";
+
+const STORAGE_KEY = "jiki_attribution";
+
+export interface Attribution {
+  referrer: string | null;
+  landing_url: string;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  captured_at: string;
+}
+
+/**
+ * Record first-touch attribution once per browser. The Rails API can't
+ * see the user's original referrer at signup time (request.referer is our
+ * own signup page by then), so we capture it client-side on first landing
+ * and ship it with the signup payload.
+ *
+ * First touch wins — if the user lands via Twitter, browses for a day,
+ * then signs up from a bookmark, we still record "Twitter".
+ */
+export function captureAttribution(): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    if (window.localStorage.getItem(STORAGE_KEY)) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const data: Attribution = {
+      referrer: document.referrer || null,
+      landing_url: window.location.href,
+      utm_source: params.get("utm_source"),
+      utm_medium: params.get("utm_medium"),
+      utm_campaign: params.get("utm_campaign"),
+      captured_at: new Date().toISOString()
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // localStorage can throw in private mode / when full — ignore
+  }
+}
+
+export function readAttribution(): Attribution | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Attribution) : null;
+  } catch {
+    return null;
+  }
+}

--- a/app/lib/auth/authStore.ts
+++ b/app/lib/auth/authStore.ts
@@ -4,6 +4,7 @@
  */
 
 import * as authService from "@/lib/auth/service";
+import { readAttribution } from "@/lib/attribution";
 import { getApiUrl } from "@/lib/api/config";
 import type { LoginCredentials, LoginResponse, PasswordReset, SignupData, User } from "@/types/auth";
 import { ApiError, AuthenticationError, NetworkError, RateLimitError } from "@/lib/api/client";
@@ -159,7 +160,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ code })
+        body: JSON.stringify({ code, attribution: readAttribution() })
       });
 
       if (!response.ok) {
@@ -202,11 +203,12 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
   signup: async (userData) => {
     set({ isLoading: true });
     try {
+      const { attribution, ...userFields } = userData;
       const response = await fetch(getApiUrl("/auth/signup"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ user: userData })
+        body: JSON.stringify({ user: userFields, attribution: attribution ?? null })
       });
 
       if (!response.ok) {

--- a/app/lib/modal/index.ts
+++ b/app/lib/modal/index.ts
@@ -13,6 +13,7 @@ export {
   showPaymentProcessing,
   showPaymentConfirming,
   showPaymentVerificationFailed,
+  showPremiumUpgradeModal,
   showWelcomeToPremium,
   useModalStore
 } from "./store";

--- a/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
+++ b/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
@@ -13,7 +13,7 @@ import Image from "next/image";
 interface PremiumUpgradeModalProps {
   trigger?: ModalTrigger;
   contextType?: string;
-  contextId?: string | number;
+  contextSlug?: string;
   onSuccess?: () => void;
   onCancel?: () => void;
 }
@@ -21,7 +21,7 @@ interface PremiumUpgradeModalProps {
 export function PremiumUpgradeModal({
   trigger,
   contextType,
-  contextId,
+  contextSlug,
   onSuccess,
   onCancel
 }: PremiumUpgradeModalProps) {
@@ -29,16 +29,18 @@ export function PremiumUpgradeModal({
   const user = useAuthStore((state: any) => state.user);
 
   useEffect(() => {
-    trackEvent("premium_modal_shown", {
-      trigger: trigger ?? null,
-      context_type: contextType ?? null,
-      context_id: contextId ?? null
-    });
-    // If the modal stays mounted while showModal is called again with a new
-    // trigger (rare but possible — the global provider doesn't always
-    // remount), refire so the funnel reflects the new context rather than
-    // recording the old one.
-  }, [trigger, contextType, contextId]);
+    // Omit absent keys rather than sending null — PostHog filters render
+    // "null" as a literal value, which clutters the funnel. Backend's
+    // events endpoint already treats missing keys as "not set".
+    const properties: Record<string, unknown> = {};
+    if (trigger) properties.trigger = trigger;
+    if (contextType) properties.context_type = contextType;
+    if (contextSlug) properties.context_slug = contextSlug;
+    trackEvent("premium_modal_shown", properties);
+    // Refire if showModal is called again with new context while the modal
+    // stays mounted — keeps the funnel honest in the rare reopen-without-
+    // unmount case.
+  }, [trigger, contextType, contextSlug]);
 
   const { handleUpgrade } = useUpgradeFlow({
     setIsLoading,

--- a/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
+++ b/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
@@ -34,10 +34,11 @@ export function PremiumUpgradeModal({
       context_type: contextType ?? null,
       context_id: contextId ?? null
     });
-    // Fire once per modal mount. Trigger is captured at open time; later
-    // prop changes (none expected) shouldn't re-fire.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    // If the modal stays mounted while showModal is called again with a new
+    // trigger (rare but possible — the global provider doesn't always
+    // remount), refire so the funnel reflects the new context rather than
+    // recording the old one.
+  }, [trigger, contextType, contextId]);
 
   const { handleUpgrade } = useUpgradeFlow({
     setIsLoading,

--- a/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
+++ b/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { hideModal } from "../../store";
 import { useAuthStore } from "@/lib/auth/authStore";
+import { trackEvent, type ModalTrigger } from "@/lib/analytics";
 import { BasicPlanSection } from "./BasicPlanSection";
 import { PremiumPlanSection } from "./PremiumPlanSection";
 import { useUpgradeFlow } from "./useUpgradeFlow";
@@ -10,13 +11,33 @@ import styles from "./PremiumUpgradeModal.module.css";
 import Image from "next/image";
 
 interface PremiumUpgradeModalProps {
+  trigger?: ModalTrigger;
+  contextType?: string;
+  contextId?: string | number;
   onSuccess?: () => void;
   onCancel?: () => void;
 }
 
-export function PremiumUpgradeModal({ onSuccess, onCancel }: PremiumUpgradeModalProps) {
+export function PremiumUpgradeModal({
+  trigger,
+  contextType,
+  contextId,
+  onSuccess,
+  onCancel
+}: PremiumUpgradeModalProps) {
   const [isLoading, setIsLoading] = useState(false);
   const user = useAuthStore((state: any) => state.user);
+
+  useEffect(() => {
+    trackEvent("premium_modal_shown", {
+      trigger: trigger ?? null,
+      context_type: contextType ?? null,
+      context_id: contextId ?? null
+    });
+    // Fire once per modal mount. Trigger is captured at open time; later
+    // prop changes (none expected) shouldn't re-fire.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { handleUpgrade } = useUpgradeFlow({
     setIsLoading,

--- a/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
+++ b/app/lib/modal/modals/PremiumUpgradeModal/index.tsx
@@ -13,7 +13,12 @@ import Image from "next/image";
 interface PremiumUpgradeModalProps {
   trigger?: ModalTrigger;
   contextType?: string;
+  // Backend stores three type-accurate fields and never both at once.
+  // Pass `contextSlug` for slug-keyed entities (lesson, project) and
+  // `contextUuid` for uuid-keyed ones (episode). `context_id` is the
+  // backend's integer PK — materialised server-side, never sent here.
   contextSlug?: string;
+  contextUuid?: string;
   onSuccess?: () => void;
   onCancel?: () => void;
 }
@@ -22,6 +27,7 @@ export function PremiumUpgradeModal({
   trigger,
   contextType,
   contextSlug,
+  contextUuid,
   onSuccess,
   onCancel
 }: PremiumUpgradeModalProps) {
@@ -36,11 +42,12 @@ export function PremiumUpgradeModal({
     if (trigger) properties.trigger = trigger;
     if (contextType) properties.context_type = contextType;
     if (contextSlug) properties.context_slug = contextSlug;
+    if (contextUuid) properties.context_uuid = contextUuid;
     trackEvent("premium_modal_shown", properties);
     // Refire if showModal is called again with new context while the modal
     // stays mounted — keeps the funnel honest in the rare reopen-without-
     // unmount case.
-  }, [trigger, contextType, contextSlug]);
+  }, [trigger, contextType, contextSlug, contextUuid]);
 
   const { handleUpgrade } = useUpgradeFlow({
     setIsLoading,

--- a/app/lib/modal/store.ts
+++ b/app/lib/modal/store.ts
@@ -158,7 +158,7 @@ export const showPremiumUpgradeModal = (
   trigger: ModalTrigger,
   options?: {
     contextType?: string;
-    contextId?: string | number;
+    contextSlug?: string;
     onSuccess?: () => void;
     onCancel?: () => void;
   }

--- a/app/lib/modal/store.ts
+++ b/app/lib/modal/store.ts
@@ -1,7 +1,9 @@
 import { create } from "zustand";
+import type { ModalTrigger } from "@/lib/analytics";
 import type { MembershipTier } from "@/lib/pricing";
 import confirmationStyles from "@/app/styles/components/confirmation-modal.module.css";
 import paymentProcessingStyles from "./modals/PaymentProcessingModal.module.css";
+import premiumUpgradeStyles from "./modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
 import subscriptionCheckoutStyles from "./modals/SubscriptionCheckoutModal.module.css";
 import welcomeToPremiumStyles from "./modals/WelcomeToPremiumModal.module.css";
 import walkthroughConfirmStyles from "./modals/WalkthroughConfirmModal.module.css";
@@ -146,6 +148,26 @@ export const showPaymentVerificationFailed = (props?: { onClose?: () => void }) 
 // Convenience function for welcome to premium modal
 export const showWelcomeToPremium = (props?: { onClose?: () => void }) => {
   showModal("welcome-to-premium-modal", props ?? {}, undefined, welcomeToPremiumStyles.modal);
+};
+
+// Convenience function for the premium upgrade modal. Always pass a trigger
+// from `MODAL_TRIGGERS` so the `premium_modal_shown` event has consistent
+// vocabulary — inconsistent values fragment the funnel data permanently.
+export const showPremiumUpgradeModal = (
+  trigger: ModalTrigger,
+  options?: {
+    contextType?: string;
+    contextId?: string | number;
+    onSuccess?: () => void;
+    onCancel?: () => void;
+  }
+) => {
+  showModal(
+    "premium-upgrade-modal",
+    { trigger, ...options },
+    premiumUpgradeStyles.premiumModalOverlay,
+    premiumUpgradeStyles.premiumModalWidth
+  );
 };
 
 // Convenience function for video walkthrough modal

--- a/app/lib/modal/store.ts
+++ b/app/lib/modal/store.ts
@@ -159,6 +159,7 @@ export const showPremiumUpgradeModal = (
   options?: {
     contextType?: string;
     contextSlug?: string;
+    contextUuid?: string;
     onSuccess?: () => void;
     onCancel?: () => void;
   }

--- a/app/lib/modal/store.ts
+++ b/app/lib/modal/store.ts
@@ -150,9 +150,10 @@ export const showWelcomeToPremium = (props?: { onClose?: () => void }) => {
   showModal("welcome-to-premium-modal", props ?? {}, undefined, welcomeToPremiumStyles.modal);
 };
 
-// Convenience function for the premium upgrade modal. Always pass a trigger
-// from `MODAL_TRIGGERS` so the `premium_modal_shown` event has consistent
-// vocabulary — inconsistent values fragment the funnel data permanently.
+// Convenience function for the premium upgrade modal. The `trigger` arg is
+// typed as `ModalTrigger`, a closed union of allowed values — keep that type
+// the single source of truth so the `premium_modal_shown` funnel data stays
+// consistent (new triggers must be added to the type before use).
 export const showPremiumUpgradeModal = (
   trigger: ModalTrigger,
   options?: {

--- a/app/tests/unit/components/AttributionCapture.test.tsx
+++ b/app/tests/unit/components/AttributionCapture.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { AttributionCapture } from "@/components/AttributionCapture";
+import { captureAttribution } from "@/lib/attribution";
+
+jest.mock("@/lib/attribution", () => ({
+  captureAttribution: jest.fn()
+}));
+
+const mockCaptureAttribution = captureAttribution as jest.MockedFunction<typeof captureAttribution>;
+
+describe("AttributionCapture", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls captureAttribution on mount", () => {
+    render(<AttributionCapture />);
+    expect(mockCaptureAttribution).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing", () => {
+    const { container } = render(<AttributionCapture />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/tests/unit/components/auth/SignupForm.test.tsx
+++ b/app/tests/unit/components/auth/SignupForm.test.tsx
@@ -108,7 +108,8 @@ describe("SignupForm", () => {
         expect(mockSignup).toHaveBeenCalledWith({
           email: "test@example.com",
           password: "password123",
-          password_confirmation: "password123"
+          password_confirmation: "password123",
+          attribution: null
         });
       });
     });

--- a/app/tests/unit/components/build-episode/BuildEpisodeVideo.test.tsx
+++ b/app/tests/unit/components/build-episode/BuildEpisodeVideo.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import BuildEpisodeVideo from "@/components/build-episode/BuildEpisodeVideo";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal";
 
 jest.mock("@/lib/auth/authStore");
 jest.mock("@/lib/modal", () => ({
-  showModal: jest.fn()
+  showPremiumUpgradeModal: jest.fn()
 }));
 jest.mock("@/components/build-episode/lib/useBuildEpisodeProgress", () => ({
   useBuildEpisodeProgress: () => ({
@@ -75,12 +75,7 @@ describe("BuildEpisodeVideo", () => {
 
     render(<BuildEpisodeVideo {...baseProps} videoProvider="mux" premium={true} />);
 
-    expect(showModal).toHaveBeenCalledWith(
-      "premium-upgrade-modal",
-      expect.any(Object),
-      expect.any(String),
-      expect.any(String)
-    );
+    expect(showPremiumUpgradeModal).toHaveBeenCalledWith("locked_episode_video", expect.any(Object));
     expect(mockReplace).toHaveBeenCalledWith("/build/building-basics");
     // Player should not be rendered while locked
     expect(screen.queryByTestId("mux-player")).not.toBeInTheDocument();
@@ -92,7 +87,7 @@ describe("BuildEpisodeVideo", () => {
 
     render(<BuildEpisodeVideo {...baseProps} videoProvider="mux" premium={true} />);
 
-    expect(showModal).not.toHaveBeenCalled();
+    expect(showPremiumUpgradeModal).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
     expect(screen.getByTestId("mux-player")).toBeInTheDocument();
   });
@@ -102,7 +97,7 @@ describe("BuildEpisodeVideo", () => {
 
     render(<BuildEpisodeVideo {...baseProps} videoProvider="mux" premium={true} />);
 
-    expect(showModal).not.toHaveBeenCalled();
+    expect(showPremiumUpgradeModal).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
   });
 });

--- a/app/tests/unit/components/coding-exercise/chatTokenApi.test.ts
+++ b/app/tests/unit/components/coding-exercise/chatTokenApi.test.ts
@@ -2,7 +2,12 @@
  * Unit tests for chatTokenApi.ts - JWT token fetching for chat
  */
 
-import { fetchChatToken, ChatTokenError } from "@/components/coding-exercise/lib/chatTokenApi";
+import {
+  ChatTokenAccessDeniedError,
+  ChatTokenError,
+  ChatTokenInvalidCaptchaError,
+  fetchChatToken
+} from "@/components/coding-exercise/lib/chatTokenApi";
 import { getApiUrl } from "@/lib/api/config";
 
 jest.mock("@/lib/api/config");
@@ -154,6 +159,83 @@ describe("chatTokenApi", () => {
         const chatError = error as ChatTokenError;
         expect(chatError.status).toBe(500);
         expect(chatError.data).toEqual({ error: "unknown", message: "Failed to parse error response" });
+      }
+    });
+  });
+
+  describe("403 disambiguation", () => {
+    function mock403(errorBody: unknown) {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve(errorBody)
+      });
+    }
+
+    it("throws ChatTokenAccessDeniedError when error.type is access_denied", async () => {
+      mock403({ error: { type: "access_denied", message: "Upgrade required" } });
+
+      try {
+        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        fail("expected throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChatTokenAccessDeniedError);
+        expect(error).toBeInstanceOf(ChatTokenError);
+        expect((error as ChatTokenAccessDeniedError).status).toBe(403);
+        expect((error as ChatTokenAccessDeniedError).message).toBe("Upgrade required");
+      }
+    });
+
+    it("throws ChatTokenInvalidCaptchaError when error.type is invalid_captcha", async () => {
+      mock403({ error: { type: "invalid_captcha", message: "Verification failed" } });
+
+      try {
+        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        fail("expected throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChatTokenInvalidCaptchaError);
+        expect(error).toBeInstanceOf(ChatTokenError);
+        expect((error as ChatTokenInvalidCaptchaError).message).toBe("Verification failed");
+      }
+    });
+
+    it("falls through to ChatTokenError when error.type is unknown", async () => {
+      mock403({ error: { type: "something_else", message: "Nope" } });
+
+      try {
+        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        fail("expected throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChatTokenError);
+        expect(error).not.toBeInstanceOf(ChatTokenAccessDeniedError);
+        expect(error).not.toBeInstanceOf(ChatTokenInvalidCaptchaError);
+      }
+    });
+
+    it("falls through to ChatTokenError when 403 body is malformed", async () => {
+      mock403({ unexpected: "shape" });
+
+      try {
+        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        fail("expected throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChatTokenError);
+        expect(error).not.toBeInstanceOf(ChatTokenAccessDeniedError);
+        expect(error).not.toBeInstanceOf(ChatTokenInvalidCaptchaError);
+      }
+    });
+
+    it("uses generic message when access_denied body has no message", async () => {
+      mock403({ error: { type: "access_denied" } });
+
+      try {
+        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        fail("expected throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ChatTokenAccessDeniedError);
+        expect((error as ChatTokenAccessDeniedError).message).toBe("HTTP 403: Forbidden");
       }
     });
   });

--- a/app/tests/unit/lib/analytics.test.ts
+++ b/app/tests/unit/lib/analytics.test.ts
@@ -1,0 +1,54 @@
+import { trackEvent } from "@/lib/analytics";
+import { getApiUrl } from "@/lib/api/config";
+
+jest.mock("@/lib/api/config");
+
+const mockGetApiUrl = getApiUrl as jest.MockedFunction<typeof getApiUrl>;
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe("trackEvent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetApiUrl.mockReturnValue("http://api.test/internal/events");
+    mockFetch.mockResolvedValue({ ok: true });
+  });
+
+  it("POSTs to /internal/events with keepalive and credentials", () => {
+    trackEvent("premium_modal_shown", { trigger: "locked_project" });
+
+    expect(mockGetApiUrl).toHaveBeenCalledWith("/internal/events");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("http://api.test/internal/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: "premium_modal_shown", properties: { trigger: "locked_project" } }),
+      credentials: "include",
+      keepalive: true
+    });
+  });
+
+  it("defaults properties to an empty object", () => {
+    trackEvent("some_event");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ event: "some_event", properties: {} });
+  });
+
+  it("swallows rejected fetch promises (analytics must never throw)", async () => {
+    mockFetch.mockReturnValueOnce(Promise.reject(new Error("network down")));
+
+    expect(() => trackEvent("x")).not.toThrow();
+    // Let the microtask queue drain so the swallowed .catch settles before
+    // the test ends and any "unhandled rejection" detector runs.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it("swallows synchronous errors thrown by fetch construction", () => {
+    mockFetch.mockImplementationOnce(() => {
+      throw new Error("URL invalid");
+    });
+
+    expect(() => trackEvent("x")).not.toThrow();
+  });
+});

--- a/app/tests/unit/lib/attribution.test.ts
+++ b/app/tests/unit/lib/attribution.test.ts
@@ -1,0 +1,117 @@
+import { captureAttribution, readAttribution } from "@/lib/attribution";
+
+const STORAGE_KEY = "jiki_attribution";
+
+// jsdom doesn't let you reassign window.location, but it does honour
+// history.pushState — use that to drive pathname + search.
+function setLocation(url: string) {
+  const parsed = new URL(url);
+  window.history.pushState({}, "", parsed.pathname + parsed.search);
+}
+
+function setReferrer(referrer: string) {
+  Object.defineProperty(document, "referrer", {
+    value: referrer,
+    configurable: true
+  });
+}
+
+describe("attribution", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    setReferrer("");
+  });
+
+  describe("captureAttribution", () => {
+    it("stores referrer, landing_path, and UTM params on first call", () => {
+      setReferrer("https://twitter.com/some/post");
+      setLocation("https://jiki.io/landing?utm_source=twitter&utm_medium=social&utm_campaign=launch&extra=x");
+
+      captureAttribution();
+
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!);
+      expect(stored).toMatchObject({
+        referrer: "https://twitter.com/some/post",
+        landing_path: "/landing",
+        utm_source: "twitter",
+        utm_medium: "social",
+        utm_campaign: "launch"
+      });
+      expect(typeof stored.captured_at).toBe("string");
+    });
+
+    it("stores pathname only — never the full URL with query string", () => {
+      setLocation("https://jiki.io/auth/confirm?confirmation_token=SECRET123");
+
+      captureAttribution();
+
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!);
+      expect(stored.landing_path).toBe("/auth/confirm");
+      expect(JSON.stringify(stored)).not.toContain("SECRET123");
+    });
+
+    it("first-touch wins — does not overwrite on subsequent calls", () => {
+      setReferrer("https://twitter.com/a");
+      setLocation("https://jiki.io/?utm_source=twitter");
+      captureAttribution();
+      const first = window.localStorage.getItem(STORAGE_KEY);
+
+      setReferrer("https://google.com/");
+      setLocation("https://jiki.io/?utm_source=google");
+      captureAttribution();
+
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe(first);
+    });
+
+    it("stores null for missing referrer / UTM params", () => {
+      setLocation("https://jiki.io/");
+
+      captureAttribution();
+
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!);
+      expect(stored).toMatchObject({
+        referrer: null,
+        landing_path: "/",
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null
+      });
+    });
+
+    it("does not throw if localStorage.setItem throws (private mode / quota)", () => {
+      const setItem = jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("QuotaExceeded");
+      });
+
+      expect(() => captureAttribution()).not.toThrow();
+
+      setItem.mockRestore();
+    });
+  });
+
+  describe("readAttribution", () => {
+    it("returns the parsed attribution object when present", () => {
+      const payload = {
+        referrer: "https://x.com",
+        landing_path: "/",
+        utm_source: "x",
+        utm_medium: null,
+        utm_campaign: null,
+        captured_at: "2026-01-01T00:00:00.000Z"
+      };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+
+      expect(readAttribution()).toEqual(payload);
+    });
+
+    it("returns null when nothing has been captured", () => {
+      expect(readAttribution()).toBeNull();
+    });
+
+    it("returns null when stored value is malformed JSON", () => {
+      window.localStorage.setItem(STORAGE_KEY, "not-json{");
+
+      expect(readAttribution()).toBeNull();
+    });
+  });
+});

--- a/app/tests/unit/stores/authStore.login.test.ts
+++ b/app/tests/unit/stores/authStore.login.test.ts
@@ -292,7 +292,8 @@ describe("AuthStore - Login", () => {
               password: "password123",
               password_confirmation: "password123",
               name: "New User"
-            }
+            },
+            attribution: null
           })
         })
       );

--- a/app/tests/unit/stores/authStore.test.ts
+++ b/app/tests/unit/stores/authStore.test.ts
@@ -132,7 +132,7 @@ describe("AuthStore - Google Authentication", () => {
         expect.objectContaining({
           method: "POST",
           credentials: "include",
-          body: JSON.stringify({ code: "test-auth-code" })
+          body: JSON.stringify({ code: "test-auth-code", attribution: null })
         })
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -26,7 +26,7 @@ export interface LoginCredentials {
 
 export interface SignupAttribution {
   referrer: string | null;
-  landing_url: string;
+  landing_path: string;
   utm_source: string | null;
   utm_medium: string | null;
   utm_campaign: string | null;

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -24,11 +24,21 @@ export interface LoginCredentials {
   password: string;
 }
 
+export interface SignupAttribution {
+  referrer: string | null;
+  landing_url: string;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  captured_at: string;
+}
+
 export interface SignupData {
   email: string;
   password: string;
   password_confirmation: string;
   name?: string;
+  attribution?: SignupAttribution | null;
 }
 
 export interface PasswordResetRequest {


### PR DESCRIPTION
## Summary
- Wires up MVP analytics for the signup → premium funnel per the spec
- Events go through one fire-and-forget path (`trackEvent` → Rails `/internal/events`) — no PostHog SDK on the FE, ad-blocker proof, vendor-neutral
- First-touch attribution captured client-side and shipped with email + Google signup payloads

## What's in scope

**Helpers**
- `lib/analytics.ts` — `trackEvent(event, properties)` with `keepalive: true` + silent error handling
- `MODAL_TRIGGERS` and `BLOCKED_FEATURES` vocab consts (single source of truth — never hardcode strings at call sites)
- `lib/attribution.ts` + `AttributionCapture` — first-touch attribution recorded once on root-layout mount

**`premium_modal_shown`** — fired from the modal's mount via a new `showPremiumUpgradeModal(trigger, options?)` helper that replaces 10 raw `showModal(...)` call sites
- `locked_project`, `locked_episode`, `locked_episode_video`, `assistant_tab_opened`, `assistant_limit_reached`, `upgrade_cta_nav`, `upgrade_cta_projects_sidebar`, `upgrade_cta_premium_page`, `assistant_send_message`

**`premium_feature_blocked`** — passive-view tracking on three surfaces
- Projects page (free user)
- Assistant tab (any blocked free-user state)
- Build-series page where no free episodes remain unwatched

**Attribution wired into signup**
- Email signup: included in `{ user, attribution }` body
- Google OAuth: included in `{ code, attribution }` body

**403 disambiguation on chat-token endpoint**
- `access_denied` → opens upgrade modal + fires `premium_modal_shown` with trigger `assistant_send_message`
- `invalid_captcha` → inline "Verification failed" error, **no analytics event** (would pollute the funnel)
- Depends on backend shipping `{ error: { type, message } }` on 403s from `/internal/assistant_conversations`

## API expectations
- `POST /internal/events` accepting `{ event, properties }` with session-cookie auth — backend enriches with `user_id`, `membership_tier`, etc.
- `/auth/signup` and `/auth/google` accepting an `attribution` sibling field alongside the user payload
- `/internal/assistant_conversations` 403 responses with `error.type` of either `access_denied` or `invalid_captcha`

## Test plan
- [ ] Visit the site from an external referrer with `?utm_source=test` — verify `jiki_attribution` is set in localStorage
- [ ] Sign up via email; verify the request body includes the captured `attribution`
- [ ] Sign up via Google OAuth; verify attribution survives the redirect
- [ ] As a free user, visit `/projects` — verify `premium_feature_blocked` fires once with `feature: projects_page`
- [ ] As a free user on a coding exercise, open the chat tab — verify `premium_feature_blocked` with `feature: assistant_tab`
- [ ] Click a locked project card — verify `premium_modal_shown` with `trigger: locked_project` and `context_id: <slug>`
- [ ] Click the upgrade CTA in the nav sidebar — verify `trigger: upgrade_cta_nav`
- [ ] Force a 403 `access_denied` from the chat endpoint — verify modal opens with `trigger: assistant_send_message`
- [ ] Force a 403 `invalid_captcha` — verify inline error shows and NO `premium_modal_shown` event fires
- [ ] Confirm `keepalive: true` lets events complete across navigation (click "Upgrade", watch network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)