### PR TITLE
Redesign landing-page hero and refresh external header

### DIFF
--- a/app/components/landing-page/BootcampSection.tsx
+++ b/app/components/landing-page/BootcampSection.tsx
@@ -217,7 +217,7 @@ export function BootcampSection() {
           <div className={styles["building-section-arrow"]} ref={buildingSectionArrowRef}></div>
 
           <div className={styles.tag}>What we cover</div>
-          <h2>
+          <h2 className="text-center">
             But learning to code <strong>isn&apos;t enough</strong>
           </h2>
           <p className={`${styles.intro} mb-24 text-balance max-w-[820px]`}>

--- a/app/components/landing-page/Header.module.css
+++ b/app/components/landing-page/Header.module.css
@@ -3,9 +3,11 @@
     width: 100%;
     background: rgb(13, 18, 33);
     z-index: 9999;
-    padding-top: 16px;
-    padding-bottom: 16px;
+    padding-top: 10px;
+    padding-bottom: 10px;
     font-size: 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    background-color: #702af4;
 
     @media (min-width: 768px) {
         font-size: 18px;
@@ -40,6 +42,7 @@
         color: var(--color-gray-800);
         box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
         transition: all 0.3s ease-out;
+        border-color: var(--color-purple-700);
     }
     .loginButton {
         margin-left: auto;
@@ -53,6 +56,7 @@
         height: 0px;
         padding-top: 0;
         padding-bottom: 0;
+        border: 0;
         background-color: #702af4;
         position: fixed;
         top: 0;
@@ -61,10 +65,6 @@
             background-color 0.3s ease-out,
             opacity 0.3s ease-out,
             color 0.3s ease-out;
-
-        .button {
-            border-color: var(--color-purple-700);
-        }
 
         &.on-purple {
             background-color: white;

--- a/app/components/landing-page/Header.tsx
+++ b/app/components/landing-page/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
 
   return (
     <>
-      <div className={`${styles.nav} h-[64px]`} data-nav-fixed>
+      <div className={`${styles.nav} h-[63px]`} data-nav-fixed>
         <div className={`${shared["lg-container"]} flex flex-row items-center`} data-nav-contents>
           <Link className="flex flex-1 gap-12" href="/">
             <JikiLogo className={styles.logo} />

--- a/app/components/landing-page/Header.tsx
+++ b/app/components/landing-page/Header.tsx
@@ -15,7 +15,7 @@ export function Header() {
     <>
       <div className={`${styles.nav} h-[63px]`} data-nav-fixed>
         <div className={`${shared["lg-container"]} flex flex-row items-center`} data-nav-contents>
-          <Link className="flex flex-1 gap-12" href="/">
+          <Link className="flex grow-0 gap-12" href="/">
             <JikiLogo className={styles.logo} />
           </Link>
           <Link className={`ui-btn ui-btn-small ${styles.button} ${styles.loginButton}`} href="/auth/login">

--- a/app/components/landing-page/Hero.module.css
+++ b/app/components/landing-page/Hero.module.css
@@ -1,19 +1,106 @@
 .hero {
-    /* background-image: url("/static/images/landing-page/hero-bg.png"), */
-    background-image: linear-gradient(rgb(13, 18, 33), rgb(19, 47, 68));
-    background-repeat: repeat-y;
-    background-size: 100%;
-    padding-top: 24px;
+    background-image:
+        url("/static/images/landing-page/hero-grid.svg"), linear-gradient(rgb(13, 18, 33), rgb(19, 47, 68));
+    background-repeat: repeat, repeat-y;
+    background-size: 20px, 100%;
     color: white;
     overflow: hidden;
+    min-height: calc(100vh - 63px);
+    display: flex;
+    flex-direction: column;
 
-    @media (min-width: 768px) {
-        padding-top: 40px;
+    .container {
+        display: flex;
+        align-items: flex-start;
+        flex: 1;
+        padding-top: 24px;
+        padding-bottom: 80px;
+        background-image: linear-gradient(
+            to right,
+            transparent 0%,
+            rgba(15, 32, 50, 0.5) 30%,
+            rgba(15, 32, 50, 0.5) 70%,
+            transparent 100%
+        );
+
+        @media (min-width: 768px) {
+            padding-top: 54px;
+        }
+    }
+    .hero-lhs {
+        max-width: 580px;
+    }
+    .hero-rhs {
+        width: 100%;
+        max-width: 580px;
+        flex-grow: 0;
+        margin-left: 54px;
     }
 
-    .md-container {
-        padding-left: min(4%, 20px);
-        padding-right: min(4%, 20px);
+    .hero-btn {
+        margin-top: 20px;
+        padding: 18px 64px;
+        background: #7c3aed;
+        color: #fff;
+        font-weight: 600;
+        border-radius: 12px;
+        font-size: 20px;
+        border-width: 1px;
+        border-color: #c1b1dc;
+        animation: hero-btn-pulse 2.4s ease-in-out infinite;
+    }
+
+    .cta-wrapper {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .watch-prompt {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin: 0 auto;
+        max-width: 270px;
+        text-align: center;
+        color: #eee;
+        font-size: 17px;
+        font-weight: 400;
+        font-style: italic;
+    }
+
+    .watch-arrow {
+        width: 88px;
+        height: auto;
+        transform: translateX(-50%) rotate(180deg);
+        margin-bottom: 8px;
+        filter: brightness(0) invert(1);
+        opacity: 0.85;
+    }
+
+    .cta-subtext {
+        margin-top: 10px;
+        font-size: 17px;
+        color: #eee;
+        text-align: center;
+    }
+
+    .video-container {
+        width: 100%;
+        object-fit: fill;
+        background-color: #fff;
+        border-radius: 8px;
+        padding: 8px;
+        box-shadow: 0 1px 20px rgba(0, 0, 0, 0.1);
+        position: relative;
+        aspect-ratio: 760/434.5;
+
+        .video {
+            width: 100%;
+            background-color: black;
+            padding: 56.25% 0 0 0;
+            position: relative;
+        }
     }
 
     h1 {
@@ -23,7 +110,8 @@
         font-weight: 300;
 
         @media (min-width: 640px) {
-            font-size: 65px;
+            font-size: 58px;
+            line-height: 1.15;
         }
 
         strong {
@@ -33,7 +121,7 @@
 
     .tagline {
         font-size: 18px;
-        margin-bottom: 20px;
+        margin-bottom: 16px;
         font-weight: 300;
         color: var(--color-gray-200);
         margin-left: auto;
@@ -67,7 +155,7 @@
     }
 
     .bubbles {
-        margin-bottom: 40px;
+        margin-top: 20px;
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -149,26 +237,6 @@
         margin: 30px auto;
     }
 
-    .video-container {
-        max-width: 760px;
-        object-fit: fill;
-        background-color: #fff;
-        border-radius: 8px;
-        margin-left: auto;
-        margin-right: auto;
-        padding: 8px;
-        box-shadow: 0 1px 20px rgba(0, 0, 0, 0.1);
-        position: relative;
-        aspect-ratio: 760/434.5;
-
-        .video {
-            width: 100%;
-            background-color: black;
-            padding: 56.25% 0 0 0;
-            position: relative;
-        }
-    }
-
     .supported-by {
         .google {
             height: 42px;
@@ -234,7 +302,7 @@
 
 .scrolling-testimonials {
     display: flex;
-    margin-top: 80px;
+    margin-top: auto;
     position: relative;
 
     .hamster {
@@ -280,5 +348,19 @@
                 margin-right: 20px;
             }
         }
+    }
+}
+
+@keyframes hero-btn-pulse {
+    0%,
+    100% {
+        box-shadow:
+            0 0 5px rgba(255, 255, 255, 0.5),
+            0 0 5px rgba(255, 255, 255, 0.5);
+    }
+    50% {
+        box-shadow:
+            0 0 5px rgba(255, 255, 255, 0.5),
+            0 0 10px rgba(255, 255, 255, 0.8);
     }
 }

--- a/app/components/landing-page/Hero.module.css
+++ b/app/components/landing-page/Hero.module.css
@@ -5,7 +5,7 @@
     background-size: 20px, 100%;
     color: white;
     overflow: hidden;
-    min-height: calc(100vh - 63px);
+    min-height: calc(100vh - 70px);
     display: flex;
     flex-direction: column;
 
@@ -26,34 +26,37 @@
         @media (min-width: 768px) {
             padding-top: 54px;
         }
+
+        @media (max-width: 1023px) {
+            flex-direction: column;
+            align-items: center;
+        }
     }
     .hero-lhs {
         max-width: 580px;
+
+        @media (max-width: 1023px) {
+            max-width: 540px;
+            text-align: center;
+        }
     }
     .hero-rhs {
         width: 100%;
         max-width: 580px;
         flex-grow: 0;
         margin-left: 54px;
-    }
 
-    .hero-btn {
-        margin-top: 20px;
-        padding: 18px 64px;
-        background: #7c3aed;
-        color: #fff;
-        font-weight: 600;
-        border-radius: 12px;
-        font-size: 20px;
-        border-width: 1px;
-        border-color: #c1b1dc;
-        animation: hero-btn-pulse 2.4s ease-in-out infinite;
+        @media (max-width: 1023px) {
+            margin-left: 0;
+            margin-top: 40px;
+        }
     }
 
     .cta-wrapper {
         display: inline-flex;
         flex-direction: column;
         align-items: center;
+        margin-top: 16px;
     }
 
     .watch-prompt {
@@ -67,6 +70,10 @@
         font-size: 17px;
         font-weight: 400;
         font-style: italic;
+
+        @media (max-width: 1023px) {
+            display: none;
+        }
     }
 
     .watch-arrow {
@@ -114,6 +121,10 @@
             line-height: 1.15;
         }
 
+        @media (min-width: 1024px) and (max-width: 1189px) {
+            font-size: 48px;
+        }
+
         strong {
             font-weight: 600;
         }
@@ -129,6 +140,10 @@
 
         @media (min-width: 768px) {
             font-size: 22px;
+        }
+
+        @media (min-width: 1024px) and (max-width: 1189px) {
+            font-size: 20px;
         }
 
         strong {
@@ -348,19 +363,5 @@
                 margin-right: 20px;
             }
         }
-    }
-}
-
-@keyframes hero-btn-pulse {
-    0%,
-    100% {
-        box-shadow:
-            0 0 5px rgba(255, 255, 255, 0.5),
-            0 0 5px rgba(255, 255, 255, 0.5);
-    }
-    50% {
-        box-shadow:
-            0 0 5px rgba(255, 255, 255, 0.5),
-            0 0 10px rgba(255, 255, 255, 0.8);
     }
 }

--- a/app/components/landing-page/Hero.tsx
+++ b/app/components/landing-page/Hero.tsx
@@ -2,23 +2,24 @@
 
 import { useEffect, useRef } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import MuxPlayer from "@mux/mux-player-react";
 import { annotate } from "rough-notation";
 import styles from "./Hero.module.css";
 import shared from "./shared.module.css";
+import rocket from "./rocketLaunch.module.css";
 import { useScrollingTestimonials } from "./hooks/useScrollingTestimonials";
 import { useHamster } from "./hooks/useHamster";
+import { useRocketLaunch } from "./hooks/useRocketLaunch";
 
 export function Hero() {
-  const { hamsterRef, smokeRef, containerRef: hamsterContainerRef } = useHamster();
-  const { containerRef: marqueeContainerRef, ulRef } = useScrollingTestimonials(hamsterRef);
-
   const headlineRef = useRef<HTMLHeadingElement>(null);
   const taglineRef = useRef<HTMLDivElement>(null);
+  const audienceRef = useRef<HTMLParagraphElement>(null);
+  const ctaLaunch = useRocketLaunch("/auth/signup");
 
   useEffect(() => {
     const can = headlineRef.current?.querySelector<HTMLElement>("[data-anim='underline-can']");
-    const llm = taglineRef.current?.querySelector<HTMLElement>("[data-anim='highlight-llm']");
 
     const annotations: { hide: () => void }[] = [];
 
@@ -38,118 +39,186 @@ export function Hero() {
       annotations.push(a);
     }
 
-    let highlightTimer: ReturnType<typeof setTimeout> | undefined;
-    if (llm) {
-      highlightTimer = setTimeout(() => {
-        const a = annotate(llm, {
-          type: "highlight",
-          color: "#ce19e6",
-          strokeWidth: 50,
-          animationDuration: 600,
-          iterations: 2,
-          padding: [16, 6],
-          multiline: true,
-          // @ts-expect-error rough-notation supports roughness even though its types omit it
-          roughness: 0.5
-        });
-        a.show();
-        annotations.push(a);
-      }, 1200);
+    let headlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const headlineTarget = headlineRef.current?.querySelector<HTMLElement>("[data-anim='highlight-headline']");
+    if (headlineTarget) {
+      const a = annotate(headlineTarget, {
+        type: "underline",
+        color: "#ce19e6",
+        strokeWidth: 6,
+        animationDuration: 800,
+        iterations: 2,
+        padding: [-13, 0],
+        multiline: true,
+        // @ts-expect-error rough-notation supports roughness even though its types omit it
+        roughness: 1
+      });
+      headlineTimer = setTimeout(() => a.show(), 400);
+      annotations.push(a);
     }
 
+    const audienceTimers: ReturnType<typeof setTimeout>[] = [];
+    const audienceTargets = audienceRef.current?.querySelectorAll<HTMLElement>("[data-anim='highlight-audience']");
+    audienceTargets?.forEach((el, i) => {
+      const t = setTimeout(
+        () => {
+          const a = annotate(el, {
+            type: "underline",
+            color: "#FFF176",
+            strokeWidth: 3,
+            animationDuration: 800,
+            iterations: 1,
+            padding: [-2, 6],
+            multiline: true,
+            // @ts-expect-error rough-notation supports roughness even though its types omit it
+            roughness: 1
+          });
+          a.show();
+          annotations.push(a);
+        },
+        2500 + i * 1000
+      );
+      audienceTimers.push(t);
+    });
+
     return () => {
-      if (highlightTimer) clearTimeout(highlightTimer);
+      if (headlineTimer) clearTimeout(headlineTimer);
+      audienceTimers.forEach((t) => clearTimeout(t));
       annotations.forEach((a) => a.hide());
     };
   }, []);
 
   return (
     <div className={styles.hero}>
-      <div className={shared["md-container"]}>
-        <div className="text-center">
+      <div className={[styles["container"], shared["lg-container"]].join(" ")}>
+        <div className={styles["hero-lhs"]}>
           <h1 ref={headlineRef} className={styles["rock-solid"]} data-rock-solid>
-            Yes, you{" "}
-            <strong data-anim="underline-can" className="inline-block">
-              can
-            </strong>{" "}
-            still get into tech in {new Date().getFullYear()}.
+            Learn to{" "}
+            <span data-anim="highlight-headline" className="inline">
+              code and build
+            </span>{" "}
+            in the LLM-era!
           </h1>
-          <div ref={taglineRef} className={`${styles.tagline} max-w-[750px]`} data-tagline>
-            The skills you need to{" "}
-            <span data-anim="highlight-llm" className="inline">
-              be relevant in the <strong className="font-semibold">LLM-era.</strong>
+          <div ref={taglineRef} className={`${styles.tagline}`} data-tagline>
+            Learn the skills you need to create awesome things, be productive, and{" "}
+            <strong className="font-semibold">stay relevant in {new Date().getFullYear()}.</strong>
+          </div>
+          <p ref={audienceRef} className={`${styles.tagline} `}>
+            Designed for{" "}
+            <span data-anim="highlight-audience" className="font-medium text-white">
+              people getting into tech
             </span>
+            ,{" "}
+            <span data-anim="highlight-audience" className="font-medium text-white">
+              junior developers
+            </span>{" "}
+            who want to accelerate, and{" "}
+            <span data-anim="highlight-audience" className="font-medium text-white">
+              vibe-coders
+            </span>{" "}
+            wanting to do things properly!
+          </p>
+          <div className={styles["cta-wrapper"]}>
+            <Link
+              href="/auth/signup"
+              className={["ui-btn", styles["hero-btn"], rocket.bounceOnHover].join(" ")}
+              onClick={ctaLaunch.handleClick}
+            >
+              Sign Up (it&apos;s free!){" "}
+              <span
+                className={`inline-block align-middle ${rocket.rocketWrapper} ${rocket.rocketWrapperLg} ${ctaLaunch.launching ? rocket.launching : ""}`}
+              >
+                <Image
+                  src="/static/images/landing-page/rocket.svg"
+                  alt=""
+                  width={32}
+                  height={32}
+                  className={rocket.rocket}
+                />
+              </span>
+            </Link>
+            <div className={styles["cta-subtext"]}>...or read on to learn more!</div>
           </div>
         </div>
-        <div className={styles.bubbles}>
-          <div className={styles.bubble}>
-            <Image src="/static/images/landing-page/video-tutorial.svg" alt="" width={16} height={16} />
-            <div className={styles.text}>
-              Learn to <strong>Code</strong>
-            </div>
+        <div className={styles["hero-rhs"]}>
+          <div className={styles["video-container"]} data-video-container>
+            <MuxPlayer
+              playbackId="v2kO7cS7n8IhguzE013jOmPHmkXrrIwFNcM5qgz1P17c"
+              poster="https://assets.exercism.org/images/thumbnails/jiki-waiting.png"
+              metadata={{ video_title: "Waiting Page 1" }}
+              accentColor="#7c3aed"
+              style={{ display: "block", width: "100%", aspectRatio: "16/9" }}
+            />
           </div>
-          <div className={styles.bubble}>
-            <Image src="/static/images/landing-page/fun.svg" alt="" width={16} height={16} />
-            <div className={styles.text}>
-              <strong>Build</strong> with LLMs
-            </div>
-          </div>
-          <div className={styles.bubble}>
-            <Image src="/static/images/landing-page/globe.svg" alt="" width={16} height={16} />
-            <div className={styles.text}>
-              In your <strong>Language</strong>
-            </div>
-          </div>
-        </div>
-        <div className={styles["video-container"]} data-video-container>
-          <MuxPlayer
-            playbackId="v2kO7cS7n8IhguzE013jOmPHmkXrrIwFNcM5qgz1P17c"
-            poster="https://assets.exercism.org/images/thumbnails/jiki-waiting.png"
-            metadata={{ video_title: "Waiting Page 1" }}
-            accentColor="#7c3aed"
-            style={{ display: "block", width: "100%", aspectRatio: "16/9" }}
-          />
+          <WatchPrompt />
         </div>
       </div>
-      <div className={styles["scrolling-testimonials"]} ref={hamsterContainerRef}>
-        <div className={styles.hamster} ref={hamsterRef}></div>
-        <div ref={smokeRef}></div>
-        <div className={styles.inner} ref={marqueeContainerRef}>
-          <ul ref={ulRef}>
-            <li>&quot;Perfect mixture of challenge and fun&quot;</li>
-            <li>&quot;Amazing value&quot;</li>
-            <li>&quot;My best time investment for years&quot;</li>
-            <li>&quot;Incredibly Fun!&quot;</li>
-            <li>&quot;Its been transformative!&quot;</li>
-            <li>&quot;You *will* learn to code&quot;</li>
-            <li>&quot;Learning, as it should be!&quot;</li>
-            <li>&quot;The best course I&apos;ve done&quot;</li>
-            <li>&quot;Made learning a joy again&quot;</li>
-            <li>&quot;This course is pure gold.&quot;</li>
-            <li>&quot;A wonderful Learning Experience&quot;</li>
-            <li>&quot;Proper Hands-on learning&quot;</li>
-            <li>&quot;The knowledge you didn&apos;t think you needed&quot;</li>
-            <li>&quot;100% recommended!&quot;</li>
-            <li>&quot;So glad I stumbled on this&quot;</li>
-            <li>&quot;A great way to learn!&quot;</li>
-            <li>&quot;Fun exercises, clear explanations, cool hats&quot;</li>
-            <li>&quot;Exceptional course, truly outstanding&quot;</li>
-            <li>&quot;Addictive in a good way&quot;</li>
-            <li>&quot;Amazing fun&quot;</li>
-            <li>&quot;Fantastic community&quot;</li>
-            <li>&quot;Zero coding experience required&quot;</li>
-            <li>&quot;Fun and inspiring&quot;</li>
-            <li>&quot;It&apos;s changed the way I think about learning&quot;</li>
-            <li>&quot;An incredibly rewarding journey&quot;</li>
-            <li>&quot;Insane value&quot;</li>
-            <li>&quot;An opportunity to learn from a bonafide master&quot;</li>
-            <li>&quot;It&apos;s really an amazing and lovely thing&quot;</li>
-            <li>&quot;The best investment I made in myself this year&quot;</li>
-            <li>&quot;Its massively increased my confidence and motivation&quot;</li>
-            <li>&quot;Very supportive community!&quot;</li>
-            <li>&quot;Even as a prior programmer, its transformative!&quot;</li>
-          </ul>
-        </div>
+      <ScrollingTestimonials />
+    </div>
+  );
+}
+
+function WatchPrompt() {
+  return (
+    <div className={styles["watch-prompt"]}>
+      <Image
+        src="/static/images/landing-page/arrow-1.svg"
+        alt=""
+        width={48}
+        height={100}
+        className={styles["watch-arrow"]}
+      />
+      <p>
+        (Reading not your thing? <span className="font-medium text-white">Click play</span> and I&apos;ll tell you
+        everything you need to know!)
+      </p>
+    </div>
+  );
+}
+
+function ScrollingTestimonials() {
+  const { hamsterRef, smokeRef, containerRef: hamsterContainerRef } = useHamster();
+  const { containerRef: marqueeContainerRef, ulRef } = useScrollingTestimonials(hamsterRef);
+
+  return (
+    <div className={styles["scrolling-testimonials"]} ref={hamsterContainerRef}>
+      <div className={styles.hamster} ref={hamsterRef}></div>
+      <div ref={smokeRef}></div>
+      <div className={styles.inner} ref={marqueeContainerRef}>
+        <ul ref={ulRef}>
+          <li>&quot;Perfect mixture of challenge and fun&quot;</li>
+          <li>&quot;Amazing value&quot;</li>
+          <li>&quot;My best time investment for years&quot;</li>
+          <li>&quot;Incredibly Fun!&quot;</li>
+          <li>&quot;Its been transformative!&quot;</li>
+          <li>&quot;You *will* learn to code&quot;</li>
+          <li>&quot;Learning, as it should be!&quot;</li>
+          <li>&quot;The best course I&apos;ve done&quot;</li>
+          <li>&quot;Made learning a joy again&quot;</li>
+          <li>&quot;This course is pure gold.&quot;</li>
+          <li>&quot;A wonderful Learning Experience&quot;</li>
+          <li>&quot;Proper Hands-on learning&quot;</li>
+          <li>&quot;The knowledge you didn&apos;t think you needed&quot;</li>
+          <li>&quot;100% recommended!&quot;</li>
+          <li>&quot;So glad I stumbled on this&quot;</li>
+          <li>&quot;A great way to learn!&quot;</li>
+          <li>&quot;Fun exercises, clear explanations, cool hats&quot;</li>
+          <li>&quot;Exceptional course, truly outstanding&quot;</li>
+          <li>&quot;Addictive in a good way&quot;</li>
+          <li>&quot;Amazing fun&quot;</li>
+          <li>&quot;Fantastic community&quot;</li>
+          <li>&quot;Zero coding experience required&quot;</li>
+          <li>&quot;Fun and inspiring&quot;</li>
+          <li>&quot;It&apos;s changed the way I think about learning&quot;</li>
+          <li>&quot;An incredibly rewarding journey&quot;</li>
+          <li>&quot;Insane value&quot;</li>
+          <li>&quot;An opportunity to learn from a bonafide master&quot;</li>
+          <li>&quot;It&apos;s really an amazing and lovely thing&quot;</li>
+          <li>&quot;The best investment I made in myself this year&quot;</li>
+          <li>&quot;Its massively increased my confidence and motivation&quot;</li>
+          <li>&quot;Very supportive community!&quot;</li>
+          <li>&quot;Even as a prior programmer, its transformative!&quot;</li>
+        </ul>
       </div>
     </div>
   );

--- a/app/components/landing-page/Hero.tsx
+++ b/app/components/landing-page/Hero.tsx
@@ -2,21 +2,18 @@
 
 import { useEffect, useRef } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import MuxPlayer from "@mux/mux-player-react";
 import { annotate } from "rough-notation";
 import styles from "./Hero.module.css";
 import shared from "./shared.module.css";
-import rocket from "./rocketLaunch.module.css";
 import { useScrollingTestimonials } from "./hooks/useScrollingTestimonials";
 import { useHamster } from "./hooks/useHamster";
-import { useRocketLaunch } from "./hooks/useRocketLaunch";
+import { SignupButton } from "./SignupButton";
 
 export function Hero() {
   const headlineRef = useRef<HTMLHeadingElement>(null);
-  const taglineRef = useRef<HTMLDivElement>(null);
+  const taglineRef = useRef<HTMLParagraphElement>(null);
   const audienceRef = useRef<HTMLParagraphElement>(null);
-  const ctaLaunch = useRocketLaunch("/auth/signup");
 
   useEffect(() => {
     const can = headlineRef.current?.querySelector<HTMLElement>("[data-anim='underline-can']");
@@ -42,13 +39,15 @@ export function Hero() {
     let headlineTimer: ReturnType<typeof setTimeout> | undefined;
     const headlineTarget = headlineRef.current?.querySelector<HTMLElement>("[data-anim='highlight-headline']");
     if (headlineTarget) {
+      const w = window.innerWidth;
+      const isSmallHeadline = w < 640 || (w >= 1024 && w < 1190);
       const a = annotate(headlineTarget, {
         type: "underline",
         color: "#ce19e6",
-        strokeWidth: 6,
+        strokeWidth: isSmallHeadline ? 4 : 6,
         animationDuration: 800,
         iterations: 2,
-        padding: [-13, 0],
+        padding: isSmallHeadline ? [-10, 0] : [-13, 0],
         multiline: true,
         // @ts-expect-error rough-notation supports roughness even though its types omit it
         roughness: 1
@@ -99,10 +98,10 @@ export function Hero() {
             </span>{" "}
             in the LLM-era!
           </h1>
-          <div ref={taglineRef} className={`${styles.tagline}`} data-tagline>
+          <p ref={taglineRef} className={`${styles.tagline}`} data-tagline>
             Learn the skills you need to create awesome things, be productive, and{" "}
             <strong className="font-semibold">stay relevant in {new Date().getFullYear()}.</strong>
-          </div>
+          </p>
           <p ref={audienceRef} className={`${styles.tagline} `}>
             Designed for{" "}
             <span data-anim="highlight-audience" className="font-medium text-white">
@@ -119,24 +118,7 @@ export function Hero() {
             wanting to do things properly!
           </p>
           <div className={styles["cta-wrapper"]}>
-            <Link
-              href="/auth/signup"
-              className={["ui-btn", styles["hero-btn"], rocket.bounceOnHover].join(" ")}
-              onClick={ctaLaunch.handleClick}
-            >
-              Sign Up (it&apos;s free!){" "}
-              <span
-                className={`inline-block align-middle ${rocket.rocketWrapper} ${rocket.rocketWrapperLg} ${ctaLaunch.launching ? rocket.launching : ""}`}
-              >
-                <Image
-                  src="/static/images/landing-page/rocket.svg"
-                  alt=""
-                  width={32}
-                  height={32}
-                  className={rocket.rocket}
-                />
-              </span>
-            </Link>
+            <SignupButton />
             <div className={styles["cta-subtext"]}>...or read on to learn more!</div>
           </div>
         </div>

--- a/app/components/landing-page/LandingPage.tsx
+++ b/app/components/landing-page/LandingPage.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import Image from "next/image";
-import { ExternalFooter } from "../layout/ExternalFooter";
+import HeaderLayout from "../layout/HeaderLayout";
 import { BootcampSection } from "./BootcampSection";
 import { Exercism } from "./Exercism";
 import { FAQs } from "./FAQs";
-import { Header } from "./Header";
 import { Hero } from "./Hero";
 import { useStickyNav } from "./hooks/useStickyNav";
 import styles from "./LandingPage.module.css";
@@ -18,29 +17,29 @@ export function LandingPage() {
 
   return (
     <div className={styles.page}>
-      <Header />
-      <Hero />
-      <WelcomeSection />
-      <BootcampSection />
-      <TestimonialsSection />
-      <SignupSection />
-      <Image
-        className="w-[100px] mx-auto my-64"
-        src="/static/images/landing-page/divider.png"
-        alt=""
-        width={100}
-        height={100}
-      />
-      <Exercism />
-      <Image
-        className="w-[100px] mx-auto my-64"
-        src="/static/images/landing-page/divider.png"
-        alt=""
-        width={100}
-        height={100}
-      />
-      <FAQs />
-      <ExternalFooter />
+      <HeaderLayout>
+        <Hero />
+        <WelcomeSection />
+        <BootcampSection />
+        <TestimonialsSection />
+        <SignupSection />
+        <Image
+          className="w-[100px] mx-auto my-64"
+          src="/static/images/landing-page/divider.png"
+          alt=""
+          width={100}
+          height={100}
+        />
+        <Exercism />
+        <Image
+          className="w-[100px] mx-auto my-64"
+          src="/static/images/landing-page/divider.png"
+          alt=""
+          width={100}
+          height={100}
+        />
+        <FAQs />
+      </HeaderLayout>
     </div>
   );
 }

--- a/app/components/landing-page/SignupButton.module.css
+++ b/app/components/landing-page/SignupButton.module.css
@@ -1,0 +1,31 @@
+.btn {
+    padding: 18px 64px;
+    background: #7c3aed;
+    color: #fff;
+    font-weight: 600;
+    border-radius: 12px;
+    font-size: 20px;
+    border-width: 1px;
+    border-color: #c1b1dc;
+    animation: btn-pulse 2.4s ease-in-out infinite;
+}
+
+.free {
+    @media (max-width: 767px) {
+        display: none;
+    }
+}
+
+@keyframes btn-pulse {
+    0%,
+    100% {
+        box-shadow:
+            0 0 5px rgba(255, 255, 255, 0.5),
+            0 0 10px rgba(255, 255, 255, 0.5);
+    }
+    50% {
+        box-shadow:
+            0 0 5px rgba(255, 255, 255, 0.5),
+            0 0 22px rgba(255, 255, 255, 0.8);
+    }
+}

--- a/app/components/landing-page/SignupButton.tsx
+++ b/app/components/landing-page/SignupButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./SignupButton.module.css";
+import rocket from "./rocketLaunch.module.css";
+import { useRocketLaunch } from "./hooks/useRocketLaunch";
+
+interface SignupButtonProps {
+  className?: string;
+}
+
+export function SignupButton({ className = "" }: SignupButtonProps) {
+  const ctaLaunch = useRocketLaunch("/auth/signup");
+
+  return (
+    <Link
+      href="/auth/signup"
+      className={["ui-btn", styles.btn, rocket.bounceOnHover, className].join(" ")}
+      onClick={ctaLaunch.handleClick}
+    >
+      <span>
+        Sign Up<span className={styles.free}> (it&apos;s free!)</span>
+      </span>
+      <span
+        className={`inline-block align-middle ${rocket.rocketWrapper} ${rocket.rocketWrapperLg} ${ctaLaunch.launching ? rocket.launching : ""}`}
+      >
+        <Image src="/static/images/landing-page/rocket.svg" alt="" width={32} height={32} className={rocket.rocket} />
+      </span>
+    </Link>
+  );
+}

--- a/app/components/landing-page/WelcomeSection.module.css
+++ b/app/components/landing-page/WelcomeSection.module.css
@@ -125,6 +125,22 @@
     transform: rotate(140deg);
 }
 
+.ctaRowCompact {
+    display: none;
+    justify-content: center;
+    margin-top: 32px;
+    margin-bottom: 32px;
+
+    @media (max-width: 999px) {
+        display: flex;
+    }
+
+    > a {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
 .ctaRow {
     display: flex;
     align-items: center;
@@ -132,6 +148,10 @@
     gap: 24px;
     margin-top: 32px;
     margin-bottom: 32px;
+
+    @media (max-width: 999px) {
+        display: none;
+    }
 
     > a {
         flex-grow: 1;

--- a/app/components/landing-page/WelcomeSection.tsx
+++ b/app/components/landing-page/WelcomeSection.tsx
@@ -37,7 +37,7 @@ export function WelcomeSection() {
               <span className="rough-highlight">
                 <strong>Software engineering has never been about writing code.</strong>
               </span>{" "}
-              The coding is how you communicate with the computer, but the real skill has always been in{" "}
+              Coding is how you communicate with the computer, but the real skill has always been in{" "}
               <strong>critical-thinking</strong>, in <strong>problem solving</strong>, in{" "}
               <strong>building and architecting</strong>. It&apos;s always been about taking ideas and{" "}
               <strong>turning them into reality</strong>.
@@ -45,12 +45,13 @@ export function WelcomeSection() {
             <p>
               Thanks to LLMs{" "}
               <span className="rough-highlight">
-                <strong>you don&apos;t have to spend years learning</strong>
+                <strong>you don&apos;t have to spend years mastering coding</strong>
               </span>{" "}
               in order to be useful. But you still have a lot to learn! You still need to learn{" "}
-              <strong>coding fundamentals</strong>. You need to learn <strong>how everything works</strong>. You need to
-              learn <strong>how to build</strong>. But the journey is <strong>much more fun</strong> than it&apos;s ever
-              been before. And I&apos;m here{" "}
+              <strong>coding fundamentals</strong>. You need to learn{" "}
+              <strong className="rough-highlight">how everything works</strong>. You need to learn{" "}
+              <strong className="rough-highlight">how to build</strong>. But the journey is{" "}
+              <strong>much more fun</strong> than it&apos;s ever been before. And I&apos;m here{" "}
               <strong className="font-medium">
                 <span className="intro-you">to be your guide on that journey!</span>
               </strong>
@@ -82,12 +83,12 @@ export function WelcomeSection() {
         </p>
         <p>
           If you&apos;re starting out today then most of your work is going to be{" "}
-          <strong>reading code, not writing it.</strong>
-          And that means something that&apos;s a little sad for me to admit...
+          <strong>reading code, not writing it.</strong> And that means something that&apos;s a little sad for me to
+          admit...
         </p>
         <h3>
           <strong>Getting good</strong> at writing code is{" "}
-          <span className="inline rough-highlight">utterly irrelevant</span> 😢
+          <span className="inline rough-highlight">becoming irrelevant</span> 😢
         </h3>
         <p>
           You are never going to be better than an LLM at writing code. I have been coding for 34 years and LLMs are at

--- a/app/components/landing-page/WelcomeSection.tsx
+++ b/app/components/landing-page/WelcomeSection.tsx
@@ -10,6 +10,7 @@ import { useWavingHand } from "./hooks/useWavingHand";
 import { useArrowAnimation } from "./hooks/useArrowAnimations";
 import { useRocketLaunch } from "./hooks/useRocketLaunch";
 import rocket from "./rocketLaunch.module.css";
+import { SignupButton } from "./SignupButton";
 
 export function WelcomeSection() {
   const annotationsRef = useRoughAnnotations();
@@ -254,6 +255,9 @@ export function WelcomeSection() {
           <span className={`${styles.ctaPointer} ${styles.ctaPointerLeft}`} aria-hidden="true">
             👈
           </span>
+        </div>
+        <div className={styles.ctaRowCompact}>
+          <SignupButton />
         </div>
         {/* <h3>
           <span className="rough-highlight">Focusing on what matters.</span>

--- a/app/components/layout/header/external.tsx
+++ b/app/components/layout/header/external.tsx
@@ -2,15 +2,29 @@ import Link from "next/link";
 import JikiLogo from "@/icons/jiki-logo.svg";
 import shared from "@/components/landing-page/shared.module.css";
 
+const navLinkStyle = { borderBottom: "1px solid var(--color-gray-400)", lineHeight: 1.2 };
+
 export default function ExternalHeader() {
   return (
     <header className="fixed top-0 left-0 right-0 h-72 bg-white border-b-2 border-gray-200 z-[1000]">
-      <div className={`${shared["lg-container"]} h-full flex items-center justify-between`}>
+      <div className={`${shared["lg-container"]} h-full flex items-center gap-36`}>
         <Link href="/" aria-label="Jiki home" className="flex items-center text-gray-900">
           <JikiLogo className="h-40 w-auto" />
         </Link>
 
-        <div className="flex items-center gap-12">
+        <div className="flex items-center gap-12 font-medium text-gray-700 max-[719px]:hidden">
+          <Link href="/about" style={navLinkStyle}>
+            About
+          </Link>
+          <Link href="/premium" style={navLinkStyle}>
+            Premium
+          </Link>
+          <Link href="/testimonials" style={navLinkStyle}>
+            Testimonials
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-12 ml-auto">
           <Link href="/auth/login" className="ui-btn ui-btn-small ui-btn-secondary">
             Login
           </Link>

--- a/app/components/premium/PremiumPage.module.css
+++ b/app/components/premium/PremiumPage.module.css
@@ -528,7 +528,7 @@
 /* FAQ section */
 
 .faq-section {
-    padding: 20px 16px 60px;
+    padding: 40px 16px 60px;
     background: white;
 }
 
@@ -540,7 +540,7 @@
 
 @media (min-width: 768px) {
     .faq-section {
-        padding: 20px 40px 60px;
+        padding: 40px 40px 60px;
     }
 
     .faq-inner {

--- a/app/public/static/images/landing-page/hero-grid.svg
+++ b/app/public/static/images/landing-page/hero-grid.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <g opacity="0.1">
+    <line x1="40" y1="0" x2="40" y2="40" stroke="#ddd" stroke-width="5"/>
+    <line x1="0" y1="40" x2="40" y2="40" stroke="#ddd" stroke-width="5"/>
+  </g>
+</svg>

--- a/app/tests/e2e/auth-flows.test.ts
+++ b/app/tests/e2e/auth-flows.test.ts
@@ -104,7 +104,7 @@ test.describe("Authentication Flows", () => {
     await waitForLoadingToComplete(page);
     await page.locator("h1").waitFor();
     const heading = await page.locator("h1").textContent();
-    expect(heading).toContain("get into tech in 2026");
+    expect(heading).toContain("Learn to code and build");
   }
 
   async function assertSignUpButton(page: Page) {

--- a/app/tests/e2e/home.test.ts
+++ b/app/tests/e2e/home.test.ts
@@ -17,7 +17,7 @@ test.describe("Home Page E2E", () => {
 
   test("should display the marketing headline", async ({ page }) => {
     const headingText = await page.locator("h1").textContent();
-    expect(headingText).toContain("get into tech in 2026");
+    expect(headingText).toContain("Learn to code and build");
   });
 
   test("should have login and signup links", async ({ page }) => {

--- a/app/tests/integration/home.test.tsx
+++ b/app/tests/integration/home.test.tsx
@@ -19,7 +19,8 @@ describe("Home Page (Landing Page)", () => {
     const loginLink = screen.getByRole("link", { name: "Log In" });
     expect(loginLink).toHaveAttribute("href", "/auth/login");
 
-    const signupLink = screen.getByRole("link", { name: /Sign Up/ });
-    expect(signupLink).toHaveAttribute("href", "/auth/signup");
+    const signupLinks = screen.getAllByRole("link", { name: /Sign Up/ });
+    expect(signupLinks.length).toBeGreaterThan(0);
+    signupLinks.forEach((link) => expect(link).toHaveAttribute("href", "/auth/signup"));
   });
 });

--- a/app/tests/integration/home.test.tsx
+++ b/app/tests/integration/home.test.tsx
@@ -16,7 +16,7 @@ describe("Home Page (Landing Page)", () => {
   it("has Log In and Sign Up links in the header", async () => {
     render(await RootPage());
 
-    const loginLink = screen.getByRole("link", { name: "Log In" });
+    const loginLink = screen.getByRole("link", { name: /Log ?in/i });
     expect(loginLink).toHaveAttribute("href", "/auth/login");
 
     const signupLinks = screen.getAllByRole("link", { name: /Sign Up/ });


### PR DESCRIPTION
## Summary
- Reworks the landing-page hero with a new headline, audience copy, rough-notation accents, grid background and a pulsing purple Sign Up CTA.
- Extracts `SignupButton` into its own module so it can be reused; swaps the chunky WelcomeSection CTA for the compact button below 1000px.
- Replaces the bespoke landing-page `Header` with the shared `HeaderLayout` and adds About / Premium / Testimonials nav links to `ExternalHeader` (hidden below 720px).
- Adds responsive font sizing and a single-column reflow for the hero, plus a small `BootcampSection` h2 centering tweak and a `PremiumPage` FAQ padding bump.

## Test plan
- [ ] Load the landing page at >=1190px, 1024-1189px, 768-1023px and <768px viewports and confirm hero layout/typography matches the design.
- [ ] Click "Sign Up (it's free!)" and confirm rocket-launch animation + navigation to `/auth/signup`.
- [ ] Resize across 1000px to confirm the WelcomeSection swaps the "Enough with all the talking!" CTA for the compact SignupButton.
- [ ] Visit `/premium` and confirm the shared header still renders and the FAQ section's new top padding looks right.
- [ ] Confirm the ExternalHeader nav links (About / Premium / Testimonials) hide below 720px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)