### PR TITLE
Wrap /auth/check-email in AuthLayout

### DIFF
--- a/app/app/(external)/auth/check-email/page.tsx
+++ b/app/app/(external)/auth/check-email/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { CheckInboxMessage } from "@/components/auth/CheckInboxMessage";
+import { AuthLayout } from "@/components/ui/AuthLayout";
 
 export default function CheckEmailPage() {
   const [email, setEmail] = useState<string | null>(null);
@@ -18,5 +19,9 @@ export default function CheckEmailPage() {
     return null;
   }
 
-  return <CheckInboxMessage email={email} />;
+  return (
+    <AuthLayout>
+      <CheckInboxMessage email={email} />
+    </AuthLayout>
+  );
 }


### PR DESCRIPTION
## Summary
- `/auth/check-email` was rendering `CheckInboxMessage` directly without the shared auth frame used by every other `/auth/*` page (login, signup, forgot-password, resend-confirmation, confirm-email, exercism/callback).
- Wrap it in `<AuthLayout>` for visual consistency.

## Test plan
- [ ] Visit `/auth/check-email` and confirm it now renders inside the auth frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)