### PR TITLE
Add Turnstile bot protection + auth UX polish

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -209,6 +209,9 @@ jobs:
         run: pnpm test:e2e
         env:
           CI: true
+          # Cloudflare's documented "always passes (invisible)" test site key,
+          # so Turnstile resolves immediately in CI without a real challenge.
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: 1x00000000000000000000AA
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,10 @@ jobs:
             missing_vars+=("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY")
           fi
 
+          if [ -z "${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}" ]; then
+            missing_vars+=("NEXT_PUBLIC_TURNSTILE_SITE_KEY")
+          fi
+
           if [ -z "${{ secrets.SENTRY_AUTH_TOKEN }}" ]; then
             missing_vars+=("SENTRY_AUTH_TOKEN")
           fi
@@ -75,6 +79,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   deploy-llm-chat-proxy:

--- a/app/app/(external)/auth/check-email/page.tsx
+++ b/app/app/(external)/auth/check-email/page.tsx
@@ -1,50 +1,22 @@
 "use client";
 
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
-import styles from "@/components/auth/AuthForm.module.css";
-
-function CheckEmailContent() {
-  const searchParams = useSearchParams();
-  const email = searchParams.get("email");
-
-  return (
-    <div className={styles.leftSide}>
-      <div className={styles.formContainer}>
-        <header>
-          <h1>Check your email</h1>
-          <p>
-            We&apos;ve sent a confirmation link to <strong>{email}</strong>.
-          </p>
-          <p>Please check your inbox and click the link to confirm your account.</p>
-        </header>
-
-        <div className={styles.footerLinks}>
-          <p>
-            Didn&apos;t receive the email?{" "}
-            <Link
-              href={`/auth/resend-confirmation${email ? `?email=${encodeURIComponent(email)}` : ""}`}
-              className="ui-link"
-            >
-              Resend it
-            </Link>
-          </p>
-          <p>
-            <Link href="/auth/login" className="ui-link">
-              Back to login
-            </Link>
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
+import { useEffect, useState } from "react";
+import { CheckInboxMessage } from "@/components/auth/CheckInboxMessage";
 
 export default function CheckEmailPage() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <CheckEmailContent />
-    </Suspense>
-  );
+  const [email, setEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      setEmail(localStorage.getItem("just_signed_up_email") ?? "");
+    } catch {
+      setEmail("");
+    }
+  }, []);
+
+  if (email === null) {
+    return null;
+  }
+
+  return <CheckInboxMessage email={email} />;
 }

