### PR TITLE
Remove basic auth from production

### DIFF
--- a/app/.context/deployment.md
+++ b/app/.context/deployment.md
@@ -7,10 +7,6 @@ Cloudflare Workers with Next.js Edge Runtime
 ## Production Environment
 
 - **Production URL**: https://jiki.io
-- **Basic Authentication**:
-  - Username: `jiki`
-  - Password: `ave-fetching-chloe-packed`
-  - Enabled only in production (`NODE_ENV=production`)
 - **Edge Runtime**: Cloudflare Workers with global distribution
 - **Custom Domain**: Automatic DNS management via Cloudflare
 - **Caching**: R2 bucket for incremental builds with 30-minute regional cache
@@ -64,7 +60,6 @@ The following secrets must be configured in repository settings:
 
 - **Development Server**: http://localhost:3061 (`pnpm dev`)
 - **Preview with Wrangler**: `pnpm preview` (simulates Workers environment locally)
-- **E2E Tests**: Run with `NODE_ENV=test` to bypass basic auth
 
 ## Infrastructure
 
@@ -84,7 +79,6 @@ The following secrets must be configured in repository settings:
 
 - **Content Security Policy**: Nonce-based script execution in production
 - **Process.env Support**: Via `nodejs_compat_populate_process_env` compatibility flag
-- **Basic Auth**: Protects production site during pre-launch phase
 
 ## Site Metadata & Well-Known Files
 

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -4,13 +4,6 @@ import { AUTHENTICATION_COOKIE_NAME } from "./lib/auth/cookie-config";
 import { setInternalNavigationCookie } from "./lib/middleware/internal-navigation";
 import { isExternalUrl } from "./lib/routing/external-urls";
 
-// Basic authentication credentials
-// NOTE: These credentials are intentionally hardcoded and not considered secrets.
-// They provide basic protection during development/staging but are not meant for
-// production security. Username: jiki, Password: ave-fetching-chloe-packed
-const BASIC_AUTH_USER = "jiki";
-const BASIC_AUTH_PASSWORD = "ave-fetching-chloe-packed";
-
 function setCSP(response: NextResponse): void {
   const isProduction = process.env.NODE_ENV === "production";
 
@@ -38,84 +31,7 @@ function setCSP(response: NextResponse): void {
   response.headers.set("Content-Security-Policy", cspHeader);
 }
 
-function checkBasicAuth(request: NextRequest): NextResponse | null {
-  // Only apply basic auth in production
-  if (process.env.NODE_ENV !== "production") {
-    return null;
-  }
-
-  const authHeader = request.headers.get("authorization");
-
-  if (!authHeader) {
-    return new NextResponse("Authentication required", {
-      status: 401,
-      headers: {
-        "WWW-Authenticate": 'Basic realm="Secure Area"'
-      }
-    });
-  }
-
-  try {
-    // Validate Authorization header format
-    const parts = authHeader.split(" ");
-    if (parts.length !== 2 || parts[0] !== "Basic") {
-      return new NextResponse("Authentication failed", {
-        status: 401,
-        headers: {
-          "WWW-Authenticate": 'Basic realm="Secure Area"'
-        }
-      });
-    }
-
-    const auth = parts[1];
-    const decoded = Buffer.from(auth, "base64").toString("utf-8");
-
-    // Validate decoded credentials format
-    const colonIndex = decoded.indexOf(":");
-    if (colonIndex === -1) {
-      return new NextResponse("Authentication failed", {
-        status: 401,
-        headers: {
-          "WWW-Authenticate": 'Basic realm="Secure Area"'
-        }
-      });
-    }
-
-    const user = decoded.substring(0, colonIndex);
-    const password = decoded.substring(colonIndex + 1);
-
-    // Use constant-time comparison to prevent timing attacks
-    const userMatch = user === BASIC_AUTH_USER;
-    const passwordMatch = password === BASIC_AUTH_PASSWORD;
-
-    if (!userMatch || !passwordMatch) {
-      return new NextResponse("Authentication failed", {
-        status: 401,
-        headers: {
-          "WWW-Authenticate": 'Basic realm="Secure Area"'
-        }
-      });
-    }
-
-    return null;
-  } catch {
-    // Handle any decoding errors
-    return new NextResponse("Authentication failed", {
-      status: 401,
-      headers: {
-        "WWW-Authenticate": 'Basic realm="Secure Area"'
-      }
-    });
-  }
-}
-
 export function middleware(request: NextRequest) {
-  // Check basic auth first
-  const authResponse = checkBasicAuth(request);
-  if (authResponse) {
-    return authResponse;
-  }
-
   const path = request.nextUrl.pathname;
 
   // Block direct access to external routes


### PR DESCRIPTION
## Summary
- Remove basic auth check from `middleware.ts` (production no longer prompts for credentials)
- Drop the corresponding notes from `app/.context/deployment.md`

## Test plan
- [x] `pnpm typecheck`
- [x] Pre-commit hook (lint + tests) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)