### PR TITLE
Report swallowed API errors to Sentry

### DIFF
--- a/app/components/build-episode/lib/useBuildEpisodeProgress.ts
+++ b/app/components/build-episode/lib/useBuildEpisodeProgress.ts
@@ -1,6 +1,7 @@
 import type { MuxPlayerRefAttributes } from "@mux/mux-player-react";
 import { useEffect, useRef, useState } from "react";
 import { fetchUserVideo, updateUserVideoPercentage, type UserVideoData } from "@/lib/api/user-videos";
+import { reportError } from "@/lib/reportError";
 
 interface ProgressPlayer {
   getCurrentTime: () => number;
@@ -44,7 +45,7 @@ export function useBuildEpisodeProgress(uuid: string, videoProvider?: "mux" | "y
       return;
     }
     lastReportedPercentRef.current = rounded;
-    updateUserVideoPercentage(uuid, rounded).catch(() => {});
+    updateUserVideoPercentage(uuid, rounded).catch(reportError);
   };
 
   const reportFromPlayer = (player: ProgressPlayer | null) => {

--- a/app/components/checkout/CheckoutReturnHandler.tsx
+++ b/app/components/checkout/CheckoutReturnHandler.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { extractAndClearCheckoutSessionId } from "@/lib/subscriptions/verification";
 import { verifyCheckoutSession } from "@/lib/api/subscriptions";
+import { reportError } from "@/lib/reportError";
 import {
   showPaymentConfirming,
   showPaymentProcessing,
@@ -45,7 +46,8 @@ export function CheckoutReturnHandler() {
         }
         void refreshUser();
       })
-      .catch(() => {
+      .catch((error) => {
+        reportError(error);
         showPaymentVerificationFailed();
       });
   }, [hasCheckedAuth, isAuthenticated, refreshUser]);

--- a/app/components/landing-page/MonthlyPrice.tsx
+++ b/app/components/landing-page/MonthlyPrice.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { fetchExternalPricing } from "@/lib/api/externalPricing";
 import type { PremiumPrices } from "@/lib/pricing";
+import { reportError } from "@/lib/reportError";
 
 const FALLBACK = "$9.99";
 
@@ -39,9 +40,7 @@ export function MonthlyPrice() {
       .then((data) => {
         if (!cancelled) setPrices(data.premium_prices);
       })
-      .catch(() => {
-        // Swallow: keep showing the USD fallback if the call fails.
-      });
+      .catch(reportError);
     return () => {
       cancelled = true;
     };

--- a/app/components/premium/PublicPremiumPrice.tsx
+++ b/app/components/premium/PublicPremiumPrice.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { fetchExternalPricing } from "@/lib/api/externalPricing";
 import type { PremiumPrices } from "@/lib/pricing";
+import { reportError } from "@/lib/reportError";
 
 function fractionDigits(currency: string): number {
   return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
@@ -38,9 +39,7 @@ export function PublicPremiumPrice() {
           setPublicPrices(res.premium_prices);
         }
       })
-      .catch(() => {
-        // Fail silently — fallback below renders nothing.
-      });
+      .catch(reportError);
     return () => {
       cancelled = true;
     };

--- a/app/components/video-exercise/lib/useVideoExercise.ts
+++ b/app/components/video-exercise/lib/useVideoExercise.ts
@@ -1,4 +1,5 @@
 import { markLessonComplete, fetchUserLesson } from "@/lib/api/lessons";
+import { reportError } from "@/lib/reportError";
 import type { MuxPlayerRefAttributes } from "@mux/mux-player-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -25,7 +26,7 @@ export function useVideoExercise(lessonSlug: string) {
           setShowCheckmark(true);
         }
       })