--- a/app/app/dev/llm-chat/page.tsx
+++ b/app/app/dev/llm-chat/page.tsx
@@ -113,10 +113,13 @@ export default function LLMChatTestPage() {
 
   const handleLogin = async () => {
     try {
-      await login({
-        email: "ihid@jiki.io",
-        password: "password"
-      });
+      await login(
+        {
+          email: "ihid@jiki.io",
+          password: "password"
+        },
+        "dev-stub-token"
+      );
     } catch (err) {
       console.error("Login failed:", err);
     }
@@ -195,7 +198,10 @@ export default function LLMChatTestPage() {
       let token = chatToken;
       if (!token) {
         addDebugEvent("request", { type: "fetch_token", lessonSlug: selectedExercise });
-        token = await fetchChatToken({ context: { type: "lesson", slug: selectedExercise } });
+        token = await fetchChatToken({
+          context: { type: "lesson", slug: selectedExercise },
+          cfTurnstileResponse: "dev-stub-token"
+        });
         setChatToken(token);
         addDebugEvent("response", { type: "token_received" });
       }
@@ -207,7 +213,10 @@ export default function LLMChatTestPage() {
         if (err instanceof ChatTokenExpiredError) {
           addDebugEvent("sse", { type: "token_expired", retrying: true });
           setChatToken(null);
-          const newToken = await fetchChatToken({ context: { type: "lesson", slug: selectedExercise } });
+          const newToken = await fetchChatToken({
+            context: { type: "lesson", slug: selectedExercise },
+            cfTurnstileResponse: "dev-stub-token"
+          });
           setChatToken(newToken);
           await performRequest(newToken);
         } else {

--- a/app/app/dev/oauth-google/page.tsx
+++ b/app/app/dev/oauth-google/page.tsx
@@ -45,10 +45,13 @@ export default function GoogleOAuthTestPage() {
   // Handle traditional email/password login for testing
   const handleTraditionalLogin = async () => {
     try {
-      await login({
-        email: "ihid@jiki.io",
-        password: "password"
-      });
+      await login(
+        {
+          email: "ihid@jiki.io",
+          password: "password"
+        },
+        "dev-stub-token"
+      );
     } catch (err) {
       console.error("Login failed:", err);
     }

--- a/app/app/dev/stripe-test/page.tsx
+++ b/app/app/dev/stripe-test/page.tsx
@@ -24,10 +24,13 @@ export default function StripeTestPage() {
 
   const handleLogin = async () => {
     try {
-      await login({
-        email: "ihid@jiki.io",
-        password: "password"
-      });
+      await login(
+        {
+          email: "ihid@jiki.io",
+          password: "password"
+        },
+        "dev-stub-token"
+      );
     } catch (err) {
       console.error("Login failed:", err);
     }

--- a/app/components/auth/AuthForm.module.css
+++ b/app/components/auth/AuthForm.module.css
@@ -78,10 +78,10 @@
 
 .errorMessage {
     background: var(--color-error-bg);
-    border: 2px solid var(--color-error-border);
+    border: 1.5px solid var(--color-red-600);
     border-radius: 8px;
     padding: 16px;
-    color: var(--color-error-text);
+    color: var(--color-red-600);
     font-size: 15px;
     font-weight: 500;
     line-height: 1.5;

--- a/app/components/auth/AuthForm.module.css
+++ b/app/components/auth/AuthForm.module.css
@@ -110,6 +110,10 @@
     justify-content: center;
     margin: 0 auto 24px;
     color: var(--color-blue-600);
+
+    > svg {
+        width: 40px;
+    }
 }
 
 .confirmationCard {

--- a/app/components/auth/AuthForm.module.css
+++ b/app/components/auth/AuthForm.module.css
@@ -76,6 +76,18 @@
     text-wrap-style: balance;
 }
 
+.errorMessage {
+    background: var(--color-error-bg);
+    border: 2px solid var(--color-error-border);
+    border-radius: 8px;
+    padding: 16px;
+    color: var(--color-error-text);
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.5;
+    text-wrap-style: balance;
+}
+
 .confirmationMessage {
     text-align: center;
 

--- a/app/components/auth/ForgotPasswordForm.tsx
+++ b/app/components/auth/ForgotPasswordForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { ApiError } from "@/lib/api/client";
 import { useAuthStore } from "@/lib/auth/authStore";
+import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import Link from "next/link";
 import type { FormEvent } from "react";
 import { useState } from "react";
@@ -9,10 +11,13 @@ import styles from "./AuthForm.module.css";
 
 export function ForgotPasswordForm() {
   const { requestPasswordReset, isLoading } = useAuthStore();
+  const turnstile = useTurnstile();
 
   const [email, setEmail] = useState("");
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [successMessage, setSuccessMessage] = useState("");
+  const [verifying, setVerifying] = useState(false);
+  const [captchaError, setCaptchaError] = useState(false);
 
   const validate = () => {
     const errors: Record<string, string> = {};
@@ -30,17 +35,37 @@ export function ForgotPasswordForm() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setSuccessMessage("");
+    setCaptchaError(false);
 
     if (!validate()) {
       return;
     }
 
+    let token: string;
+    setVerifying(true);
     try {
-      await requestPasswordReset(email);
+      token = await turnstile.execute();
+    } catch (err) {
+      console.error("Turnstile failed:", err);
+      setCaptchaError(true);
+      setVerifying(false);
+      return;
+    }
+    setVerifying(false);
+
+    try {
+      await requestPasswordReset(email, token);
       setSuccessMessage("If an account with that email exists, you'll receive reset instructions shortly.");
       setEmail("");
     } catch (err) {
       console.error("Password reset request failed:", err);
+      if (
+        err instanceof ApiError &&
+        err.status === 403 &&
+        (err.data as { error?: { type?: string } } | undefined)?.error?.type === "invalid_captcha"
+      ) {
+        setCaptchaError(true);
+      }
     }
   };
 
@@ -84,14 +109,16 @@ export function ForgotPasswordForm() {
             )}
           </div>
 
+          {captchaError && <div className={styles.errorMessage}>Verification failed, please try again.</div>}
+
           <button
             type="submit"
             id="submit-btn"
             className="ui-btn ui-btn-large ui-btn-primary"
             style={{ width: "100%" }}
-            disabled={isLoading}
+            disabled={isLoading || verifying}
           >
-            {isLoading ? "Sending..." : "Send Reset Link"}
+            {verifying ? "Verifying..." : isLoading ? "Sending..." : "Send Reset Link"}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/ForgotPasswordForm.tsx
+++ b/app/components/auth/ForgotPasswordForm.tsx
@@ -51,13 +51,13 @@ export function ForgotPasswordForm() {
       setVerifying(false);
       return;
     }
-    setVerifying(false);
 
     try {
       await requestPasswordReset(email, token);
       setSuccessMessage("If an account with that email exists, you'll receive reset instructions shortly.");
       setEmail("");
     } catch (err) {
+      setVerifying(false);
       console.error("Password reset request failed:", err);
       if (
         err instanceof ApiError &&
@@ -118,7 +118,7 @@ export function ForgotPasswordForm() {
             style={{ width: "100%" }}
             disabled={isLoading || verifying}
           >
-            {verifying ? "Verifying..." : isLoading ? "Sending..." : "Send Reset Link"}
+            {isLoading ? "Sending..." : verifying ? "Verifying..." : "Send Reset Link"}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/ForgotPasswordForm.tsx
+++ b/app/components/auth/ForgotPasswordForm.tsx
@@ -109,7 +109,12 @@ export function ForgotPasswordForm() {
             )}
           </div>
 
-          {captchaError && <div className={styles.errorMessage}>Verification failed, please try again.</div>}
+          {captchaError && (
+            <div className={styles.errorMessage}>
+              Our systems tried to determine whether you were a bot or a human, but couldn&apos;t. Please try again
+              using the button below.
+            </div>
+          )}
 
           <button
             type="submit"

--- a/app/components/auth/ForgotPasswordForm.tsx
+++ b/app/components/auth/ForgotPasswordForm.tsx
@@ -54,6 +54,7 @@ export function ForgotPasswordForm() {
 
     try {
       await requestPasswordReset(email, token);
+      setVerifying(false);
       setSuccessMessage("If an account with that email exists, you'll receive reset instructions shortly.");
       setEmail("");
     } catch (err) {

--- a/app/components/auth/LoginForm.tsx
+++ b/app/components/auth/LoginForm.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { AuthenticationError } from "@/lib/api/client";
+import { ApiError, AuthenticationError } from "@/lib/api/client";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { useAuth } from "@/lib/auth/useAuth";
 import { buildUrlWithReturnTo } from "@/lib/auth/return-to";
+import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import Link from "next/link";
 import type { FormEvent } from "react";
 import { useState } from "react";
@@ -15,12 +16,15 @@ import { GoogleAuthButton } from "./GoogleAuthButton";
 export function LoginForm() {
   const { login, isLoading } = useAuthStore();
   const { handleAuthResponse, handleGoogleSuccess, googleAuthError, returnTo, TwoFactorForm } = useAuth();
+  const turnstile = useTurnstile();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [hasAuthError, setHasAuthError] = useState(false);
   const [unconfirmedEmail, setUnconfirmedEmail] = useState<string | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [captchaError, setCaptchaError] = useState(false);
 
   const validate = () => {
     const errors: Record<string, string> = {};
@@ -45,16 +49,37 @@ export function LoginForm() {
     e.preventDefault();
     setHasAuthError(false);
     setUnconfirmedEmail(null);
+    setCaptchaError(false);
 
     if (!validate()) {
       return;
     }
 
+    let token: string;
+    setVerifying(true);
     try {
-      const result = await login({ email, password });
+      token = await turnstile.execute();
+    } catch (err) {
+      console.error("Turnstile failed:", err);
+      setCaptchaError(true);
+      setVerifying(false);
+      return;
+    }
+    setVerifying(false);
+
+    try {
+      const result = await login({ email, password }, token);
       handleAuthResponse(result);
     } catch (err) {
       console.error("Login failed:", err);
+      if (
+        err instanceof ApiError &&
+        err.status === 403 &&
+        (err.data as { error?: { type?: string } } | undefined)?.error?.type === "invalid_captcha"
+      ) {
+        setCaptchaError(true);
+        return;
+      }
       if (err instanceof AuthenticationError) {
         // Check if the error is specifically for unconfirmed email
         const errorData = err.data as { error?: { type?: string; email?: string } } | undefined;
@@ -187,14 +212,16 @@ export function LoginForm() {
             </div>
           </div>
 
+          {captchaError && <div className={styles.errorMessage}>Verification failed, please try again.</div>}
+
           <button
             type="submit"
             id="submit-btn"
             className="ui-btn ui-btn-large ui-btn-primary"
             style={{ width: "100%" }}
-            disabled={isLoading}
+            disabled={isLoading || verifying}
           >
-            {isLoading ? "Logging in..." : "Log In"}
+            {verifying ? "Verifying..." : isLoading ? "Logging in..." : "Log In"}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/LoginForm.tsx
+++ b/app/components/auth/LoginForm.tsx
@@ -212,7 +212,12 @@ export function LoginForm() {
             </div>
           </div>
 
-          {captchaError && <div className={styles.errorMessage}>Verification failed, please try again.</div>}
+          {captchaError && (
+            <div className={styles.errorMessage}>
+              Our systems tried to determine whether you were a bot or a human, but couldn&apos;t. Please try logging in
+              again using the button below.
+            </div>
+          )}
 
           <button
             type="submit"

--- a/app/components/auth/LoginForm.tsx
+++ b/app/components/auth/LoginForm.tsx
@@ -65,12 +65,12 @@ export function LoginForm() {
       setVerifying(false);
       return;
     }
-    setVerifying(false);
 
     try {
       const result = await login({ email, password }, token);
       handleAuthResponse(result);
     } catch (err) {
+      setVerifying(false);
       console.error("Login failed:", err);
       if (
         err instanceof ApiError &&
@@ -221,7 +221,7 @@ export function LoginForm() {
             style={{ width: "100%" }}
             disabled={isLoading || verifying}
           >
-            {verifying ? "Verifying..." : isLoading ? "Logging in..." : "Log In"}
+            {isLoading ? "Logging in..." : verifying ? "Verifying..." : "Log In"}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/SignupForm.tsx
+++ b/app/components/auth/SignupForm.tsx
@@ -5,6 +5,7 @@ import { readAttribution } from "@/lib/attribution";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { useAuth } from "@/lib/auth/useAuth";
 import { buildUrlWithReturnTo } from "@/lib/auth/return-to";
+import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import Link from "next/link";
 import type { FormEvent } from "react";
 import { useState } from "react";
@@ -17,6 +18,7 @@ import { GoogleAuthButton } from "./GoogleAuthButton";
 export function SignupForm() {
   const { signup, isLoading } = useAuthStore();
   const { handleAuthResponse, handleGoogleSuccess, googleAuthError, returnTo, TwoFactorForm } = useAuth();
+  const turnstile = useTurnstile();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -24,6 +26,8 @@ export function SignupForm() {
   const [hasAuthError, setHasAuthError] = useState(false);
   const [authErrorField, setAuthErrorField] = useState<string | null>(null);
   const [signupSuccessEmail, setSignupSuccessEmail] = useState<string | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [captchaError, setCaptchaError] = useState(false);
 
   const validate = () => {
     const errors: Record<string, string> = {};
@@ -48,18 +52,34 @@ export function SignupForm() {
     e.preventDefault();
     setHasAuthError(false);
     setAuthErrorField(null);
+    setCaptchaError(false);
 
     if (!validate()) {
       return;
     }
 
+    let token: string;
+    setVerifying(true);
     try {
-      const user = await signup({
-        email,
-        password,
-        password_confirmation: password,
-        attribution: readAttribution()
-      });
+      token = await turnstile.execute();
+    } catch (err) {
+      console.error("Turnstile failed:", err);
+      setCaptchaError(true);
+      setVerifying(false);
+      return;
+    }
+    setVerifying(false);
+
+    try {
+      const user = await signup(
+        {
+          email,
+          password,
+          password_confirmation: password,
+          attribution: readAttribution()
+        },
+        token
+      );
 
       if (user.email_confirmed) {
         handleAuthResponse({ status: "success", user });
@@ -70,6 +90,13 @@ export function SignupForm() {
       console.error("Signup failed:", err);
 
       if (err instanceof ApiError) {
+        if (
+          err.status === 403 &&
+          (err.data as { error?: { type?: string } } | undefined)?.error?.type === "invalid_captcha"
+        ) {
+          setCaptchaError(true);
+          return;
+        }
         // Handle specific HTTP status codes
         if (err.status === 409 || err.status === 422) {
           // 409 Conflict or 422 Unprocessable Entity - likely email already exists
@@ -181,14 +208,16 @@ export function SignupForm() {
             )}
           </div>
 
+          {captchaError && <div className={styles.errorMessage}>Verification failed, please try again.</div>}
+
           <button
             type="submit"
             id="submit-btn"
             className="ui-btn ui-btn-large ui-btn-primary submit-btn"
             style={{ width: "100%" }}
-            disabled={isLoading}
+            disabled={isLoading || verifying}
           >
-            {isLoading ? "Signing up..." : "Sign Up"}
+            {verifying ? "Verifying..." : isLoading ? "Signing up..." : "Sign Up"}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/SignupForm.tsx
+++ b/app/components/auth/SignupForm.tsx
@@ -7,25 +7,25 @@ import { useAuth } from "@/lib/auth/useAuth";
 import { buildUrlWithReturnTo } from "@/lib/auth/return-to";
 import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import type { FormEvent } from "react";
 import { useState } from "react";
 import EmailIcon from "@/icons/email.svg";
 import PasswordIcon from "@/icons/password.svg";
 import styles from "./AuthForm.module.css";
-import { CheckInboxMessage } from "./CheckInboxMessage";
 import { GoogleAuthButton } from "./GoogleAuthButton";
 
 export function SignupForm() {
   const { signup, isLoading } = useAuthStore();
   const { handleAuthResponse, handleGoogleSuccess, googleAuthError, returnTo, TwoFactorForm } = useAuth();
   const turnstile = useTurnstile();
+  const router = useRouter();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [hasAuthError, setHasAuthError] = useState(false);
   const [authErrorField, setAuthErrorField] = useState<string | null>(null);
-  const [signupSuccessEmail, setSignupSuccessEmail] = useState<string | null>(null);
   const [verifying, setVerifying] = useState(false);
   const [captchaError, setCaptchaError] = useState(false);
 
@@ -83,7 +83,12 @@ export function SignupForm() {
       if (user.email_confirmed) {
         handleAuthResponse({ status: "success", user });
       } else {
-        setSignupSuccessEmail(email);
+        try {
+          localStorage.setItem("just_signed_up_email", email);
+        } catch {
+          // Storage may be disabled — the check-email page will fall back gracefully.
+        }
+        router.push("/auth/check-email");
       }
     } catch (err) {
       setVerifying(false);
@@ -111,10 +116,6 @@ export function SignupForm() {
 
   if (TwoFactorForm) {
     return TwoFactorForm;
-  }
-
-  if (signupSuccessEmail) {
-    return <CheckInboxMessage email={signupSuccessEmail} />;
   }
 
   return (
@@ -208,7 +209,12 @@ export function SignupForm() {
             )}
           </div>
 
-          {captchaError && <div className={styles.errorMessage}>Verification failed, please try again.</div>}
+          {captchaError && (
+            <div className={styles.errorMessage}>
+              Our systems tried to determine whether you were a bot or a human, but couldn&apos;t. Please try signing up
+              again using the button below.
+            </div>
+          )}
 
           <button
             type="submit"

--- a/app/components/auth/SignupForm.tsx
+++ b/app/components/auth/SignupForm.tsx
@@ -68,7 +68,6 @@ export function SignupForm() {
       setVerifying(false);
       return;
     }
-    setVerifying(false);
 
     try {
       const user = await signup(
@@ -87,6 +86,7 @@ export function SignupForm() {
         setSignupSuccessEmail(email);
       }
     } catch (err) {
+      setVerifying(false);
       console.error("Signup failed:", err);
 
       if (err instanceof ApiError) {
@@ -217,7 +217,7 @@ export function SignupForm() {
             style={{ width: "100%" }}
             disabled={isLoading || verifying}
           >
-            {verifying ? "Verifying..." : isLoading ? "Signing up..." : "Sign Up"}
+            {isLoading ? "Signing up..." : verifying ? "Verifying..." : "Sign Up"}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/coding-exercise/lib/chatTokenApi.ts
+++ b/app/components/coding-exercise/lib/chatTokenApi.ts
@@ -34,6 +34,7 @@ export class ChatTokenInvalidCaptchaError extends ChatTokenError {
 
 export interface FetchChatTokenParams {
   context: ExerciseContext;
+  cfTurnstileResponse: string;
 }
 
 export interface ChatTokenResponse {
@@ -41,8 +42,9 @@ export interface ChatTokenResponse {
 }
 
 export async function fetchChatToken(params: FetchChatTokenParams): Promise<string> {
-  const { context } = params;
-  const body = context.type === "project" ? { project_slug: context.slug } : { lesson_slug: context.slug };
+  const { context, cfTurnstileResponse } = params;
+  const slug = context.type === "project" ? { project_slug: context.slug } : { lesson_slug: context.slug };
+  const body = { ...slug, cf_turnstile_response: cfTurnstileResponse };
 
   const response = await fetch(getApiUrl("/internal/assistant_conversations"), {
     method: "POST",

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -1,16 +1,18 @@
 import { useCallback, useRef } from "react";
 import { showPremiumUpgradeModal } from "@/lib/modal";
+import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import { useChatState } from "./useChatState";
 import { useChatContext } from "./useChatContext";
 import { sendChatMessage, ChatTokenExpiredError } from "./chatApi";
 import { saveConversation } from "./conversationApi";
-import { ChatTokenAccessDeniedError, fetchChatToken } from "./chatTokenApi";
+import { ChatTokenAccessDeniedError, ChatTokenInvalidCaptchaError, fetchChatToken } from "./chatTokenApi";
 import { formatChatError } from "./chatErrorHandler";
 import type Orchestrator from "./Orchestrator";
 
 export function useChat(orchestrator: Orchestrator) {
   const chatState = useChatState();
   const context = useChatContext(orchestrator);
+  const turnstile = useTurnstile();
   const tokenFetchInProgress = useRef<Promise<string> | null>(null);
 
   // Get existing token or fetch a new one
@@ -25,10 +27,15 @@ export function useChat(orchestrator: Orchestrator) {
       return tokenFetchInProgress.current;
     }
 
-    // Fetch new token
-    tokenFetchInProgress.current = fetchChatToken({
-      context: context.context
-    });
+    // Run Turnstile, then exchange for a chat JWT. One Turnstile pass per
+    // chat session — once we hold a chat token, subsequent messages reuse it.
+    tokenFetchInProgress.current = (async () => {
+      const cfTurnstileResponse = await turnstile.execute();
+      return fetchChatToken({
+        context: context.context,
+        cfTurnstileResponse
+      });
+    })();
 
     try {
       const token = await tokenFetchInProgress.current;
@@ -37,7 +44,7 @@ export function useChat(orchestrator: Orchestrator) {
     } finally {
       tokenFetchInProgress.current = null;
     }
-  }, [chatState, context.context]);
+  }, [chatState, context.context, turnstile]);
 
   // Perform the actual chat request with a given token
   const performChatRequest = useCallback(
@@ -125,6 +132,12 @@ export function useChat(orchestrator: Orchestrator) {
             contextSlug: context.context.slug
           });
           chatState.setStatus("idle");
+          return;
+        }
+
+        if (error instanceof ChatTokenInvalidCaptchaError) {
+          chatState.setError("Verification failed, please try again.");
+          chatState.setStatus("error");
           return;
         }
 

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -154,6 +154,11 @@ jest.mock("../public/icons/jiki-logo.svg", () => {
   };
 });
 
+// Mock Turnstile hook so tests don't hit the real Cloudflare widget.
+jest.mock("@/lib/turnstile/useTurnstile", () => ({
+  useTurnstile: () => ({ execute: jest.fn().mockResolvedValue("test-token") })
+}));
+
 // Mock theme hook
 jest.mock("@/lib/theme/useTheme", () => ({
   useTheme: () => ({

--- a/app/lib/auth/authStore.ts
+++ b/app/lib/auth/authStore.ts
@@ -20,15 +20,15 @@ interface AuthStore {
   hasCheckedAuth: boolean;
 
   // Actions
-  login: (credentials: LoginCredentials) => Promise<LoginResponse>;
+  login: (credentials: LoginCredentials, cfTurnstileResponse: string) => Promise<LoginResponse>;
   setup2FA: (otpCode: string) => Promise<void>;
   verify2FA: (otpCode: string) => Promise<void>;
-  signup: (userData: SignupData) => Promise<User>;
+  signup: (userData: SignupData, cfTurnstileResponse: string) => Promise<User>;
   googleLogin: (code: string) => Promise<LoginResponse>;
   logout: () => Promise<{ success: boolean; error?: "network" }>;
   checkAuth: () => Promise<void>;
   refreshUser: () => Promise<void>;
-  requestPasswordReset: (email: string) => Promise<void>;
+  requestPasswordReset: (email: string, cfTurnstileResponse: string) => Promise<void>;
   resetPassword: (data: PasswordReset) => Promise<void>;
   resendConfirmation: (email: string) => Promise<void>;
   clearError: () => void;
@@ -47,14 +47,14 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
 
   // Login action - calls Rails directly
   // Returns the response so caller can handle 2FA flows
-  login: async (credentials): Promise<LoginResponse> => {
+  login: async (credentials, cfTurnstileResponse): Promise<LoginResponse> => {
     set({ isLoading: true });
     try {
       const response = await fetch(getApiUrl("/auth/login"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ user: credentials })
+        body: JSON.stringify({ user: credentials, cf_turnstile_response: cfTurnstileResponse })
       });
 
       if (!response.ok) {
@@ -200,7 +200,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
 
   // Signup action - calls Rails directly
   // Returns user data so caller can check email_confirmed status
-  signup: async (userData) => {
+  signup: async (userData, cfTurnstileResponse) => {
     set({ isLoading: true });
     try {
       const { attribution, ...userFields } = userData;
@@ -208,7 +208,11 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ user: userFields, attribution: attribution ?? null })
+        body: JSON.stringify({
+          user: userFields,
+          attribution: attribution ?? null,
+          cf_turnstile_response: cfTurnstileResponse
+        })
       });
 
       if (!response.ok) {
@@ -357,10 +361,10 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
   },
 
   // Request password reset
-  requestPasswordReset: async (email) => {
+  requestPasswordReset: async (email, cfTurnstileResponse) => {
     set({ isLoading: true, error: null });
     try {
-      await authService.requestPasswordReset({ email });
+      await authService.requestPasswordReset({ email }, cfTurnstileResponse);
       set({ isLoading: false });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to send reset email";

--- a/app/lib/auth/service.ts
+++ b/app/lib/auth/service.ts
@@ -15,8 +15,8 @@ import type { PasswordReset, PasswordResetRequest, User } from "@/types/auth";
  * Request password reset
  * POST /auth/password
  */
-export async function requestPasswordReset(data: PasswordResetRequest): Promise<void> {
-  await api.post("/auth/password", { user: data });
+export async function requestPasswordReset(data: PasswordResetRequest, cfTurnstileResponse: string): Promise<void> {
+  await api.post("/auth/password", { user: data, cf_turnstile_response: cfTurnstileResponse });
 }
 
 /**

--- a/app/lib/turnstile/useTurnstile.ts
+++ b/app/lib/turnstile/useTurnstile.ts
@@ -1,0 +1,212 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+interface TurnstileRenderOptions {
+  sitekey: string;
+  size?: "normal" | "compact" | "flexible";
+  execution?: "render" | "execute";
+  appearance?: "always" | "execute" | "interaction-only";
+  theme?: "light" | "dark" | "auto";
+  callback?: (token: string) => void;
+  "error-callback"?: (code: string) => void;
+  "expired-callback"?: () => void;
+  "timeout-callback"?: () => void;
+  "before-interactive-callback"?: () => void;
+  "after-interactive-callback"?: () => void;
+}
+
+interface TurnstileApi {
+  render: (container: HTMLElement, options: TurnstileRenderOptions) => string;
+  execute: (widgetId: string) => void;
+  reset: (widgetId: string) => void;
+  remove: (widgetId: string) => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+    __turnstileScriptPromise?: Promise<void>;
+  }
+}
+
+function loadTurnstileScript(): Promise<void> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("Turnstile cannot load on the server"));
+  }
+  if (window.turnstile) {
+    return Promise.resolve();
+  }
+  if (window.__turnstileScriptPromise) {
+    return window.__turnstileScriptPromise;
+  }
+  window.__turnstileScriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error("Failed to load Turnstile script"));
+    document.head.appendChild(script);
+  });
+  return window.__turnstileScriptPromise;
+}
+
+export interface UseTurnstileResult {
+  execute: () => Promise<string>;
+}
+
+interface PendingResolver {
+  resolve: (token: string) => void;
+  reject: (err: Error) => void;
+}
+
+export function useTurnstile(): UseTurnstileResult {
+  // widgetIdRef and pendingRef are populated by the most recent effect run.
+  // The effect itself scopes its own state in closures so racy late .then()
+  // callbacks from a cancelled run can't clobber the live widget.
+  const widgetIdRef = useRef<string | null>(null);
+  const pendingRef = useRef<PendingResolver | null>(null);
+  const readyRef = useRef<Promise<void> | null>(null);
+
+  useEffect(() => {
+    const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+    if (!siteKey) {
+      readyRef.current = Promise.reject(new Error("NEXT_PUBLIC_TURNSTILE_SITE_KEY is not set"));
+      return;
+    }
+
+    let cancelled = false;
+    let localWidgetId: string | null = null;
+    // Turnstile renders its interactive challenge *inline* in the container.
+    // To present it as a proper explained modal, we wrap the widget container
+    // inside our own overlay+panel and toggle visibility via the
+    // before/after-interactive-callbacks.
+    const overlay = document.createElement("div");
+    overlay.style.cssText = [
+      "position: fixed",
+      "inset: 0",
+      "background: rgba(15, 23, 42, 0.95)",
+      "display: none",
+      "align-items: center",
+      "justify-content: center",
+      "z-index: 9999",
+      "padding: 16px"
+    ].join(";");
+
+    const panel = document.createElement("div");
+    panel.style.cssText = [
+      "background: #fff",
+      "border-radius: 12px",
+      "padding: 32px 40px",
+      "max-width: 500px",
+      "width: 100%",
+      "box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4)",
+      "font-family: inherit",
+      "text-align: center",
+      "display: flex",
+      "flex-direction: column",
+      "align-items: center"
+    ].join(";");
+
+    const heading = document.createElement("h2");
+    heading.textContent = "Please verify you are not a bot";
+    heading.style.cssText = "margin: 0 0 12px 0; font-size: 22px; font-weight: 600; color: #0f172a;";
+
+    const para = document.createElement("p");
+    para.textContent =
+      "We are constantly attacked by bots (apparently they're very keen to get into coding!). Please tick the box below to confirm you are human.";
+    para.style.cssText = "margin: 0 0 20px 0; font-size: 15px; line-height: 1.5; color: #475569;";
+
+    const container = document.createElement("div");
+    container.style.cssText = "display: flex; justify-content: center;";
+
+    panel.appendChild(heading);
+    panel.appendChild(para);
+    panel.appendChild(container);
+    overlay.appendChild(panel);
+    document.body.appendChild(overlay);
+
+    const showOverlay = () => {
+      overlay.style.display = "flex";
+    };
+    const hideOverlay = () => {
+      overlay.style.display = "none";
+    };
+
+    readyRef.current = loadTurnstileScript().then(() => {
+      if (cancelled || !window.turnstile) {
+        return;
+      }
+      localWidgetId = window.turnstile.render(container, {
+        sitekey: siteKey,
+        execution: "execute",
+        appearance: "interaction-only",
+        callback: (token) => {
+          hideOverlay();
+          pendingRef.current?.resolve(token);
+          pendingRef.current = null;
+        },
+        "error-callback": (code) => {
+          hideOverlay();
+          pendingRef.current?.reject(new Error(`Turnstile error: ${code}`));
+          pendingRef.current = null;
+        },
+        "expired-callback": () => {
+          hideOverlay();
+          pendingRef.current?.reject(new Error("Turnstile token expired before use"));
+          pendingRef.current = null;
+        },
+        "timeout-callback": () => {
+          hideOverlay();
+          pendingRef.current?.reject(new Error("Turnstile timed out"));
+          pendingRef.current = null;
+        },
+        "before-interactive-callback": () => {
+          showOverlay();
+        }
+      });
+      widgetIdRef.current = localWidgetId;
+    });
+
+    return () => {
+      cancelled = true;
+      if (window.turnstile && localWidgetId) {
+        try {
+          window.turnstile.remove(localWidgetId);
+        } catch {
+          // Widget was never registered or already removed — ignore.
+        }
+      }
+      if (widgetIdRef.current === localWidgetId) {
+        widgetIdRef.current = null;
+      }
+      if (overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay);
+      }
+      pendingRef.current = null;
+    };
+  }, []);
+
+  const execute = useCallback(async (): Promise<string> => {
+    if (!readyRef.current) {
+      throw new Error("Turnstile not initialized");
+    }
+    await readyRef.current;
+    if (!window.turnstile || !widgetIdRef.current) {
+      throw new Error("Turnstile widget not available");
+    }
+    if (pendingRef.current) {
+      pendingRef.current.reject(new Error("Turnstile execute() called while previous call was pending"));
+    }
+    return new Promise<string>((resolve, reject) => {
+      pendingRef.current = { resolve, reject };
+      window.turnstile!.reset(widgetIdRef.current!);
+      window.turnstile!.execute(widgetIdRef.current!);
+    });
+  }, []);
+
+  return { execute };
+}

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -18,13 +18,13 @@ function setCSP(response: NextResponse): void {
   // Allow unsafe-inline for Next.js inline scripts (required for RSC flight data)
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
+    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
     style-src 'self' 'unsafe-inline' https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self';
     media-src 'self' blob: https://*.mux.com;
     connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
-    frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com;
+    frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
     worker-src 'self' blob:;
     object-src 'none';
     base-uri 'self';

--- a/app/tests/unit/components/auth/LoginForm.test.tsx
+++ b/app/tests/unit/components/auth/LoginForm.test.tsx
@@ -117,7 +117,7 @@ describe("LoginForm", () => {
       fireEvent.click(screen.getByRole("button", { name: /log in$/i }));
 
       await waitFor(() => {
-        expect(mockLogin).toHaveBeenCalledWith({ email: "test@example.com", password: "password123" });
+        expect(mockLogin).toHaveBeenCalledWith({ email: "test@example.com", password: "password123" }, "test-token");
       });
     });
 

--- a/app/tests/unit/components/auth/SignupForm.test.tsx
+++ b/app/tests/unit/components/auth/SignupForm.test.tsx
@@ -147,7 +147,7 @@ describe("SignupForm", () => {
       });
     });
 
-    it("shows check inbox message when email is not confirmed", async () => {
+    it("redirects to /auth/check-email and stashes the email when not confirmed", async () => {
       mockSearchParamsGet.mockReturnValue(null);
       mockSignup.mockResolvedValue({ email_confirmed: false });
 
@@ -158,9 +158,9 @@ describe("SignupForm", () => {
       fireEvent.click(screen.getByRole("button", { name: /sign up$/i }));
 
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /check your inbox/i })).toBeInTheDocument();
+        expect(mockRouterPush).toHaveBeenCalledWith("/auth/check-email");
       });
-      expect(mockRouterPush).not.toHaveBeenCalled();
+      expect(localStorage.getItem("just_signed_up_email")).toBe("test@example.com");
     });
 
     it("does not use router.push for valid external return_to URL when email is confirmed", async () => {

--- a/app/tests/unit/components/auth/SignupForm.test.tsx
+++ b/app/tests/unit/components/auth/SignupForm.test.tsx
@@ -105,12 +105,15 @@ describe("SignupForm", () => {
       fireEvent.click(screen.getByRole("button", { name: /sign up$/i }));
 
       await waitFor(() => {
-        expect(mockSignup).toHaveBeenCalledWith({
-          email: "test@example.com",
-          password: "password123",
-          password_confirmation: "password123",
-          attribution: null
-        });
+        expect(mockSignup).toHaveBeenCalledWith(
+          {
+            email: "test@example.com",
+            password: "password123",
+            password_confirmation: "password123",
+            attribution: null
+          },
+          "test-token"
+        );
       });
     });
 

--- a/app/tests/unit/components/coding-exercise/chatTokenApi.test.ts
+++ b/app/tests/unit/components/coding-exercise/chatTokenApi.test.ts
@@ -32,7 +32,10 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ token: mockToken })
       });
 
-      const result = await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } });
+      const result = await fetchChatToken({
+        context: { type: "lesson", slug: "test-exercise" },
+        cfTurnstileResponse: "test-token"
+      });
 
       expect(result).toBe(mockToken);
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -42,7 +45,7 @@ describe("chatTokenApi", () => {
           "Content-Type": "application/json"
         },
         credentials: "include",
-        body: JSON.stringify({ lesson_slug: "test-exercise" })
+        body: JSON.stringify({ lesson_slug: "test-exercise", cf_turnstile_response: "test-token" })
       });
     });
 
@@ -52,10 +55,13 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ token: mockToken })
       });
 
-      await fetchChatToken({ context: { type: "lesson", slug: "my-exercise-slug" } });
+      await fetchChatToken({
+        context: { type: "lesson", slug: "my-exercise-slug" },
+        cfTurnstileResponse: "test-token"
+      });
 
       const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(requestBody).toEqual({ lesson_slug: "my-exercise-slug" });
+      expect(requestBody).toEqual({ lesson_slug: "my-exercise-slug", cf_turnstile_response: "test-token" });
     });
 
     it("should send project_slug for project context", async () => {
@@ -64,10 +70,13 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ token: mockToken })
       });
 
-      await fetchChatToken({ context: { type: "project", slug: "my-project-slug" } });
+      await fetchChatToken({
+        context: { type: "project", slug: "my-project-slug" },
+        cfTurnstileResponse: "test-token"
+      });
 
       const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(requestBody).toEqual({ project_slug: "my-project-slug" });
+      expect(requestBody).toEqual({ project_slug: "my-project-slug", cf_turnstile_response: "test-token" });
     });
 
     it("should throw ChatTokenError on 401 errors", async () => {
@@ -79,9 +88,9 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ error: "unauthorized" })
       });
 
-      await expect(fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } })).rejects.toThrow(
-        ChatTokenError
-      );
+      await expect(
+        fetchChatToken({ context: { type: "lesson", slug: "test-exercise" }, cfTurnstileResponse: "test-token" })
+      ).rejects.toThrow(ChatTokenError);
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -94,9 +103,9 @@ describe("chatTokenApi", () => {
         json: () => Promise.resolve({ error: "server_error", message: "Database connection failed" })
       });
 
-      await expect(fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } })).rejects.toThrow(
-        ChatTokenError
-      );
+      await expect(
+        fetchChatToken({ context: { type: "lesson", slug: "test-exercise" }, cfTurnstileResponse: "test-token" })
+      ).rejects.toThrow(ChatTokenError);
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -111,7 +120,7 @@ describe("chatTokenApi", () => {
       });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "nonexistent" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "nonexistent" }, cfTurnstileResponse: "test-token" });
         fail("Expected ChatTokenError to be thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);
@@ -132,7 +141,7 @@ describe("chatTokenApi", () => {
       });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" }, cfTurnstileResponse: "test-token" });
         fail("Expected ChatTokenError to be thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);
@@ -152,7 +161,7 @@ describe("chatTokenApi", () => {
       });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "test-exercise" }, cfTurnstileResponse: "test-token" });
         fail("Expected ChatTokenError to be thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);
@@ -178,7 +187,7 @@ describe("chatTokenApi", () => {
       mock403({ error: { type: "access_denied", message: "Upgrade required" } });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "x" }, cfTurnstileResponse: "test-token" });
         fail("expected throw");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenAccessDeniedError);
@@ -192,7 +201,7 @@ describe("chatTokenApi", () => {
       mock403({ error: { type: "invalid_captcha", message: "Verification failed" } });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "x" }, cfTurnstileResponse: "test-token" });
         fail("expected throw");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenInvalidCaptchaError);
@@ -205,7 +214,7 @@ describe("chatTokenApi", () => {
       mock403({ error: { type: "something_else", message: "Nope" } });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "x" }, cfTurnstileResponse: "test-token" });
         fail("expected throw");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);
@@ -218,7 +227,7 @@ describe("chatTokenApi", () => {
       mock403({ unexpected: "shape" });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "x" }, cfTurnstileResponse: "test-token" });
         fail("expected throw");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenError);
@@ -231,7 +240,7 @@ describe("chatTokenApi", () => {
       mock403({ error: { type: "access_denied" } });
 
       try {
-        await fetchChatToken({ context: { type: "lesson", slug: "x" } });
+        await fetchChatToken({ context: { type: "lesson", slug: "x" }, cfTurnstileResponse: "test-token" });
         fail("expected throw");
       } catch (error) {
         expect(error).toBeInstanceOf(ChatTokenAccessDeniedError);

--- a/app/tests/unit/components/coding-exercise/useChat-token.test.tsx
+++ b/app/tests/unit/components/coding-exercise/useChat-token.test.tsx
@@ -81,7 +81,10 @@ describe("useChat token management", () => {
       });
 
       expect(mockFetchChatToken).toHaveBeenCalledTimes(1);
-      expect(mockFetchChatToken).toHaveBeenCalledWith({ context: { type: "lesson", slug: "test-lesson" } });
+      expect(mockFetchChatToken).toHaveBeenCalledWith({
+        context: { type: "lesson", slug: "test-lesson" },
+        cfTurnstileResponse: "test-token"
+      });
       expect(mockSendChatMessage).toHaveBeenCalledTimes(1);
     });
 
@@ -303,8 +306,10 @@ describe("useChat token management", () => {
         await result.current.sendMessage("Message 1");
       });
 
-      // fetchChatToken should be called once
-      expect(mockFetchChatToken).toHaveBeenCalledTimes(1);
+      // fetchChatToken is invoked after the Turnstile token resolves (microtask).
+      await waitFor(() => {
+        expect(mockFetchChatToken).toHaveBeenCalledTimes(1);
+      });
 
       // Resolve the token fetch
       act(() => {

--- a/app/tests/unit/stores/authStore.login.test.ts
+++ b/app/tests/unit/stores/authStore.login.test.ts
@@ -57,7 +57,7 @@ describe("AuthStore - Login", () => {
       });
 
       const { login } = useAuthStore.getState();
-      const result = await login({ email: "test@example.com", password: "password123" });
+      const result = await login({ email: "test@example.com", password: "password123" }, "test-token");
 
       expect(result).toEqual({ status: "success", user: mockUser });
 
@@ -78,7 +78,7 @@ describe("AuthStore - Login", () => {
       mockFetch.mockReturnValue(fetchPromise);
 
       const { login } = useAuthStore.getState();
-      const loginPromise = login({ email: "test@example.com", password: "password123" });
+      const loginPromise = login({ email: "test@example.com", password: "password123" }, "test-token");
 
       // Check loading state is set
       expect(useAuthStore.getState().isLoading).toBe(true);
@@ -100,7 +100,9 @@ describe("AuthStore - Login", () => {
 
       const { login } = useAuthStore.getState();
 
-      await expect(login({ email: "test@example.com", password: "wrong" })).rejects.toThrow(AuthenticationError);
+      await expect(login({ email: "test@example.com", password: "wrong" }, "test-token")).rejects.toThrow(
+        AuthenticationError
+      );
 
       const state = useAuthStore.getState();
       expect(state.user).toBeNull();
@@ -116,7 +118,9 @@ describe("AuthStore - Login", () => {
 
       const { login } = useAuthStore.getState();
 
-      await expect(login({ email: "test@example.com", password: "password" })).rejects.toThrow("Server error");
+      await expect(login({ email: "test@example.com", password: "password" }, "test-token")).rejects.toThrow(
+        "Server error"
+      );
 
       const state = useAuthStore.getState();
       expect(state.user).toBeNull();
@@ -128,7 +132,9 @@ describe("AuthStore - Login", () => {
 
       const { login } = useAuthStore.getState();
 
-      await expect(login({ email: "test@example.com", password: "password" })).rejects.toThrow("Network error");
+      await expect(login({ email: "test@example.com", password: "password" }, "test-token")).rejects.toThrow(
+        "Network error"
+      );
 
       const state = useAuthStore.getState();
       expect(state.user).toBeNull();
@@ -143,14 +149,17 @@ describe("AuthStore - Login", () => {
       });
 
       const { login } = useAuthStore.getState();
-      await login({ email: "test@example.com", password: "password123" });
+      await login({ email: "test@example.com", password: "password123" }, "test-token");
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("/auth/login"),
         expect.objectContaining({
           method: "POST",
           credentials: "include",
-          body: JSON.stringify({ user: { email: "test@example.com", password: "password123" } })
+          body: JSON.stringify({
+            user: { email: "test@example.com", password: "password123" },
+            cf_turnstile_response: "test-token"
+          })
         })
       );
     });
@@ -163,7 +172,7 @@ describe("AuthStore - Login", () => {
 
       const { login } = useAuthStore.getState();
 
-      await expect(login({ email: "test@example.com", password: "password" })).rejects.toThrow(
+      await expect(login({ email: "test@example.com", password: "password" }, "test-token")).rejects.toThrow(
         "Invalid response from server"
       );
     });
@@ -179,7 +188,7 @@ describe("AuthStore - Login", () => {
       });
 
       const { login } = useAuthStore.getState();
-      const result = await login({ email: "admin@example.com", password: "password123" });
+      const result = await login({ email: "admin@example.com", password: "password123" }, "test-token");
 
       expect(result).toEqual({
         status: "2fa_setup_required",
@@ -199,7 +208,7 @@ describe("AuthStore - Login", () => {
       });
 
       const { login } = useAuthStore.getState();
-      const result = await login({ email: "admin@example.com", password: "password123" });
+      const result = await login({ email: "admin@example.com", password: "password123" }, "test-token");
 
       expect(result).toEqual({ status: "2fa_required" });
 
@@ -218,12 +227,15 @@ describe("AuthStore - Login", () => {
       });
 
       const { signup } = useAuthStore.getState();
-      await signup({
-        email: "new@example.com",
-        password: "password123",
-        password_confirmation: "password123",
-        name: "New User"
-      });
+      await signup(
+        {
+          email: "new@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "New User"
+        },
+        "test-token"
+      );
 
       const state = useAuthStore.getState();
       expect(state.user).toEqual(mockUser);
@@ -241,11 +253,14 @@ describe("AuthStore - Login", () => {
       const { signup } = useAuthStore.getState();
 
       await expect(
-        signup({
-          email: "existing@example.com",
-          password: "password123",
-          password_confirmation: "password123"
-        })
+        signup(
+          {
+            email: "existing@example.com",
+            password: "password123",
+            password_confirmation: "password123"
+          },
+          "test-token"
+        )
       ).rejects.toThrow(AuthenticationError);
     });
 
@@ -259,11 +274,14 @@ describe("AuthStore - Login", () => {
       const { signup } = useAuthStore.getState();
 
       await expect(
-        signup({
-          email: "new@example.com",
-          password: "short",
-          password_confirmation: "short"
-        })
+        signup(
+          {
+            email: "new@example.com",
+            password: "short",
+            password_confirmation: "short"
+          },
+          "test-token"
+        )
       ).rejects.toThrow("Validation failed");
     });
 
@@ -274,12 +292,15 @@ describe("AuthStore - Login", () => {
       });
 
       const { signup } = useAuthStore.getState();
-      await signup({
-        email: "new@example.com",
-        password: "password123",
-        password_confirmation: "password123",
-        name: "New User"
-      });
+      await signup(
+        {
+          email: "new@example.com",
+          password: "password123",
+          password_confirmation: "password123",
+          name: "New User"
+        },
+        "test-token"
+      );
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("/auth/signup"),
@@ -293,7 +314,8 @@ describe("AuthStore - Login", () => {
               password_confirmation: "password123",
               name: "New User"
             },
-            attribution: null
+            attribution: null,
+            cf_turnstile_response: "test-token"
           })
         })
       );


### PR DESCRIPTION
## Summary

Frontend half of the Cloudflare Turnstile integration, plus a few auth-flow improvements picked up along the way.

### Turnstile

- Adds an invisible Turnstile widget that mints a token before posting to Rails on signup, login, forgot-password, and chat-start.
- When Cloudflare wants an interactive challenge (rare), the widget appears inside a centered modal with a friendly explanation ("Please verify you are not a bot…") rather than the default inline element.
- Backend pair: Rails verifies the `cf_turnstile_response` field on the four protected endpoints and returns 403 `{ error: { type: "invalid_captcha" } }` on failure. Failure is surfaced in the UI as a contextual red banner ("Our systems tried to determine whether you were a bot or a human, but couldn't. Please try signing up again using the button below.").

### How Turnstile is wired

- `lib/turnstile/useTurnstile.ts` lazy-loads `challenges.cloudflare.com/turnstile/v0/api.js`, renders a widget with `execution: "execute"` + `appearance: "interaction-only"`, and exposes `execute()` returning a `Promise<string>`.
- The widget container is wrapped in a fixed-position overlay + centered panel, shown via `before-interactive-callback` and hidden on success/error/expired/timeout.
- `useChat` (LLM chat-start) calls `execute()` once per chat session before exchanging for the Rails-minted JWT — subsequent messages reuse the JWT.
- CSP in `middleware.ts` is extended to allow `challenges.cloudflare.com` in `script-src` and `frame-src`.

### Auth UX polish

- Submit buttons no longer briefly snap back to their default label between Turnstile resolving and the API call starting — the transition is now `Verifying...` → `Logging in.../Signing up.../Sending...` with no flash.
- Error banner styling uses `--color-red-600` with a 1.5px border for higher contrast.
- The confirmation-icon SVG is sized to 40px.
- After unconfirmed signup the form now routes to the existing `/auth/check-email` page (with the email stashed in `localStorage` as `just_signed_up_email`) rather than swapping the SignupForm body inline. Refresh now keeps the user on the right view and the URL reflects state. The page delays render until the localStorage lookup completes to avoid a flash.

## Config

- `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is now required at build time. Wired through `.github/workflows/deploy.yml` and validated in the pre-deploy check step.
- Local dev uses Cloudflare's "always passes" test key by default (`1x00000000000000000000AA`); swap to `3x00000000000000000000FF` to exercise the interactive-challenge modal, or `2x00000000000000000000AB` to exercise the failure banner.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)
- [x] `npx jest` — 128 suites, 1575 tests passing
- [ ] Manual: signup with the always-pass key — submits with no UI, redirects to `/auth/check-email`, refresh stays put
- [ ] Manual: signup with the forces-challenge key (`3x...FF`) — modal appears, ticking the checkbox lets submit through
- [ ] Manual: signup with the always-fail key (`2x...AB`) — red banner appears, no Rails POST
- [ ] Manual: same three flows on login, forgot-password, chat-start (chat-start tested via `/lesson/<slug>`, not `/dev/llm-chat` which bypasses Turnstile)
- [ ] Coordinate with backend team so this lands at the same time as their Rails-side check or before their flip-on (so users aren't broken in the gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)