### PR TITLE
Populate streaks article

### DIFF
--- a/content/src/posts/articles/streaks/en.md
+++ b/content/src/posts/articles/streaks/en.md
@@ -7,4 +7,45 @@ seo:
   keywords: ["streaks", "learning", "motivation", "jiki"]
 ---
 
-Content coming soon.
+A **streak** is the number of consecutive days you've practised on Jiki. It's a little nudge to help you build a daily learning habit, because consistency is genuinely one of the most reliable ways to get good at coding.
+
+You'll see your current streak in the sidebar, next to a little icon.
+
+## How streaks are earned
+
+Your streak goes up by one for every day you **complete at least one lesson**. That's it. There's no minimum time you need to spend, and no quota of exercises to hit. Finish a lesson and the day counts.
+
+Days are calculated in your **local timezone**, so "today" means today wherever you are, not somewhere on the other side of the world.
+
+## How streaks are lost
+
+If you go a full day without completing a lesson, your streak resets to zero the next day. We know that can sting a little, so the goal isn't to make you feel bad. It's just to give you a clear signal that the habit slipped, and a fresh chance to start again.
+
+A reset isn't a punishment. Plenty of people rebuild streaks several times before one really sticks, and your total practice still counts towards your progress regardless.
+
+## The icons
+
+The icon next to your streak number changes depending on where you're at:
+
+- 😢 **No streak yet.** Complete a lesson today to kick one off.
+- 🚀 **One day.** You're off the ground. Come back tomorrow to keep it going.
+- 🔥 **Two or more days.** You're on a roll.
+
+## Tracking more than just streaks
+
+Even if your streak resets, Jiki still tracks the **total number of days** you've been active. Nothing you've done gets wiped, your overall progress is safe, and your longest streak is recorded too.
+
+## Turning streaks off
+
+Streaks work brilliantly for some people, and feel like extra pressure to others. If they're not for you, you can switch them off in **Settings → Learning**.
+
+With streaks disabled, the sidebar shows a 🎓 icon next to your **total active days** instead. You still get the satisfaction of watching that number climb, without the daily commitment.
+
+## Some tips
+
+- **Aim small.** Even one short lesson keeps the streak alive on a busy day.
+- **Don't beat yourself up.** If your streak resets, just start again. Nobody's keeping score except you.
+- **Pick a regular time.** Tying practice to something you already do (morning coffee, the commute, after dinner) is the easiest way to make it stick.
+- **Switch them off if they're stressful.** The point is to help you learn, not to make you anxious.
+
+Streaks are there to support your learning, not to define it. Use them if they help, ignore them if they don't, and either way, enjoy the journey.


### PR DESCRIPTION
## Summary
- Replaces the "Content coming soon." stub in `articles/streaks` with a full article describing how streaks are earned, lost, displayed, and disabled, based on the actual behaviour in `api` (`User::ActivityLog`) and `app` (`UserProfile/Streak.tsx`, `LearningTab.tsx`).

## Test plan
- [ ] `cd ../app && pnpm run generate:content` succeeds
- [ ] `/articles/streaks` renders the new content