### PR TITLE
Link Beta Version tag to beta-phase article

### DIFF
--- a/app/components/common/BetaTag.module.css
+++ b/app/components/common/BetaTag.module.css
@@ -10,7 +10,6 @@
     text-align: center;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    pointer-events: none;
     width: 200px;
     padding: 6px 0;
     font-size: 12px;

--- a/app/components/common/BetaTag.tsx
+++ b/app/components/common/BetaTag.tsx
@@ -1,5 +1,10 @@
+import Link from "next/link";
 import styles from "./BetaTag.module.css";
 
 export default function BetaTag() {
-  return <div className={styles.tag}>Beta Version</div>;
+  return (
+    <Link href="/articles/beta-phase" className={styles.tag}>
+      Beta Version
+    </Link>
+  );
 }


### PR DESCRIPTION
## Summary
- The Beta Version corner tag now links to `/articles/beta-phase`
- Removed `pointer-events: none` so the tag is clickable

## Test plan
- [ ] Visit a page with the Beta tag (e.g. dashboard) and click it
- [ ] Confirm it navigates to the beta-phase article

🤖 Generated with [Claude Code](https://claude.com/claude-code)