### PR TITLE
Populate support article with help routing

### DIFF
--- a/content/src/posts/articles/support/en.md
+++ b/content/src/posts/articles/support/en.md
@@ -7,4 +7,10 @@ seo:
   keywords: ["support", "help", "contact", "jiki"]
 ---
 
-Content coming soon.
+We want you to get the help you need, in the right place, as quickly as possible. Depending on what you're after, here's where to go:
+
+- **Stuck on an exercise or have a question about the course?** Head to the [forum](/r/forum) and post your question there. It's the fastest way to get help from the community and the Jiki team.
+- **Billing, payments, or subscription issues?** Email [support@jiki.io](mailto:support@jiki.io) and we'll sort it out for you.
+- **Want Jeremy to answer one of your questions?** Premium members can ask on one of the regular Q&A livestreams, so make sure to sign up to Premium if you'd like that opportunity.
+
+Whichever route fits, we're here to help you keep moving.


### PR DESCRIPTION
## Summary
- Replaces the placeholder support article with a short intro, three bullet points (forum for course help, support@jiki.io for billing, Premium Q&A livestreams for questions to Jeremy), and a closing line.

## Test plan
- [ ] Visit /articles/support and verify the routing options render correctly
- [ ] Confirm the forum and mailto links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)