### PR TITLE
Add disableLogTab flag for early exercises

### DIFF
--- a/app/components/coding-exercise/RHS.tsx
+++ b/app/components/coding-exercise/RHS.tsx
@@ -27,6 +27,7 @@ export function RHS({ orchestrator }: RHSProps) {
   const isProject = orchestrator.isProject();
   const navTarget = isProject ? "/projects" : "/dashboard";
   const navLabel = isProject ? "Projects" : "Dashboard";
+  const logTabDisabled = orchestrator.getExercise().disableLogTab === true;
 
   // Define tabs data for PageTabs
   const tabs = [
@@ -40,11 +41,15 @@ export function RHS({ orchestrator }: RHSProps) {
       label: "Talk to Jiki",
       icon: <ChatIcon width={18} height={18} className="mr-2" />
     },
-    {
-      id: "log",
-      label: "Log",
-      icon: <LogIcon width={18} height={18} className="mr-2" />
-    },
+    ...(logTabDisabled
+      ? []
+      : [
+          {
+            id: "log",
+            label: "Log",
+            icon: <LogIcon width={18} height={18} className="mr-2" />
+          }
+        ]),
     {
       id: "hints",
       label: "Hints",

--- a/curriculum/src/exercises/cloud-rain-sun/index.ts
+++ b/curriculum/src/exercises/cloud-rain-sun/index.ts
@@ -39,7 +39,8 @@ const exerciseDefinition: VisualExerciseCore = {
     javascript: [{ fromLine: 4, toLine: 4 }],
     python: [{ fromLine: 4, toLine: 4 }],
     jikiscript: [{ fromLine: 4, toLine: 4 }]
-  }
+  },
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/fix-wall/index.ts
+++ b/curriculum/src/exercises/fix-wall/index.ts
@@ -20,7 +20,8 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["using-functions", "using-functions-with-inputs"]
+  conceptSlugs: ["using-functions", "using-functions-with-inputs"],
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/foxy-face/index.ts
+++ b/curriculum/src/exercises/foxy-face/index.ts
@@ -20,7 +20,8 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["using-functions", "using-functions-with-inputs", "strings"]
+  conceptSlugs: ["using-functions", "using-functions-with-inputs", "strings"],
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/jumbled-house/index.ts
+++ b/curriculum/src/exercises/jumbled-house/index.ts
@@ -34,7 +34,8 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["using-functions", "using-functions-with-inputs", "strings"]
+  conceptSlugs: ["using-functions", "using-functions-with-inputs", "strings"],
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/maze-solve-basic/index.ts
+++ b/curriculum/src/exercises/maze-solve-basic/index.ts
@@ -12,7 +12,8 @@ const exerciseDefinition: VisualExerciseCore = {
   ExerciseClass,
   tasks,
   scenarios,
-  functions
+  functions,
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/maze-solve-walk/index.ts
+++ b/curriculum/src/exercises/maze-solve-walk/index.ts
@@ -38,7 +38,8 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["using-functions", "using-functions-with-inputs"]
+  conceptSlugs: ["using-functions", "using-functions-with-inputs"],
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/penguin/index.ts
+++ b/curriculum/src/exercises/penguin/index.ts
@@ -41,7 +41,8 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["using-functions", "using-functions-with-inputs", "strings"]
+  conceptSlugs: ["using-functions", "using-functions-with-inputs", "strings"],
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/snowman-basic/index.ts
+++ b/curriculum/src/exercises/snowman-basic/index.ts
@@ -20,7 +20,8 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["using-functions", "using-functions-with-inputs"]
+  conceptSlugs: ["using-functions", "using-functions-with-inputs"],
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/space-invaders-solve-basic/index.ts
+++ b/curriculum/src/exercises/space-invaders-solve-basic/index.ts
@@ -28,7 +28,8 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["using-functions"]
+  conceptSlugs: ["using-functions"],
+  disableLogTab: true
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/types.ts
+++ b/curriculum/src/exercises/types.ts
@@ -29,6 +29,7 @@ interface BaseExerciseCore {
   conceptSlugs?: string[];
   readonlyRanges?: Partial<Record<Language, ReadonlyRange[]>>; // Per-language readonly code regions
   interpreterOptions?: InterpreterOptions; // Per-exercise interpreter overrides (e.g., loop iteration limits)
+  disableLogTab?: boolean; // Hide the Log tab in the RHS panel for this exercise
 }
 
 // Per-exercise interpreter options (overrides defaults when passed to interpreter)


### PR DESCRIPTION
## Summary
- Adds `disableLogTab?: boolean` to `BaseExerciseCore` so exercises can hide the Log tab on the RHS panel
- `RHS.tsx` filters out the Log tab when `exercise.disableLogTab === true`
- Applied `disableLogTab: true` to all 9 exercises in the `using-functions` and `strings-and-colors` levels — i.e. everything before `golf-rolling-ball-loop`, the first exercise that introduces logging

Affected exercises:
- using-functions: fix-wall, maze-solve-basic, maze-solve-walk, snowman-basic, space-invaders-solve-basic
- strings-and-colors: cloud-rain-sun, foxy-face, jumbled-house, penguin

## Test plan
- [ ] Load any of the affected exercises and confirm the Log tab is absent
- [ ] Load `golf-rolling-ball-loop` and confirm the Log tab still appears