### PR TITLE
Surface conversation save errors to the user

### DIFF
--- a/app/components/coding-exercise/lib/conversationApi.ts
+++ b/app/components/coding-exercise/lib/conversationApi.ts
@@ -2,39 +2,52 @@ import { getApiUrl } from "@/lib/api/config";
 import type { SignatureData } from "./chat-types";
 import type { ExerciseContext } from "./types";
 
+export class ConversationSaveError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public data?: unknown
+  ) {
+    super(message);
+    this.name = "ConversationSaveError";
+  }
+}
+
+// 403 with error.type === "invalid_captcha": the persistence endpoint
+// rejected the request as a bot. Surfaced distinctly so the user sees a
+// "verification failed" message rather than a generic save error.
+export class ConversationSaveCaptchaError extends ConversationSaveError {
+  constructor(message: string, data?: unknown) {
+    super(message, 403, data);
+    this.name = "ConversationSaveCaptchaError";
+  }
+}
+
 export async function saveConversation(
   context: ExerciseContext,
   userMessage: string,
   assistantMessage: string,
   signature: SignatureData
 ): Promise<void> {
-  try {
-    // Estimate tokens (rough approximation: 4 chars ≈ 1 token)
-    const userMessageTokens = Math.ceil(userMessage.length / 4);
-    const assistantMessageTokens = Math.ceil(assistantMessage.length / 4);
+  // Estimate tokens (rough approximation: 4 chars ≈ 1 token)
+  const userMessageTokens = Math.ceil(userMessage.length / 4);
+  const assistantMessageTokens = Math.ceil(assistantMessage.length / 4);
 
-    // Save user message
-    await saveUserMessage({
-      context_type: context.type,
-      context_identifier: context.slug,
-      content: userMessage,
-      tokens: userMessageTokens
-    });
+  await saveUserMessage({
+    context_type: context.type,
+    context_identifier: context.slug,
+    content: userMessage,
+    tokens: userMessageTokens
+  });
 
-    // Save assistant message with signature
-    await saveAssistantMessage({
-      context_type: context.type,
-      context_identifier: context.slug,
-      content: assistantMessage,
-      tokens: assistantMessageTokens,
-      timestamp: signature.timestamp,
-      signature: signature.signature
-    });
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    console.error("Failed to save conversation:", errorMessage);
-    // Don't throw - we don't want to break the UI if save fails
-  }
+  await saveAssistantMessage({
+    context_type: context.type,
+    context_identifier: context.slug,
+    content: assistantMessage,
+    tokens: assistantMessageTokens,
+    timestamp: signature.timestamp,
+    signature: signature.signature
+  });
 }
 
 async function saveUserMessage(payload: {
@@ -54,7 +67,7 @@ async function saveUserMessage(payload: {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to save user message: ${response.status} ${response.statusText}`);
+    await throwForResponse(response, "Failed to save user message");
   }
 }
 
@@ -77,6 +90,47 @@ async function saveAssistantMessage(payload: {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to save assistant message: ${response.status} ${response.statusText}`);
+    await throwForResponse(response, "Failed to save assistant message");
   }
+}
+
+async function throwForResponse(response: Response, fallback: string): Promise<never> {
+  let errorData: unknown;
+  try {
+    const contentType = response.headers.get("content-type");
+    if (contentType?.includes("application/json")) {
+      errorData = await response.json();
+    } else {
+      errorData = await response.text();
+    }
+  } catch {
+    errorData = { error: "unknown", message: "Failed to parse error response" };
+  }
+
+  if (response.status === 403 && extractErrorType(errorData) === "invalid_captcha") {
+    const message = extractErrorMessage(errorData) ?? "Verification failed.";
+    throw new ConversationSaveCaptchaError(message, errorData);
+  }
+
+  throw new ConversationSaveError(
+    `${fallback}: HTTP ${response.status} ${response.statusText}`,
+    response.status,
+    errorData
+  );
+}
+
+function extractErrorType(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const errorField = (data as { error?: unknown }).error;
+  if (typeof errorField !== "object" || errorField === null) return undefined;
+  const type = (errorField as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+function extractErrorMessage(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const errorField = (data as { error?: unknown }).error;
+  if (typeof errorField !== "object" || errorField === null) return undefined;
+  const message = (errorField as { message?: unknown }).message;
+  return typeof message === "string" ? message : undefined;
 }

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -1,10 +1,11 @@
 import { useCallback, useRef } from "react";
+import toast from "react-hot-toast";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import { useChatState } from "./useChatState";
 import { useChatContext } from "./useChatContext";
 import { sendChatMessage, ChatTokenExpiredError } from "./chatApi";
-import { saveConversation } from "./conversationApi";
+import { ConversationSaveCaptchaError, saveConversation } from "./conversationApi";
 import { ChatTokenAccessDeniedError, ChatTokenInvalidCaptchaError, fetchChatToken } from "./chatTokenApi";
 import { formatChatError } from "./chatErrorHandler";
 import type Orchestrator from "./Orchestrator";
@@ -81,7 +82,14 @@ export function useChat(orchestrator: Orchestrator) {
 
               if (signature) {
                 chatState.setSignature(signature);
-                void saveConversation(context.context, message, fullResponse, signature);
+                saveConversation(context.context, message, fullResponse, signature).catch((error: unknown) => {
+                  console.error("Failed to save conversation:", error);
+                  const toastMessage =
+                    error instanceof ConversationSaveCaptchaError
+                      ? "Verification failed while saving. This message won't be here when you come back."
+                      : "Couldn't save this message. It won't be here when you come back.";
+                  toast.error(toastMessage, { duration: 8000 });
+                });
               }
 
               chatState.setStatus("typing");


### PR DESCRIPTION
## Summary
- `saveConversation` previously swallowed failures with a `console.error`, so a failed save (e.g. backend rejecting on captcha) left the user looking at a conversation that was never persisted.
- It now throws typed errors (`ConversationSaveError`, `ConversationSaveCaptchaError`) and `useChat` surfaces an 8s toast so the user knows the message won't be there when they return.
- Captcha-specific failures get a distinct "Verification failed while saving" message; other failures get a generic "Couldn't save this message" toast. The rendered chat is untouched so the user doesn't lose the answer they just received.

Context for why this matters: the captcha gate lives at the JWT exchange (`POST /internal/assistant_conversations`, see `chatTokenApi.ts:32-38`). The save endpoints (`/user_messages`, `/assistant_messages`) don't carry a captcha token. If the backend starts rejecting saves on captcha, the user's history silently vanishes — this PR ensures they know.

## Test plan
- [ ] Local: send a chat message, force-fail the save endpoint, confirm toast renders and the rendered reply stays on screen
- [ ] Local: force a 403 `invalid_captcha` response, confirm captcha-specific toast renders
- [ ] Regression: existing chat unit tests pass (`useChat`, `conversationApi`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)