### PR TITLE
Rename maze blob to person

### DIFF
--- a/curriculum/src/exercises/maze-solve-basic/instructions/en.md
+++ b/curriculum/src/exercises/maze-solve-basic/instructions/en.md
@@ -5,7 +5,7 @@ description: "Guide Jiki through a maze using simple instructions."
 
 Welcome to your first exercise!
 
-The aim of this exercise is to get you familiar with how the learning environment works. Your task is to solve the maze you can see to the left by giving the little blob instructions. You write all out all the instructions that the blob neeeds to follow, then click **Run Code** to get it to follow them.
+The aim of this exercise is to get you familiar with how the learning environment works. Your task is to solve the maze you can see to the left by giving the little person instructions. You write all out all the instructions that the person neeeds to follow, then click **Run Code** to get it to follow them.
 
 The three instructions you can use are:
 

--- a/curriculum/src/exercises/maze-solve-basic/metadata.json
+++ b/curriculum/src/exercises/maze-solve-basic/metadata.json
@@ -4,11 +4,11 @@
   "hints": [
     {
       "question": "What am I moving where?",
-      "answer": "You're moving the little blob, which starts at the top-left, to the green circle at the bottom right, avoiding any red striped cells."
+      "answer": "You're moving the little person, who starts at the top-left, to the green circle at the bottom right, avoiding any red striped cells."
     },
     {
-      "question": "When I turn left, the blob turns right!",
-      "answer": "The blob turns relative to the position its facing. So if you are facing right, and turn left, the blob will change to face up."
+      "question": "When I turn left, the person turns right!",
+      "answer": "The person turns relative to the position they're facing. So if you are facing right, and turn left, the person will change to face up."
     }
   ]
 }

--- a/curriculum/src/exercises/maze-solve-basic/scenarios.ts
+++ b/curriculum/src/exercises/maze-solve-basic/scenarios.ts
@@ -4,7 +4,7 @@ import type MazeSolveBasicExercise from "./Exercise";
 export const tasks = [
   {
     id: "solve-maze" as const,
-    name: "Guide person to the end of the maze",
+    name: "Guide the person to the end of the maze",
     description: "Navigate through the maze to reach the green target",
     hints: [],
     requiredScenarios: ["maze-1"],
@@ -15,8 +15,8 @@ export const tasks = [
 export const scenarios: VisualScenario[] = [
   {
     slug: "maze-1",
-    name: "Guide person to the end of the maze",
-    description: "Your job is to navigate your blob through the maze to the green goal square.",
+    name: "Guide the person to the end of the maze",
+    description: "Your job is to navigate your person through the maze to the green goal square.",
     taskId: "solve-maze",
 
     setup(exercise) {

--- a/curriculum/src/exercises/space-invaders-solve-basic/metadata.json
+++ b/curriculum/src/exercises/space-invaders-solve-basic/metadata.json
@@ -4,7 +4,7 @@
   "hints": [
     {
       "question": "What do I need to do?",
-      "answer": "Like the maze, you need to move your character (this time a laser, not a blob). But you also need to shoot from the laser! Move the laser underneath an alien then shoot. Then move again until you're under the next alien, and shoot again. Continue until you've shot down the last alien!"
+      "answer": "Like the maze, you need to move your character (this time a laser, not a person). But you also need to shoot from the laser! Move the laser underneath an alien then shoot. Then move again until you're under the next alien, and shoot again. Continue until you've shot down the last alien!"
     },
     {
       "question": "I get told I can't waste ammo.",


### PR DESCRIPTION
## Summary
- Replace "blob" with "person" in maze-solve-basic copy (scenario description, instructions, hints)
- Update first scenario/task name from "Guide person..." to "Guide the person to the end of the maze"
- Update space-invaders-solve-basic hint that referenced the maze "blob"

## Test plan
- [x] Curriculum pre-commit checks pass (typecheck, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)