### PR TITLE
Pass Exercism OAuth client ID to the production build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,10 @@ jobs:
             missing_vars+=("NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID")
           fi
 
+          if [ -z "${{ secrets.NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID }}" ]; then
+            missing_vars+=("NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID")
+          fi
+
           if [ -z "${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}" ]; then
             missing_vars+=("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY")
           fi
@@ -78,6 +82,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID }}
+          NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/app/.context/auth.md
+++ b/app/.context/auth.md
@@ -572,6 +572,8 @@ Both the login and signup forms (`components/auth/LoginForm.tsx`, `components/au
 - **PKCE hashing**: uses `js-sha256` (pure JS) rather than `crypto.subtle` because the Web Crypto API is unavailable on non-secure origins like `http://local.jiki.io` in local development
 - **Env**: `NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID`, `NEXT_PUBLIC_EXERCISM_URL` (defaults to `https://exercism.org`; local dev uses `http://local.exercism.io:3020`)
 
+`NEXT_PUBLIC_*` provider client IDs are inlined at build time, so production values must be present in the build environment. They come from GitHub Actions secrets passed to the deploy step in `.github/workflows/deploy.yml`. The production Exercism client ID belongs to the Doorkeeper application registered on exercism.org with redirect URI `https://jiki.io/auth/exercism/callback`.
+
 ## Security Considerations
 
 ### Token Security


### PR DESCRIPTION
## Summary

The "Use Exercism" button (#529) wasn't showing in production because `.github/workflows/deploy.yml` never passed `NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID` into the build. `NEXT_PUBLIC_*` vars are inlined at build time, so the repo secret being set isn't enough - it has to be in the deploy step's env.

- Adds `NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID` to the deploy step env (and the required-secrets validation, matching the Google/Stripe/Turnstile pattern)
- Documents the build-time inlining requirement in `.context/auth.md`

## Note

The secret's value must be the client ID of the Doorkeeper application registered on **production exercism.org** with redirect URI `https://jiki.io/auth/exercism/callback` (not the local-dev client ID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)