### PR TITLE
Fix production deploys: exclude metadata images from SVGR rule

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -102,8 +102,11 @@ const nextConfig: NextConfig = {
     }
 
     // Add SVGR loader
+    // Exclude Next.js metadata requests (e.g. app/icon.svg favicon) so they are
+    // handled by next-metadata-image-loader as raw images, not React components
     config.module.rules.push({
       test: /\.svg$/i,
+      resourceQuery: { not: [/__next_metadata__/] },
       use: [
         {
           loader: "@svgr/webpack",


### PR DESCRIPTION
## Problem

Every deploy to `main` has failed since #520 (May 16), so production hasn't been updated in over two weeks. All four failed deploy runs show the same error:

```
Error: Image import "next-metadata-image-loader?...!app/app/icon.svg?__next_metadata__"
is not a valid image file. The image may be corrupted or an unsupported format.
```

## Cause

#520 added `app/icon.svg` as the favicon, which Next.js processes as a metadata image. The SVGR rule in the webpack config matches every `.svg` import, including metadata requests, so SVGR converted the icon into a React component and `next-metadata-image-loader` received JS instead of an image.

This only breaks the production build because deploys use webpack (via OpenNext); local dev uses Turbopack, which handles metadata icons through a different path.

## Fix

Add `resourceQuery: { not: [/__next_metadata__/] }` to the SVGR rule so Next.js handles metadata images itself, matching stock behaviour. All other SVG imports still go through SVGR as before.

## Verification

⚠️ The PR checks do **not** exercise the webpack production build (it only runs in the deploy workflow on push to `main`), so the real verification is the deploy run after merging. The deploy was already failing on every merge, so this can't make things worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)