-      .catch(() => {});
+      .catch(reportError);
 
     setIsInitializing(false);
     playerRef.current?.play().catch((error) => {
@@ -78,7 +79,7 @@ export function useVideoExercise(lessonSlug: string) {
         unlocked ? `/dashboard?completed=${lessonSlug}&unlocked=${unlocked}` : `/dashboard?completed=${lessonSlug}`
       );
     } catch (error) {
-      console.error("Failed to mark lesson as complete:", error);
+      reportError(error);
     } finally {
       setIsMarking(false);
     }

--- a/app/lib/modal/modals/hooks/useExerciseCompletionModal.ts
+++ b/app/lib/modal/modals/hooks/useExerciseCompletionModal.ts
@@ -4,6 +4,7 @@ import styles from "@/app/styles/components/modals.module.css";
 import SoundManager from "@/lib/sound/SoundManager";
 import { launchConfetti, cleanupCanvas } from "@/lib/confetti";
 import { rateLesson } from "@/lib/api/lessons";
+import { reportError } from "@/lib/reportError";
 import type { CompletionResponseData } from "@/components/coding-exercise/lib/types";
 
 export type ModalStep = "success" | "difficulty-rating" | "completed" | "concept-unlocked" | "project-unlocked";
@@ -125,7 +126,7 @@ export function useExerciseCompletionModal({
   };
 
   const handleRatingsSubmit = async (difficultyRating: number, funRating: number) => {
-    rateLesson(exerciseSlug, difficultyRating, funRating).catch(console.error);
+    rateLesson(exerciseSlug, difficultyRating, funRating).catch(reportError);
     await advanceAfterCompletion();
   };
 

--- a/app/lib/modal/modals/steps/ConceptUnlockedStep.tsx
+++ b/app/lib/modal/modals/steps/ConceptUnlockedStep.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import styles from "@/app/styles/components/modals.module.css";
 import type { CompletionResponseData } from "@/components/coding-exercise/lib/types";
 import { getConcept } from "@/lib/api/concepts";
+import { reportError } from "@/lib/reportError";
 import type { ConceptMeta } from "@/types/concepts";
 
 interface ConceptUnlockedStepProps {
@@ -22,7 +23,7 @@ export function ConceptUnlockedStep({ completionResponse, onContinue }: ConceptU
     if (!conceptSlug) {
       return;
     }
-    getConcept(conceptSlug).then(setConcept).catch(console.error);
+    getConcept(conceptSlug).then(setConcept).catch(reportError);
   }, [conceptSlug]);
 
   if (!concept) {

--- a/app/lib/modal/modals/useWalkthroughProgress.ts
+++ b/app/lib/modal/modals/useWalkthroughProgress.ts
@@ -1,6 +1,7 @@
 import type { MuxPlayerRefAttributes } from "@mux/mux-player-react";
 import { useEffect, useRef } from "react";
 import { updateWalkthroughVideoPercentage } from "@/lib/api/lessons";
+import { reportError } from "@/lib/reportError";
 
 const STORAGE_KEY_PREFIX = "walkthrough-progress-";
 
@@ -19,7 +20,7 @@ export function useWalkthroughProgress(lessonSlug: string) {
       return;
     }
     lastReportedPercentRef.current = rounded;
-    updateWalkthroughVideoPercentage(lessonSlug, rounded).catch(() => {});
+    updateWalkthroughVideoPercentage(lessonSlug, rounded).catch(reportError);
   };
 
   const handleTimeUpdate = () => {

--- a/app/lib/reportError.ts
+++ b/app/lib/reportError.ts
@@ -1,11 +1,7 @@
+import * as Sentry from "@sentry/nextjs";
+
 export function reportError(error: unknown): void {
   console.error(error);
   if (process.env.NODE_ENV !== "production") return;
-  import("@sentry/nextjs")
-    .then((Sentry) => {
-      Sentry.captureException(error);
-    })
-    .catch(() => {
-      // Sentry failed to load - nothing we can do
-    });
+  Sentry.captureException(error);
 }

--- a/app/lib/reportError.ts
+++ b/app/lib/reportError.ts
@@ -1,0 +1,11 @@
+export function reportError(error: unknown): void {
+  console.error(error);
+  if (process.env.NODE_ENV !== "production") return;
+  import("@sentry/nextjs")
+    .then((Sentry) => {
+      Sentry.captureException(error);
+    })
+    .catch(() => {
+      // Sentry failed to load - nothing we can do
+    });
+}


### PR DESCRIPTION
## Summary

- Adds `app/lib/reportError.ts` — logs to console and captures to Sentry in production
- Replaces silent `.catch(console.error)` and `.catch(() => {})` on client-side API fetches across 8 files so failures no longer disappear without a trace

Mirrors the equivalent giki helper. Intentionally left alone: clipboard, audio/video `play()`, test-runner internals, and cases that already route failures to user-facing UI.

## Test plan

- [x] \`pnpm run lint\` clean (pre-existing warnings only)
- [x] Pre-commit typecheck + 1625 unit tests pass
- [ ] Smoke: verify a forced API failure surfaces in Sentry in a deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)