### PR TITLE
Disambiguate dollar-family currencies in PremiumPrice

### DIFF
--- a/app/components/common/PremiumPrice.tsx
+++ b/app/components/common/PremiumPrice.tsx
@@ -7,6 +7,31 @@ function fractionDigits(currency: string): number {
   return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
 }
 
+// Dollar-family currencies where "narrowSymbol" collapses to "$" and loses
+// the disambiguating prefix. Intl's "symbol" form is locale-dependent
+// (en-US renders SGD as "SGD 1.99", not "S$1.99"), so we prepend the
+// prefix ourselves to guarantee disambiguation in every locale.
+const DOLLAR_PREFIX: Record<string, string> = {
+  SGD: "S",
+  CAD: "CA",
+  AUD: "A",
+  HKD: "HK",
+  NZD: "NZ",
+  MXN: "MX"
+};
+
+function disambiguate(currency: string, formatted: string): string {
+  const prefix = DOLLAR_PREFIX[currency];
+  if (!prefix) return formatted;
+  // Only prepend if the formatter rendered a bare "$" — if Intl already
+  // produced "S$" / "CA$" for the user's locale, leave it alone.
+  const idx = formatted.indexOf("$");
+  if (idx === -1) return formatted;
+  const charBefore = idx > 0 ? formatted[idx - 1] : "";
+  if (/[A-Z]/.test(charBefore)) return formatted;
+  return formatted.slice(0, idx) + prefix + formatted.slice(idx);
+}
+
 export function PremiumPrice({ interval }: { interval: BillingInterval }) {
   const user = useAuthStore((state) => state.user);
   if (!user) {
@@ -27,7 +52,7 @@ export function PremiumPrice({ interval }: { interval: BillingInterval }) {
     maximumFractionDigits: 2
   }).format(amount);
 
-  return <>{formatted}</>;
+  return <>{disambiguate(currencyUpper, formatted)}</>;
 }
 
 export function PremiumDailyPrice({ interval }: { interval: BillingInterval }) {
@@ -54,5 +79,5 @@ export function PremiumDailyPrice({ interval }: { interval: BillingInterval }) {
     maximumFractionDigits: digits
   }).format(dailyAmount);
 
-  return <>{formatted}</>;
+  return <>{disambiguate(currencyUpper, formatted)}</>;
 }

--- a/app/tests/unit/components/common/PremiumPrice.test.tsx
+++ b/app/tests/unit/components/common/PremiumPrice.test.tsx
@@ -45,6 +45,24 @@ describe("PremiumPrice", () => {
     const { container } = render(<PremiumPrice interval="monthly" />);
     expect(container.textContent).toMatch(/7\.99/);
   });
+
+  it("disambiguates SGD with S$ prefix instead of bare $", () => {
+    mockUser = { premium_prices: { currency: "sgd", monthly: 599, annual: 5900, country_code: "SG" } };
+    const { container } = render(<PremiumPrice interval="monthly" />);
+    expect(container.textContent).toMatch(/S\$/);
+  });
+
+  it("disambiguates CAD with CA$ prefix instead of bare $", () => {
+    mockUser = { premium_prices: { currency: "cad", monthly: 599, annual: 5900, country_code: "CA" } };
+    const { container } = render(<PremiumPrice interval="monthly" />);
+    expect(container.textContent).toMatch(/CA\$/);
+  });
+
+  it("keeps USD as bare $ (no US$ prefix)", () => {
+    mockUser = { premium_prices: { currency: "usd", monthly: 599, annual: 5900, country_code: "US" } };
+    const { container } = render(<PremiumPrice interval="monthly" />);
+    expect(container.textContent).toMatch(/^\$/);
+  });
 });
 
 describe("PremiumDailyPrice", () => {


### PR DESCRIPTION
## Summary
- `currencyDisplay: "narrowSymbol"` collapses SGD, CAD, AUD, HKD, NZD, MXN all to `$`, hiding the country prefix Singaporean / Canadian / Australian / etc. users expect.
- Prepend the disambiguating prefix (`S$`, `CA$`, `A$`, `HK$`, `NZ$`, `MX$`) ourselves whenever Intl renders a bare `$`. USD stays as `$`, non-dollar currencies (₹, £, €, ¥) untouched.

## Test plan
- [x] Unit tests cover SGD → `S$`, CAD → `CA$`, USD stays `$`
- [ ] Spot-check pricing page as a Singapore user