### PR TITLE
Adjust avatar edit modal padding and title size

### DIFF
--- a/app/components/dashboard/projects-sidebar/ui/UserProfile.tsx
+++ b/app/components/dashboard/projects-sidebar/ui/UserProfile.tsx
@@ -2,7 +2,7 @@
 
 import type { BadgeData } from "@/lib/api/badges";
 import { useDelayedLoading } from "@/lib/hooks/useDelayedLoading";
-import { showModal } from "@/lib/modal";
+import { showAvatarEditModal } from "@/lib/modal";
 import UserAvatar from "@/components/common/UserAvatar";
 import { Icon } from "@/components/ui-kit/Icon";
 import PencilIcon from "@/icons/pencil.svg";
@@ -40,7 +40,7 @@ export function UserProfile({ profile, badges, onBadgeRevealed, loading, isPremi
   const shouldShowSkeleton = useDelayedLoading(loading ?? false);
 
   const handleAvatarClick = () => {
-    showModal("avatar-edit-modal", {});
+    showAvatarEditModal();
   };
 
   if (shouldShowSkeleton || !profile) {

--- a/app/components/settings/modals/AvatarEditModal.module.css
+++ b/app/components/settings/modals/AvatarEditModal.module.css
@@ -1,10 +1,13 @@
+.modal {
+    padding: 32px 50px;
+}
+
 .content {
     text-align: center;
-    padding: 8px 0 8px;
 }
 
 .title {
-    font-size: 21px;
+    font-size: 23px;
     font-weight: 600;
     color: var(--color-gray-900);
     margin: 0 0 8px;

--- a/app/components/settings/modals/AvatarEditModal.module.css
+++ b/app/components/settings/modals/AvatarEditModal.module.css
@@ -78,10 +78,6 @@
 
 /* Crop step */
 
-.cropContent {
-    padding: 8px 0 8px;
-}
-
 .cropContainer {
     position: relative;
     width: 100%;

--- a/app/components/settings/modals/AvatarEditModal.tsx
+++ b/app/components/settings/modals/AvatarEditModal.tsx
@@ -95,7 +95,7 @@ export function AvatarEditModal() {
 
   if (imageSrc) {
     return (
-      <div className={styles.cropContent}>
+      <div>
         <h4 className={styles.title}>Adjust Photo</h4>
         <p className={styles.subtitle}>Zoom and position your photo.</p>
         <div ref={containerRef} className={styles.cropContainer}>

--- a/app/components/settings/sections/AvatarUploadSection.tsx
+++ b/app/components/settings/sections/AvatarUploadSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { showModal } from "@/lib/modal/store";
+import { showAvatarEditModal } from "@/lib/modal/store";
 import { useAuthStore } from "@/lib/auth/authStore";
 import AvatarPreview from "../ui/AvatarPreview";
 import PencilIcon from "@/icons/pencil.svg";
@@ -11,7 +11,7 @@ export default function AvatarUploadSection() {
   const avatarUrl = useAuthStore((state) => state.user?.avatar_url ?? null);
 
   const handleClick = () => {
-    showModal("avatar-edit-modal", {});
+    showAvatarEditModal();
   };
 
   return (

--- a/app/lib/modal/index.ts
+++ b/app/lib/modal/index.ts
@@ -15,6 +15,7 @@ export {
   showPaymentVerificationFailed,
   showPremiumUpgradeModal,
   showWelcomeToPremium,
+  showAvatarEditModal,
   useModalStore
 } from "./store";
 

--- a/app/lib/modal/store.ts
+++ b/app/lib/modal/store.ts
@@ -7,6 +7,7 @@ import premiumUpgradeStyles from "./modals/PremiumUpgradeModal/PremiumUpgradeMod
 import subscriptionCheckoutStyles from "./modals/SubscriptionCheckoutModal.module.css";
 import welcomeToPremiumStyles from "./modals/WelcomeToPremiumModal.module.css";
 import walkthroughConfirmStyles from "./modals/WalkthroughConfirmModal.module.css";
+import avatarEditStyles from "@/components/settings/modals/AvatarEditModal.module.css";
 
 interface ModalState {
   isOpen: boolean;
@@ -180,4 +181,9 @@ export const showVideoWalkthrough = (props: { playbackId: string; lessonSlug: st
 // Convenience function for walkthrough confirmation modal
 export const showWalkthroughConfirm = (props: { onConfirm?: () => void }) => {
   showModal("walkthrough-confirm-modal", props, undefined, walkthroughConfirmStyles.modal);
+};
+
+// Convenience function for avatar edit modal
+export const showAvatarEditModal = () => {
+  showModal("avatar-edit-modal", {}, undefined, avatarEditStyles.modal);
 };


### PR DESCRIPTION
## Summary
- Remove inner padding from the avatar edit modal's content (both upload and crop steps)
- Override the base modal frame padding to `32px 50px` specifically for the avatar edit modal (via a new `showAvatarEditModal()` convenience function, following the existing pattern in `lib/modal/store.ts`)
- Increase the modal title size from 21px to 23px

## Test plan
- `tsc --noEmit`, ESLint, and the full unit test suite (1575 tests) pass
- Open Settings → click profile photo, or the dashboard sidebar avatar pencil, and confirm the modal padding/title on the upload step
- Select an image and confirm the crop step's spacing matches (it relies on the modal frame padding only, same as the upload step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)