### PR TITLE
Add JikiMuxPlayer wrapper with shared defaults

### DIFF
--- a/app/app/(app)/build/PlaceholderVideo.tsx
+++ b/app/app/(app)/build/PlaceholderVideo.tsx
@@ -3,15 +3,13 @@
 import dynamic from "next/dynamic";
 import styles from "./BuildIndex.module.css";
 
-const MuxPlayer = dynamic(() => import("@mux/mux-player-react"), { ssr: false });
+const MuxPlayer = dynamic(() => import("@/components/ui/JikiMuxPlayer"), { ssr: false });
 
 export function PlaceholderVideo({ playbackId }: { playbackId: string }) {
   return (
     <div className={styles.placeholderVideo}>
       <MuxPlayer
         playbackId={playbackId}
-        streamType="on-demand"
-        defaultHiddenCaptions={true}
         className={styles.placeholderVideoPlayer}
         style={{
           ["--seek-backward-button" as string]: "none",

--- a/app/components/build-episode/BuildEpisodeVideo.tsx
+++ b/app/components/build-episode/BuildEpisodeVideo.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from "@/lib/auth/authStore";
 import type { BuildVideoProvider } from "@/lib/content/types";
 import { showPremiumUpgradeModal } from "@/lib/modal";
 import { tierIncludes } from "@/lib/pricing";
-import MuxPlayer from "@mux/mux-player-react";
+import MuxPlayer from "@/components/ui/JikiMuxPlayer";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import YouTube from "react-youtube";
@@ -77,7 +77,6 @@ export default function BuildEpisodeVideo({
           <MuxPlayer
             ref={muxPlayerRef}
             playbackId={videoKey}
-            streamType="on-demand"
             autoPlay={false}
             className={`${styles.player} ${isReady ? "" : styles.playerHidden}`}
             onTimeUpdate={handleMuxTimeUpdate}

--- a/app/components/choose-language/ui/VideoStep.tsx
+++ b/app/components/choose-language/ui/VideoStep.tsx
@@ -3,8 +3,7 @@
 import { useRef, useState, useEffect } from "react";
 import type { Lesson, VideoSource } from "@/types/lesson";
 import type { ProgrammingLanguage } from "@/types/course";
-import MuxPlayer from "@mux/mux-player-react";
-import type { MuxPlayerRefAttributes } from "@mux/mux-player-react";
+import MuxPlayer, { type MuxPlayerRefAttributes } from "@/components/ui/JikiMuxPlayer";
 import styles from "../ChooseLanguage.module.css";
 
 type ChooseLanguageLesson = Lesson & {
@@ -65,11 +64,7 @@ export function VideoStep({ lessonData, onReady, onProceedToSelector, hasVisited
             <MuxPlayer
               ref={playerRef}
               playbackId={playbackId}
-              streamType="on-demand"
               autoPlay={true}
-              loop={false}
-              muted={false}
-              volume={0.5}
               className={`${styles.muxPlayer} ${isVideoVisible ? styles.muxPlayerVisible : styles.muxPlayerHidden}`}
               onPlay={handleVideoPlay}
               onEnded={handleVideoEnd}

--- a/app/components/coding-exercise/ui/HintsPanel.tsx
+++ b/app/components/coding-exercise/ui/HintsPanel.tsx
@@ -19,7 +19,7 @@ import style from "./hints-panel.module.css";
 hljs.registerLanguage("jikiscript", setupJikiscript);
 hljs.registerLanguage("javascript", setupJavascript);
 
-const MuxPlayer = dynamic(() => import("@mux/mux-player-react"), { ssr: false });
+const MuxPlayer = dynamic(() => import("@/components/ui/JikiMuxPlayer"), { ssr: false });
 
 interface HintsViewProps {
   hints: Hint[] | undefined;
@@ -129,11 +129,7 @@ function InlineWalkthroughPlayer({ playbackId, lessonSlug }: { playbackId: strin
       <MuxPlayer
         ref={playerRef}
         playbackId={playbackId}
-        streamType="on-demand"
         autoPlay={true}
-        loop={false}
-        muted={false}
-        volume={0.5}
         className={style.walkthroughPlayer}
         onTimeUpdate={handleTimeUpdate}
         onEnded={handleVideoEnd}

--- a/app/components/landing-page/Hero.tsx
+++ b/app/components/landing-page/Hero.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import Image from "next/image";
-import MuxPlayer from "@mux/mux-player-react";
+import MuxPlayer from "@/components/ui/JikiMuxPlayer";
 import { annotate } from "rough-notation";
 import styles from "./Hero.module.css";
 import shared from "./shared.module.css";
@@ -128,8 +128,6 @@ export function Hero() {
               playbackId="zYEf6JjYXCZYUnqXllzzMaUO02aMaaMbX02m6erDKEg7A"
               poster="https://assets.jiki.io/landing-video-thumbnail-ef14e.webp"
               metadata={{ video_title: "Waiting Page 1" }}
-              accentColor="#7c3aed"
-              defaultHiddenCaptions={true}
               style={{
                 display: "block",
                 width: "100%",

--- a/app/components/ui/JikiMuxPlayer.tsx
+++ b/app/components/ui/JikiMuxPlayer.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { forwardRef } from "react";
+import MuxPlayer from "@mux/mux-player-react";
+import type { MuxPlayerProps, MuxPlayerRefAttributes } from "@mux/mux-player-react";
+
+const JikiMuxPlayer = forwardRef<MuxPlayerRefAttributes, MuxPlayerProps>(function JikiMuxPlayer(props, ref) {
+  return (
+    <MuxPlayer
+      ref={ref}
+      streamType="on-demand"
+      defaultHiddenCaptions={true}
+      muted={false}
+      volume={1}
+      loop={false}
+      accentColor="#7c3aed"
+      {...props}
+    />
+  );
+});
+
+export default JikiMuxPlayer;
+export type { MuxPlayerRefAttributes };

--- a/app/components/video-exercise/VideoExercise.tsx
+++ b/app/components/video-exercise/VideoExercise.tsx
@@ -2,7 +2,7 @@
 
 import { LessonQuitButton } from "@/components/lesson/LessonQuitButton";
 import type { Lesson, VideoSource } from "@/types/lesson";
-import MuxPlayer from "@mux/mux-player-react";
+import MuxPlayer from "@/components/ui/JikiMuxPlayer";
 import { useEffect } from "react";
 import { FloatingPill } from "./ui/FloatingPill";
 import { NoVideoPlaceholder } from "./ui/NoVideoPlaceholder";
@@ -49,12 +49,7 @@ export default function VideoExercise({ lessonData, onReady }: { lessonData: Vid
             <MuxPlayer
               ref={playerRef}
               playbackId={playbackId}
-              streamType="on-demand"
-              defaultHiddenCaptions
               autoPlay={true}
-              loop={false}
-              muted={false}
-              volume={0.5}
               className={`${videoWatched ? styles.muxPlayerCompleted : styles.muxPlayer} ${isVideoVisible ? styles.muxPlayerVisible : styles.muxPlayerHidden}`}
               onPlay={handleVideoPlay}
               onEnded={handleVideoEnd}

--- a/app/lib/modal/modals/VideoWalkthroughModal.tsx
+++ b/app/lib/modal/modals/VideoWalkthroughModal.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import { useWalkthroughProgress } from "./useWalkthroughProgress";
 import styles from "./VideoWalkthroughModal.module.css";
 
-const MuxPlayer = dynamic(() => import("@mux/mux-player-react"), { ssr: false });
+const MuxPlayer = dynamic(() => import("@/components/ui/JikiMuxPlayer"), { ssr: false });
 
 interface VideoWalkthroughModalProps {
   playbackId: string;
@@ -19,11 +19,7 @@ export function VideoWalkthroughModal({ playbackId, lessonSlug }: VideoWalkthrou
       <MuxPlayer
         ref={playerRef}
         playbackId={playbackId}
-        streamType="on-demand"
         autoPlay={true}
-        loop={false}
-        muted={false}
-        volume={0.5}
         className={styles.muxPlayer}
         onTimeUpdate={handleTimeUpdate}
         onEnded={handleVideoEnd}

--- a/app/lib/modal/modals/WelcomeModal.tsx
+++ b/app/lib/modal/modals/WelcomeModal.tsx
@@ -6,7 +6,7 @@ import Tooltip from "@/components/ui/Tooltip";
 import { hideModal } from "../store";
 import styles from "./WelcomeModal.module.css";
 
-const MuxPlayer = dynamic(() => import("@mux/mux-player-react"), { ssr: false });
+const MuxPlayer = dynamic(() => import("@/components/ui/JikiMuxPlayer"), { ssr: false });
 
 const WELCOME_VIDEO_PLAYBACK_ID = "rhfF43a6sjaqX7E5Cxcvt7efmwn00knZZ202CvgViQRDc";
 const VIDEO_LOAD_FALLBACK_MS = 5000;
@@ -43,12 +43,7 @@ export function WelcomeModal() {
       <div className={styles.videoWrapper}>
         <MuxPlayer
           playbackId={WELCOME_VIDEO_PLAYBACK_ID}
-          streamType="on-demand"
           autoPlay={true}
-          loop={false}
-          muted={false}
-          volume={0.5}
-          defaultHiddenCaptions={true}
           className={styles.muxPlayer}
           onCanPlay={() => setCanPlay(true)}
           onEnded={() => setWatched(true)}

--- a/app/tests/unit/components/build-episode/BuildEpisodeVideo.test.tsx
+++ b/app/tests/unit/components/build-episode/BuildEpisodeVideo.test.tsx
@@ -24,7 +24,7 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mockReplace, push: mockPush })
 }));
 
-jest.mock("@mux/mux-player-react", () => ({
+jest.mock("@/components/ui/JikiMuxPlayer", () => ({
   __esModule: true,
   default: (props: { playbackId: string }) => <div data-testid="mux-player" data-playback-id={props.playbackId} />
 }));


### PR DESCRIPTION
## Summary
- New `components/ui/JikiMuxPlayer.tsx` wraps `@mux/mux-player-react` with project-wide defaults: `streamType="on-demand"`, `defaultHiddenCaptions={true}`, `muted={false}`, `volume={1}`, `loop={false}`, `accentColor="#7c3aed"`.
- All 8 existing MuxPlayer call sites switched to import the wrapper and drop now-redundant props.
- Updated BuildEpisodeVideo test mock to target the wrapper path.

## Test plan
- [ ] Hero video on landing page plays at full volume with captions off
- [ ] Welcome modal video plays at full volume with captions off
- [ ] Video lesson (`video-exercise`) plays at full volume with captions off
- [ ] Choose-language intro video plays at full volume with captions off
- [ ] Walkthrough video in hints panel plays at full volume with captions off
- [ ] Build episode mux video still tracks progress correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)