### PR TITLE
Add beta phase article and BetaTag component

### DIFF
--- a/app/app/(app)/achievements/page.tsx
+++ b/app/app/(app)/achievements/page.tsx
@@ -1,3 +1,4 @@
+import BetaTag from "@/components/common/BetaTag";
 import SidebarLayout from "../../../components/layout/SidebarLayout";
 import { AchievementsContent } from "./AchievementsContent";
 import type { Metadata } from "next";
@@ -10,6 +11,7 @@ export const metadata: Metadata = {
 export default function AchievementsPage() {
   return (
     <SidebarLayout activeItem="achievements">
+      <BetaTag />
       <AchievementsContent />
     </SidebarLayout>
   );

--- a/app/app/(app)/dashboard/page.tsx
+++ b/app/app/(app)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import BetaTag from "@/components/common/BetaTag";
 import ExercisePath from "@/components/dashboard/exercise-path/ExercisePath";
 import ProjectsSidebar from "@/components/dashboard/projects-sidebar/ProjectsSidebar";
 import SidebarLayout from "../../../components/layout/SidebarLayout";
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
 export default function DashboardPage() {
   return (
     <SidebarLayout activeItem="learn">
+      <BetaTag />
       <div className={styles.dashboardContainer}>
         <div className={styles.mainContent}>
           <ExercisePath />

--- a/app/app/(app)/projects/page.tsx
+++ b/app/app/(app)/projects/page.tsx
@@ -1,3 +1,4 @@
+import BetaTag from "@/components/common/BetaTag";
 import SidebarLayout from "../../../components/layout/SidebarLayout";
 import { ProjectsContent } from "./ProjectsContent";
 import type { Metadata } from "next";
@@ -10,6 +11,7 @@ export const metadata: Metadata = {
 export default function ProjectsPage() {
   return (
     <SidebarLayout activeItem="projects">
+      <BetaTag />
       <ProjectsContent />
     </SidebarLayout>
   );

--- a/app/app/(app)/settings/SettingsContent.tsx
+++ b/app/app/(app)/settings/SettingsContent.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import BetaTag from "@/components/common/BetaTag";
 import SidebarLayout from "@/components/layout/SidebarLayout";
 import SettingsPage from "@/components/settings/SettingsPage";
 
 export default function SettingsContent() {
   return (
     <SidebarLayout activeItem="settings">
+      <BetaTag />
       <SettingsPage />
     </SidebarLayout>
   );

--- a/app/app/(hybrid)/concepts/[slug]/page.tsx
+++ b/app/app/(hybrid)/concepts/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import BetaTag from "@/components/common/BetaTag";
 import ConceptDetailPage from "@/components/concepts/ConceptDetailPage";
 import SidebarLayout from "@/components/layout/SidebarLayout";
 import { getConceptMetadata } from "@/lib/concepts/metadata";
@@ -16,6 +17,7 @@ export default async function AppConceptPage({ params }: Props) {
 
   return (
     <SidebarLayout activeItem="concepts">
+      <BetaTag />
       <ConceptDetailPage slug={slug} />
     </SidebarLayout>
   );

--- a/app/app/styles/theme/spacing.css
+++ b/app/app/styles/theme/spacing.css
@@ -34,6 +34,7 @@
     --z-index-tooltip-content: 81;
     --z-index-nav: 100;
     --z-index-nav-popover: 110;
+    --z-index-beta-tag: 999;
     --z-index-modal-backdrop: 1000;
     --z-index-modal: 1001;
     --z-index-spotlight-backdrop: 1100;

--- a/app/components/common/BetaTag.module.css
+++ b/app/components/common/BetaTag.module.css
@@ -2,7 +2,7 @@
     top: 40px;
     right: -50px;
     position: fixed;
-    z-index: 99999;
+    z-index: var(--z-index-beta-tag);
     transform: rotate(45deg);
 
     background: var(--color-blue-600);

--- a/app/components/common/BetaTag.module.css
+++ b/app/components/common/BetaTag.module.css
@@ -1,0 +1,20 @@
+.tag {
+    top: 40px;
+    right: -50px;
+    position: fixed;
+    z-index: 99999;
+    transform: rotate(45deg);
+
+    background: var(--color-blue-600);
+    color: #fff;
+    text-align: center;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    pointer-events: none;
+    width: 200px;
+    padding: 6px 0;
+    font-size: 12px;
+    font-weight: 700;
+
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}

--- a/app/components/common/BetaTag.tsx
+++ b/app/components/common/BetaTag.tsx
@@ -1,0 +1,5 @@
+import styles from "./BetaTag.module.css";
+
+export default function BetaTag() {
+  return <div className={styles.tag}>Beta Version</div>;
+}

--- a/content/src/posts/articles/beta-phase/config.json
+++ b/content/src/posts/articles/beta-phase/config.json
@@ -1,0 +1,5 @@
+{
+  "date": "2026-06-07",
+  "author": "ihid",
+  "listed": true
+}

--- a/content/src/posts/articles/beta-phase/en.md
+++ b/content/src/posts/articles/beta-phase/en.md
@@ -1,0 +1,14 @@
+---
+title: "Beta Phase"
+excerpt: "Jiki is in beta for June 2026. Here's what that means for you."
+tags: ["announcements"]
+seo:
+  description: "Jiki is in beta throughout June 2026, with the aim of moving out of beta on July 1st."
+  keywords: ["beta", "jiki", "launch"]
+---
+
+Jiki is currently in beta throughout June 2026, with the aim of moving out of beta on July 1st.
+
+During this period, we expect everything to work. That said, you might run into bugs that we didn't discover ourselves. If you do, please head to the [forum](/r/forum) and let us know what you found.
+
+Thank you for reporting bugs, and for helping us make Jiki better for everyone.

--- a/content/src/posts/articles/beta-phase/hu.md
+++ b/content/src/posts/articles/beta-phase/hu.md
@@ -1,0 +1,14 @@
+---
+title: "Beta Phase"
+excerpt: "Jiki is in beta for June 2026. Here's what that means for you."
+tags: ["announcements"]
+seo:
+  description: "Jiki is in beta throughout June 2026, with the aim of moving out of beta on July 1st."
+  keywords: ["beta", "jiki", "launch"]
+---
+
+Jiki is currently in beta throughout June 2026, with the aim of moving out of beta on July 1st.
+
+During this period, we expect everything to work. That said, you might run into bugs that we didn't discover ourselves. If you do, please head to the [forum](/r/forum) and let us know what you found.
+
+Thank you for reporting bugs, and for helping us make Jiki better for everyone.


### PR DESCRIPTION
## Summary
- New `BetaTag` component (fixed-position rotated banner, blue-600) shown on dashboard, projects, concepts/[slug], achievements, and settings
- New `beta-phase` article (en + hu) explaining the June 2026 beta period and pointing users to the forum for bug reports

## Test plan
- [ ] Tag visible (and rotated) in top-right on dashboard, projects, a concept page, achievements, and settings
- [ ] `/articles/beta-phase` renders correctly
- [ ] Forum link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)