### PR TITLE
Fix middleware blocking /testimonials in production

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -126,7 +126,7 @@ export function middleware(request: NextRequest) {
   //
   // Block access to /dev and test routes in production
   //
-  const isTestRoute = path.startsWith("/dev") || path.startsWith("/test");
+  const isTestRoute = path === "/dev" || path.startsWith("/dev/") || path === "/test" || path.startsWith("/test/");
   const isDevelopment = process.env.NODE_ENV === "development" || process.env.VERCEL_ENV === "development";
   if (isTestRoute && !isDevelopment) {
     return new NextResponse(null, { status: 404 });


### PR DESCRIPTION
## Summary

`https://jiki.io/testimonials` was returning a bare 0-byte 404 in production while working locally. The cause: `middleware.ts` blocks `/dev*` and `/test*` routes in production using `path.startsWith("/test")`, which also matches `/testimonials` (and would catch any future `/test…` path, e.g. `/testbed`).

Fix: match exact + `"/"`-boundary instead of raw prefix.

```ts
// before
path.startsWith("/dev") || path.startsWith("/test")
// after
path === "/dev" || path.startsWith("/dev/") || path === "/test" || path.startsWith("/test/")
```

## Test plan

- [ ] Verify `/testimonials` returns 200 on the preview deploy
- [ ] Verify `/test` and `/test/quiz` still return 404 in production
- [ ] Verify `/dev` and `/dev/buttons` still return 404 in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)