### PR TITLE
Format payment history amounts using returned currency

### DIFF
--- a/app/components/common/PremiumPrice.tsx
+++ b/app/components/common/PremiumPrice.tsx
@@ -1,36 +1,8 @@
 "use client";
 
 import { useAuthStore } from "@/lib/auth/authStore";
+import { currencyFractionDigits, formatCurrency } from "@/lib/formatCurrency";
 import type { BillingInterval } from "@/lib/pricing";
-
-function fractionDigits(currency: string): number {
-  return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
-}
-
-// Dollar-family currencies where "narrowSymbol" collapses to "$" and loses
-// the disambiguating prefix. Intl's "symbol" form is locale-dependent
-// (en-US renders SGD as "SGD 1.99", not "S$1.99"), so we prepend the
-// prefix ourselves to guarantee disambiguation in every locale.
-const DOLLAR_PREFIX: Record<string, string> = {
-  SGD: "S",
-  CAD: "CA",
-  AUD: "A",
-  HKD: "HK",
-  NZD: "NZ",
-  MXN: "MX"
-};
-
-function disambiguate(currency: string, formatted: string): string {
-  const prefix = DOLLAR_PREFIX[currency];
-  if (!prefix) return formatted;
-  // Only prepend if the formatter rendered a bare "$" — if Intl already
-  // produced "S$" / "CA$" for the user's locale, leave it alone.
-  const idx = formatted.indexOf("$");
-  if (idx === -1) return formatted;
-  const charBefore = idx > 0 ? formatted[idx - 1] : "";
-  if (/[A-Z]/.test(charBefore)) return formatted;
-  return formatted.slice(0, idx) + prefix + formatted.slice(idx);
-}
 
 export function PremiumPrice({ interval }: { interval: BillingInterval }) {
   const user = useAuthStore((state) => state.user);
@@ -39,20 +11,9 @@ export function PremiumPrice({ interval }: { interval: BillingInterval }) {
   }
 
   const { currency, monthly, annual } = user.premium_prices;
-  const currencyUpper = currency.toUpperCase();
   const smallestUnit = interval === "monthly" ? monthly : annual;
-  const divisor = Math.pow(10, fractionDigits(currencyUpper));
-  const amount = smallestUnit / divisor;
 
-  const formatted = new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: currencyUpper,
-    currencyDisplay: "narrowSymbol",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(amount);
-
-  return <>{disambiguate(currencyUpper, formatted)}</>;
+  return <>{formatCurrency(smallestUnit, currency, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}</>;
 }
 
 export function PremiumDailyPrice({ interval }: { interval: BillingInterval }) {
@@ -62,22 +23,16 @@ export function PremiumDailyPrice({ interval }: { interval: BillingInterval }) {
   }
 
   const { currency, monthly, annual } = user.premium_prices;
-  const currencyUpper = currency.toUpperCase();
   const smallestUnit = interval === "monthly" ? monthly : annual;
-  const divisor = Math.pow(10, fractionDigits(currencyUpper));
-  const amount = smallestUnit / divisor;
   const daysInPeriod = interval === "monthly" ? 30 : 365;
-  const dailyAmount = amount / daysInPeriod;
+  const digits = currencyFractionDigits(currency.toUpperCase());
 
-  const digits = fractionDigits(currencyUpper);
-
-  const formatted = new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: currencyUpper,
-    currencyDisplay: "narrowSymbol",
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits
-  }).format(dailyAmount);
-
-  return <>{disambiguate(currencyUpper, formatted)}</>;
+  return (
+    <>
+      {formatCurrency(smallestUnit / daysInPeriod, currency, {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits
+      })}
+    </>
+  );
 }

--- a/app/components/settings/payment-history/PaymentHistoryRow.tsx
+++ b/app/components/settings/payment-history/PaymentHistoryRow.tsx
@@ -1,3 +1,4 @@
+import { formatCurrency } from "@/lib/formatCurrency";
 import styles from "./PaymentHistory.module.css";
 import type { Payment } from "./types";
 
