### PR TITLE
Redesign article cards and add compact variant

### DIFF
--- a/app/components/articles/ArticleCard.module.css
+++ b/app/components/articles/ArticleCard.module.css
@@ -2,8 +2,9 @@
     background: white;
     border: 2px solid var(--color-gray-200);
     border-radius: 16px;
-    padding: 16px;
-    display: block;
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
     text-decoration: none;
     transition: all 0.3s ease;
 }
@@ -15,25 +16,8 @@
         0 4px 16px var(--color-blue-500-40);
 }
 
-.articleCardImage {
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    border-radius: 8px;
-    margin-bottom: 12px;
-    background-color: var(--color-gray-200);
-}
-
 .articleCardMeta {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
-}
-
-.articleCardDate {
-    font-size: 12px;
-    color: var(--color-gray-500);
-    font-weight: 500;
+    margin-bottom: 14px;
 }
 
 .articleCardBadge {
@@ -44,28 +28,39 @@
         rgb(from var(--color-purple-500) r g b / 0.1) 100%
     );
     color: var(--color-purple-500);
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 10px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 14px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
 
 .articleCardTitle {
-    font-size: 16px;
-    font-weight: 600;
+    font-size: 20px;
+    font-weight: 700;
     color: var(--color-gray-900);
+    margin-bottom: 10px;
+    line-height: 1.35;
+}
+
+.compact .articleCardBadge {
+    font-size: 12px;
+    padding: 3px 8px;
+}
+
+.compact .articleCardTitle {
+    font-size: 18px;
     margin-bottom: 6px;
-    line-height: 1.3;
 }
 
 .articleCardExcerpt {
-    font-size: 14px;
+    font-size: 15px;
     color: var(--color-gray-600);
-    line-height: 1.5;
+    line-height: 1.65;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    flex-grow: 1;
 }

--- a/app/components/articles/ArticleCard.tsx
+++ b/app/components/articles/ArticleCard.tsx
@@ -1,24 +1,24 @@
 import Link from "next/link";
 import type { ArticleMeta } from "@/lib/content/types";
-import { formatBlogDate } from "@/lib/utils";
 import styles from "./ArticleCard.module.css";
 
 interface ArticleCardProps {
   article: ArticleMeta;
   locale: string;
+  compact?: boolean;
 }
 
-export default function ArticleCard({ article, locale }: ArticleCardProps) {
+export default function ArticleCard({ article, locale, compact = false }: ArticleCardProps) {
   const articleUrl = locale === "en" ? `/articles/${article.slug}` : `/${locale}/articles/${article.slug}`;
   const firstTag = article.tags[0];
 
   return (
-    <Link href={articleUrl} className={styles.articleCard}>
-      <div className={styles.articleCardImage} />
-      <div className={styles.articleCardMeta}>
-        <span className={styles.articleCardDate}>{formatBlogDate(article.date)}</span>
-        {firstTag && <span className={styles.articleCardBadge}>{firstTag}</span>}
-      </div>
+    <Link href={articleUrl} className={`${styles.articleCard} ${compact ? styles.compact : ""}`}>
+      {firstTag && (
+        <div className={styles.articleCardMeta}>
+          <span className={styles.articleCardBadge}>{firstTag}</span>
+        </div>
+      )}
       <h4 className={styles.articleCardTitle}>{article.title}</h4>
       <p className={styles.articleCardExcerpt}>{article.excerpt}</p>
     </Link>

--- a/app/components/articles/RelatedArticles.tsx
+++ b/app/components/articles/RelatedArticles.tsx
@@ -17,7 +17,7 @@ export default function RelatedArticles({ articles, locale }: RelatedArticlesPro
       <h3 className={styles.relatedArticlesTitle}>Related Articles</h3>
       <div className={styles.relatedArticlesSection}>
         {articles.map((article) => (
-          <ArticleCard key={article.slug} article={article} locale={locale} />
+          <ArticleCard key={article.slug} article={article} locale={locale} compact />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Restyles `ArticleCard` to match the articles-page design: 28px padding, 16px radius, larger badge (14px), 20px/700 title, 15px excerpt with 3-line clamp and `flex-grow` so cards align in the grid. Drops the image and date.
- Adds a `compact` prop used by `RelatedArticles`: 12px badge, 18px title with 6px bottom margin.

## Test plan
- [ ] /articles renders the new card style
- [ ] Article detail page → Related Articles section uses the compact variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)