### PR TITLE
Replace chat empty state with Jiki greeting

### DIFF
--- a/app/components/coding-exercise/ui/ChatInput.tsx
+++ b/app/components/coding-exercise/ui/ChatInput.tsx
@@ -42,6 +42,7 @@ export default function ChatInput({
         </div>
         <div className={styles.chatInputField}>
           <textarea
+            autoFocus
             className={styles.chatInput}
             value={message}
             onChange={(e) => setMessage(e.target.value)}

--- a/app/components/coding-exercise/ui/ChatMessages.module.css
+++ b/app/components/coding-exercise/ui/ChatMessages.module.css
@@ -29,9 +29,3 @@
     background: var(--color-gray-200);
     z-index: 0;
 }
-
-.emptyState {
-    text-align: center;
-    font-size: 14px;
-    color: var(--color-gray-500);
-}

--- a/app/components/coding-exercise/ui/ChatMessages.tsx
+++ b/app/components/coding-exercise/ui/ChatMessages.tsx
@@ -32,9 +32,7 @@ export default function ChatMessages({
       {header}
       <div ref={chatMessagesRef} className={styles.chatMessages}>
         {messages.length === 0 && !currentResponse && (
-          <div className={styles.emptyState}>
-            Start a conversation! Ask questions about your code, the exercise, or request help with specific tasks.
-          </div>
+          <ChatMessageItem message={{ role: "assistant", content: "What can I help you with?" }} />
         )}
 
         {messages.map((message, index) => (


### PR DESCRIPTION
## Summary
- Replace the plain "Start a conversation!" empty state with a real assistant message ("What can I help you with?") rendered via `ChatMessageItem`, so the Jiki avatar and styling match subsequent responses.
- Autofocus the chat textarea so the user can start typing immediately.

## Test plan
- [ ] Open a coding exercise and the chat panel
- [ ] Verify the Jiki avatar + "What can I help you with?" appears in the empty state
- [ ] Verify the textarea is focused on mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)