### PR TITLE
Underline syntax error span in editor

### DIFF
--- a/app/components/coding-exercise/codemirror.css
+++ b/app/components/coding-exercise/codemirror.css
@@ -115,9 +115,9 @@
         background: var(--color-background-secondary);
     }
     .ͼ1 .cm-underline {
+        background: var(--color-red-200);
+        border-bottom: 2px solid var(--color-red-500);
         text-decoration: none;
-        border-bottom: 2px solid red;
-        background: rgba(255, 0, 0, 0.2);
     }
 }
 

--- a/app/components/coding-exercise/lib/orchestrator/EditorManager.ts
+++ b/app/components/coding-exercise/lib/orchestrator/EditorManager.ts
@@ -418,7 +418,6 @@ export class EditorManager {
     }
   }
 
-  // UNUSED: This function is currently not called.
   applyUnderlineRange(range: UnderlineRange | undefined) {
     const effectRange = range || { from: 0, to: 0 };
     this.editorView.dispatch({

--- a/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
+++ b/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
@@ -1,4 +1,5 @@
 import type { ExerciseDefinition } from "@jiki/curriculum";
+import type { SyntaxError } from "@jiki/interpreters";
 import toast from "react-hot-toast";
 import type { StoreApi } from "zustand/vanilla";
 import { ApiError, AuthenticationError, NetworkError, RateLimitError } from "@/lib/api/client";
@@ -6,14 +7,6 @@ import { processMessageContent } from "../../ui/messageUtils";
 import type { TestSuiteResult, TestExpect } from "../test-results-types";
 import type { ExerciseContext, OrchestratorStore } from "../types";
 import { ERROR_HIGHLIGHT_COLOR } from "../../ui/codemirror/extensions/lineHighlighter";
-
-// Define SyntaxError interface inline since it's not exported from interpreters
-interface SyntaxError {
-  message: string;
-  location: {
-    line: number;
-  };
-}
 
 /**
  * Manages test suite execution, results, and processing
@@ -35,6 +28,7 @@ export class TestSuiteManager {
     state.setHasSyntaxError(false);
     state.setStatus("running");
     state.setError(null);
+    state.setUnderlineRange(undefined);
   }
 
   /**
@@ -55,6 +49,10 @@ export class TestSuiteManager {
     state.setShouldShowInformationWidget(true);
     state.setHighlightedLine(error.location.line);
     state.setHighlightedLineColor(ERROR_HIGHLIGHT_COLOR);
+    state.setUnderlineRange({
+      from: Math.max(0, error.location.absolute.begin - 1),
+      to: Math.max(0, error.location.absolute.end - 1)
+    });
   }
 
   /**

--- a/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
@@ -180,7 +180,10 @@ describe("TestSuiteManager", () => {
       const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
 
       const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-      const syntaxError = { message: "Unexpected token", location: { line: 5 } };
+      const syntaxError = {
+        message: "Unexpected token",
+        location: { line: 5, relative: { begin: 1, end: 9 }, absolute: { begin: 42, end: 50 } }
+      };
       (runTests as jest.Mock).mockImplementation(() => {
         throw syntaxError;
       });
@@ -198,7 +201,19 @@ describe("TestSuiteManager", () => {
       expect(widgetCall.html).not.toContain("Oops, something went wrong!");
       expect(state.setShouldShowInformationWidget).toHaveBeenCalledWith(true);
       expect(state.setHighlightedLine).toHaveBeenCalledWith(5);
+      expect(state.setUnderlineRange).toHaveBeenCalledWith({ from: 41, to: 49 });
       expect(state.setStatus).toHaveBeenCalledWith("error");
+    });
+
+    it("clears the underline range at the start of every run", async () => {
+      const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
+
+      const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
+      (runTests as jest.Mock).mockResolvedValue({ tests: [], status: "pass" });
+
+      await manager.runCode(mockCode, mockExercise);
+
+      expect(mockStore.getState().setUnderlineRange).toHaveBeenCalledWith(undefined);
     });
 
     it("rethrows non-syntax errors in test/dev so they surface in the overlay", async () => {


### PR DESCRIPTION
## Summary
- Syntax errors now produce a red character-range underline on the offending span, in addition to the existing full-line tint and info widget — matching Exercism's bootcamp editor.
- `TestSuiteManager.handleSyntaxError` now uses the real `SyntaxError` type from `@jiki/interpreters` and dispatches `setUnderlineRange({from: absolute.begin - 1, to: absolute.end - 1})`. Previously the inline interface dropped `location.absolute`, so the char range never reached CodeMirror.
- `prepareStateForTestRun` clears the underline at the start of every run so stale errors don't linger.
- The underline pipeline (extension, store action, EditorManager subscription, `.cm-underline` CSS) already existed — `applyUnderlineRange` was just marked UNUSED. That comment is now removed.

## Test plan
- [x] `pnpm test:app` — 1649 tests pass, including new coverage that `handleSyntaxError` dispatches `setUnderlineRange` with the right offsets and that `prepareStateForTestRun` clears it.
- [x] `tsc --noEmit` clean.
- [ ] Manual: open a JS exercise, type `fill_color_hex("#AA4A44)` (unterminated string), run — expect red line tint + red underline on `"#AA4A44)` + info widget.
- [ ] Manual: trigger another syntax error (missing paren, unexpected token) and confirm the underlined span matches what the interpreter reports.
- [ ] Manual: run a successful test after a failing one — the underline clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)