### PR TITLE
Rename seen_flags API to flags

### DIFF
--- a/app/app/dev/welcome-modal-test/page.tsx
+++ b/app/app/dev/welcome-modal-test/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { showWelcomeModal } from "@/lib/modal";
-import { clearSeenFlagLocal } from "@/lib/api/seen-flags";
+import { clearFlagLocal } from "@/lib/api/flags";
 
-const WELCOME_SEEN_KEY = "welcome_modal";
+const WELCOME_FLAG_KEY = "welcome_modal";
 
 export default function WelcomeModalTestPage() {
   const handleShow = () => {
@@ -11,7 +11,7 @@ export default function WelcomeModalTestPage() {
   };
 
   const handleReset = () => {
-    clearSeenFlagLocal(WELCOME_SEEN_KEY);
+    clearFlagLocal(WELCOME_FLAG_KEY);
   };
 
   return (
@@ -34,14 +34,14 @@ export default function WelcomeModalTestPage() {
         <div className="border border-border-secondary rounded-lg p-6 bg-bg-secondary">
           <h2 className="text-xl font-semibold mb-2 text-text-primary">Reset localStorage flag</h2>
           <p className="text-text-secondary text-sm mb-4">
-            Clears the <code className="font-mono text-xs bg-bg-tertiary px-1 py-0.5 rounded">{WELCOME_SEEN_KEY}</code>{" "}
+            Clears the <code className="font-mono text-xs bg-bg-tertiary px-1 py-0.5 rounded">{WELCOME_FLAG_KEY}</code>{" "}
             key so the modal will trigger again on next page load.
           </p>
           <button
             onClick={handleReset}
             className="w-full px-4 py-3 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors font-medium"
           >
-            Reset &quot;seen&quot; flag
+            Reset flag
           </button>
         </div>
       </div>

--- a/app/components/WelcomeModalHandler.tsx
+++ b/app/components/WelcomeModalHandler.tsx
@@ -3,12 +3,12 @@
 import { useEffect } from "react";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { showWelcomeModal } from "@/lib/modal";
-import { checkSeenFlag, setSeenFlag } from "@/lib/api/seen-flags";
+import { checkFlag, setFlag } from "@/lib/api/flags";
 
-const WELCOME_SEEN_KEY = "welcome_modal";
+const WELCOME_FLAG_KEY = "welcome_modal";
 
 /**
- * Shows the welcome video modal once per user, tracked via the seen-flags API
+ * Shows the welcome video modal once per user, tracked via the flags API
  * (with a localStorage cache).
  */
 export function WelcomeModalHandler() {
@@ -20,12 +20,12 @@ export function WelcomeModalHandler() {
     }
 
     void (async () => {
-      const seen = await checkSeenFlag(WELCOME_SEEN_KEY);
-      if (seen) {
+      const flagged = await checkFlag(WELCOME_FLAG_KEY);
+      if (flagged) {
         return;
       }
 
-      void setSeenFlag(WELCOME_SEEN_KEY);
+      void setFlag(WELCOME_FLAG_KEY);
       showWelcomeModal();
     })();
   }, [hasCheckedAuth, isAuthenticated]);

--- a/app/lib/api/flags.ts
+++ b/app/lib/api/flags.ts
@@ -1,10 +1,10 @@
 "use client";
 
 /**
- * Seen Flags API
+ * Flags API
  *
- * Tracks "things the user has seen" (welcome modal, feature announcements, etc).
- * Backed by the API at /internal/settings/seen_flags/:key with a localStorage
+ * Tracks per-user flags (welcome modal dismissed, tour completed, etc).
+ * Backed by the API at /internal/settings/flags/:key with a localStorage
  * cache so repeat checks are instant and survive transient API failures.
  *
  * Note: keys have a maximum length of 100 characters (enforced by the API).
@@ -12,10 +12,10 @@
 
 import { api } from "./client";
 
-const STORAGE_PREFIX = "jiki_seen_flag_";
+const STORAGE_PREFIX = "jiki_flag_";
 
-interface SeenFlagResponse {
-  seen: boolean;
+interface FlagResponse {
+  flagged: boolean;
 }
 
 function storageKey(key: string) {
@@ -37,17 +37,17 @@ function writeLocal(key: string) {
 }
 
 /**
- * Returns true if the flag is seen. Checks localStorage first; on a miss,
+ * Returns true if the flag is set. Checks localStorage first; on a miss,
  * falls back to the API and caches a positive result.
  */
-export async function checkSeenFlag(key: string): Promise<boolean> {
+export async function checkFlag(key: string): Promise<boolean> {
   if (readLocal(key)) {
     return true;
   }
 
   try {
-    const response = await api.get<SeenFlagResponse>(`/internal/settings/seen_flags/${key}`);
-    if (response.data.seen) {
+    const response = await api.get<FlagResponse>(`/internal/settings/flags/${key}`);
+    if (response.data.flagged) {
       writeLocal(key);
       return true;
     }
@@ -59,14 +59,14 @@ export async function checkSeenFlag(key: string): Promise<boolean> {
 }
 
 /**
- * Marks the flag as seen, both on the server and in localStorage.
+ * Marks the flag set, both on the server and in localStorage.
  */
-export async function setSeenFlag(key: string): Promise<void> {
+export async function setFlag(key: string): Promise<void> {
   writeLocal(key);
-  await api.post<SeenFlagResponse>(`/internal/settings/seen_flags/${key}`);
+  await api.post(`/internal/settings/flags/${key}`);
 }
 
-export function clearSeenFlagLocal(key: string) {
+export function clearFlagLocal(key: string) {
   if (typeof window === "undefined") {
     return;
   }

--- a/app/tests/e2e/badge-reveal.test.ts
+++ b/app/tests/e2e/badge-reveal.test.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "./helpers/test";
-import { mockAPIBadgeReveal, mockAPIBadges, mockAPIInternalMe, mockAPISeenFlag } from "./helpers/api-mocks";
+import { mockAPIBadgeReveal, mockAPIBadges, mockAPIInternalMe, mockAPIFlag } from "./helpers/api-mocks";
 import { AUTHENTICATION_COOKIE_NAME } from "@/lib/auth/cookie-config";
 import { createMockUser } from "../mocks/user";
 
@@ -68,7 +68,7 @@ test.describe("Badge Reveal E2E", () => {
   test("reveals an unrevealed badge when clicked", async ({ page }) => {
     await setupAuthentication(page);
     await mockAPIInternalMe(page, createMockUser());
-    await mockAPISeenFlag(page, "welcome_modal", true);
+    await mockAPIFlag(page, "welcome_modal", true);
     await mockAPIBadges(page, BADGES_FIXTURE);
     await mockAPIBadgeReveal(page, 2, {
       id: 2,

--- a/app/tests/e2e/helpers/api-mocks.ts
+++ b/app/tests/e2e/helpers/api-mocks.ts
@@ -104,12 +104,12 @@ export async function mockAPILogout(page: Page) {
   });
 }
 
-export async function mockAPISeenFlag(page: Page, key: string, seen: boolean) {
-  await page.route(`${API_BASE}/internal/settings/seen_flags/${key}`, (route) =>
+export async function mockAPIFlag(page: Page, key: string, flagged: boolean) {
+  await page.route(`${API_BASE}/internal/settings/flags/${key}`, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ seen })
+      body: JSON.stringify({ flagged })
     })
   );
 }

--- a/app/tests/unit/lib/api/flags.test.ts
+++ b/app/tests/unit/lib/api/flags.test.ts
@@ -1,4 +1,4 @@
-import { checkSeenFlag, clearSeenFlagLocal, setSeenFlag } from "@/lib/api/seen-flags";
+import { checkFlag, clearFlagLocal, setFlag } from "@/lib/api/flags";
 
 jest.mock("@/lib/api/client", () => ({
   api: {
@@ -12,19 +12,19 @@ import { api } from "@/lib/api/client";
 const mockApi = api as jest.Mocked<typeof api>;
 
 const KEY = "welcome_modal";
-const STORAGE_KEY = `jiki_seen_flag_${KEY}`;
+const STORAGE_KEY = `jiki_flag_${KEY}`;
 
-describe("seen-flags API", () => {
+describe("flags API", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
   });
 
-  describe("checkSeenFlag", () => {
+  describe("checkFlag", () => {
     it("returns true from localStorage without hitting the API", async () => {
       localStorage.setItem(STORAGE_KEY, "true");
 
-      const result = await checkSeenFlag(KEY);
+      const result = await checkFlag(KEY);
 
       expect(result).toBe(true);
       expect(mockApi.get).not.toHaveBeenCalled();
@@ -32,26 +32,26 @@ describe("seen-flags API", () => {
 
     it("falls back to the API when localStorage is empty and caches a positive result", async () => {
       mockApi.get.mockResolvedValue({
-        data: { seen: true },
+        data: { flagged: true },
         status: 200,
         headers: new Headers()
       });
 
-      const result = await checkSeenFlag(KEY);
+      const result = await checkFlag(KEY);
 
-      expect(mockApi.get).toHaveBeenCalledWith(`/internal/settings/seen_flags/${KEY}`);
+      expect(mockApi.get).toHaveBeenCalledWith(`/internal/settings/flags/${KEY}`);
       expect(result).toBe(true);
       expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
     });
 
-    it("returns false and does not cache when the API says unseen", async () => {
+    it("returns false and does not cache when the API says unflagged", async () => {
       mockApi.get.mockResolvedValue({
-        data: { seen: false },
+        data: { flagged: false },
         status: 200,
         headers: new Headers()
       });
 
-      const result = await checkSeenFlag(KEY);
+      const result = await checkFlag(KEY);
 
       expect(result).toBe(false);
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
@@ -60,33 +60,33 @@ describe("seen-flags API", () => {
     it("returns false when the API request fails", async () => {
       mockApi.get.mockRejectedValue(new Error("network down"));
 
-      const result = await checkSeenFlag(KEY);
+      const result = await checkFlag(KEY);
 
       expect(result).toBe(false);
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });
   });
 
-  describe("setSeenFlag", () => {
+  describe("setFlag", () => {
     it("writes to localStorage and POSTs to the API", async () => {
       mockApi.post.mockResolvedValue({
-        data: { seen: true },
+        data: {},
         status: 200,
         headers: new Headers()
       });
 
-      await setSeenFlag(KEY);
+      await setFlag(KEY);
 
       expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
-      expect(mockApi.post).toHaveBeenCalledWith(`/internal/settings/seen_flags/${KEY}`);
+      expect(mockApi.post).toHaveBeenCalledWith(`/internal/settings/flags/${KEY}`);
     });
   });
 
-  describe("clearSeenFlagLocal", () => {
+  describe("clearFlagLocal", () => {
     it("removes the localStorage entry", () => {
       localStorage.setItem(STORAGE_KEY, "true");
 
-      clearSeenFlagLocal(KEY);
+      clearFlagLocal(KEY);
 
       expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     });


### PR DESCRIPTION
## Summary
- Switch client to renamed `/internal/settings/flags/:key` endpoints (GET returns `{ flagged }`, POST idempotently sets the flag).
- Rename `lib/api/seen-flags.ts` → `lib/api/flags.ts` with `checkFlag` / `setFlag` / `clearFlagLocal`; localStorage prefix is now `jiki_flag_`.
- Update `WelcomeModalHandler`, dev test page, e2e mock helper (`mockAPIFlag`), and the badge-reveal e2e test.

## Test plan
- [x] `pnpm test:app` (1662 passed)
- [x] `pnpm typecheck`
- [ ] Manual: log in as a user without the `welcome_modal` flag set → welcome modal appears; reload → no modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)