### PR TITLE
Truncate long names in sidebar UserProfile header

### DIFF
--- a/app/components/dashboard/projects-sidebar/ui/UserProfile.module.css
+++ b/app/components/dashboard/projects-sidebar/ui/UserProfile.module.css
@@ -137,7 +137,7 @@
 
 .info {
     flex: 1;
-    margin-left: 11px;
+    min-width: 0;
 }
 
 .name {
@@ -145,10 +145,16 @@
     font-weight: 600;
     color: #1a202c;
     margin-bottom: -1px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .handle {
     font-size: 13px;
     color: #718096;
     margin-bottom: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/app/components/dashboard/projects-sidebar/ui/UserProfile/Streak.module.css
+++ b/app/components/dashboard/projects-sidebar/ui/UserProfile/Streak.module.css
@@ -1,8 +1,5 @@
 .streak {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    right: 0;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
     gap: 4px;


### PR DESCRIPTION
## Summary
- Long usernames in the sidebar UserProfile card overflowed the streak badge and got hidden behind it.
- Make the streak a normal flex child instead of `position: absolute`, and ellipsis-truncate the name/handle when they don't fit.

## Test plan
- [ ] Open the dashboard sidebar with a long username (e.g. `nicolechalmers1-test2`) and confirm the name truncates with `...` before colliding with the streak badge.
- [ ] Confirm short names render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)