@@ -7,19 +8,6 @@ interface PaymentHistoryRowProps {
 }
 
 export default function PaymentHistoryRow({ payment, onDownloadReceipt }: PaymentHistoryRowProps) {
-  const formatAmount = (amountInCents: number, currency: string) => {
-    const currencyUpper = currency.toUpperCase();
-    const fractionDigits =
-      new Intl.NumberFormat(undefined, { style: "currency", currency: currencyUpper }).resolvedOptions()
-        .minimumFractionDigits ?? 2;
-    const amount = amountInCents / Math.pow(10, fractionDigits);
-    return new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency: currencyUpper,
-      currencyDisplay: "narrowSymbol"
-    }).format(amount);
-  };
-
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     const options: Intl.DateTimeFormatOptions = {
@@ -33,7 +21,7 @@ export default function PaymentHistoryRow({ payment, onDownloadReceipt }: Paymen
   return (
     <tr className={styles.paymentRow}>
       <td className={styles.paymentDate}>{formatDate(payment.date)}</td>
-      <td className={styles.paymentAmount}>{formatAmount(payment.amountInCents, payment.currency)}</td>
+      <td className={styles.paymentAmount}>{formatCurrency(payment.amountInCents, payment.currency)}</td>
       <td className={styles.paymentType}>{payment.type}</td>
       <td className={styles.paymentMethod}>{payment.method}</td>
       <td className={styles.paymentAction}>

--- a/app/components/settings/payment-history/PaymentHistoryRow.tsx
+++ b/app/components/settings/payment-history/PaymentHistoryRow.tsx
@@ -7,8 +7,17 @@ interface PaymentHistoryRowProps {
 }
 
 export default function PaymentHistoryRow({ payment, onDownloadReceipt }: PaymentHistoryRowProps) {
-  const formatAmount = (amount: number) => {
-    return `$${amount.toFixed(2)}`;
+  const formatAmount = (amountInCents: number, currency: string) => {
+    const currencyUpper = currency.toUpperCase();
+    const fractionDigits =
+      new Intl.NumberFormat(undefined, { style: "currency", currency: currencyUpper }).resolvedOptions()
+        .minimumFractionDigits ?? 2;
+    const amount = amountInCents / Math.pow(10, fractionDigits);
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currencyUpper,
+      currencyDisplay: "narrowSymbol"
+    }).format(amount);
   };
 
   const formatDate = (dateString: string) => {
@@ -24,7 +33,7 @@ export default function PaymentHistoryRow({ payment, onDownloadReceipt }: Paymen
   return (
     <tr className={styles.paymentRow}>
       <td className={styles.paymentDate}>{formatDate(payment.date)}</td>
-      <td className={styles.paymentAmount}>{formatAmount(payment.amount)}</td>
+      <td className={styles.paymentAmount}>{formatAmount(payment.amountInCents, payment.currency)}</td>
       <td className={styles.paymentType}>{payment.type}</td>
       <td className={styles.paymentMethod}>{payment.method}</td>
       <td className={styles.paymentAction}>

--- a/app/components/settings/payment-history/types.ts
+++ b/app/components/settings/payment-history/types.ts
@@ -1,7 +1,8 @@
 export interface Payment {
   id: string;
   date: string;
-  amount: number;
+  amountInCents: number;
+  currency: string;
   type: "Recurring" | "One-time";
   method: "Stripe" | "PayPal" | "Other";
   receiptUrl?: string;

--- a/app/components/settings/payment-history/usePayments.ts
+++ b/app/components/settings/payment-history/usePayments.ts
@@ -20,8 +20,7 @@ function formatDate(dateString: string): string {
     .replace(/\//g, "-");
 }
 
-function formatAmount(amountInCents: number): number {
-  // Validate the amount
+function sanitizeAmount(amountInCents: number): number {
   if (!Number.isFinite(amountInCents)) {
     console.error(`Invalid amount: ${amountInCents}`);
     return 0;
@@ -32,14 +31,15 @@ function formatAmount(amountInCents: number): number {
     return 0;
   }
 
-  return amountInCents / 100;
+  return amountInCents;
 }
 
 function mapApiPaymentToPayment(apiPayment: ApiPayment): Payment {
   return {
     id: apiPayment.id,
     date: formatDate(apiPayment.paid_at),
-    amount: formatAmount(apiPayment.amount_in_cents),
+    amountInCents: sanitizeAmount(apiPayment.amount_in_cents),
+    currency: apiPayment.currency,
     type: "Recurring",
     method: "Stripe",
     receiptUrl: apiPayment.external_receipt_url

--- a/app/lib/formatCurrency.ts
+++ b/app/lib/formatCurrency.ts
@@ -1,0 +1,45 @@
+// Dollar-family currencies where "narrowSymbol" collapses to "$" and loses
+// the disambiguating prefix. Intl's "symbol" form is locale-dependent
+// (en-US renders SGD as "SGD 1.99", not "S$1.99"), so we prepend the
+// prefix ourselves to guarantee disambiguation in every locale.
+const DOLLAR_PREFIX: Record<string, string> = {
+  SGD: "S",
+  CAD: "CA",
+  AUD: "A",
+  HKD: "HK",
+  NZD: "NZ",
+  MXN: "MX"
+};
+
+export function currencyFractionDigits(currency: string): number {
+  return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
+}
+
+function disambiguate(currency: string, formatted: string): string {
+  const prefix = DOLLAR_PREFIX[currency];
+  if (!prefix) return formatted;
+  // Only prepend if the formatter rendered a bare "$" — if Intl already
+  // produced "S$" / "CA$" for the user's locale, leave it alone.
+  const idx = formatted.indexOf("$");
+  if (idx === -1) return formatted;
+  const charBefore = idx > 0 ? formatted[idx - 1] : "";
+  if (/[A-Z]/.test(charBefore)) return formatted;
+  return formatted.slice(0, idx) + prefix + formatted.slice(idx);
+}
+
+export function formatCurrency(
+  amountInMinorUnits: number,
+  currency: string,
+  options?: { minimumFractionDigits?: number; maximumFractionDigits?: number }
+): string {
+  const currencyUpper = currency.toUpperCase();
+  const digits = currencyFractionDigits(currencyUpper);
+  const amount = amountInMinorUnits / Math.pow(10, digits);
+  const formatted = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currencyUpper,
+    currencyDisplay: "narrowSymbol",
+    ...options
+  }).format(amount);
+  return disambiguate(currencyUpper, formatted);
+}


### PR DESCRIPTION
## Summary
- `PaymentHistoryRow` previously hardcoded `$` and `usePayments` always divided `amount_in_cents` by 100, so a ¥999 charge rendered as `$9.99`.
- Carry the API's `currency` through `Payment` and format with `Intl.NumberFormat`, which handles both the symbol and zero-decimal currencies (JPY, KRW) correctly.

## Test plan
- [ ] Settings → payment history: USD charge still renders as `$X.YY`
- [ ] Mock a JPY payment (`amount_in_cents: 999`, `currency: "jpy"`) and confirm it renders as `¥999`

🤖 Generated with [Claude Code](https://claude.com/claude-code)