### PR TITLE
Match email preferences page width to blog/articles container

### DIFF
--- a/app/app/dev/unsubscribe/page.tsx
+++ b/app/app/dev/unsubscribe/page.tsx
@@ -93,50 +93,52 @@ export default function UnsubscribeDevPage() {
         {/* Actual Unsubscribe Page UI */}
         <div className={`${styles.pageBackground} rounded-lg shadow-sm p-6`}>
           <div className={styles.pageWrapper}>
-            <header className={styles.pageHeader}>
-              <h1 className={styles.pageTitle}>Email Preferences</h1>
-              <p className={styles.pageSubtitle}>Manage how and when we communicate with you.</p>
-            </header>
+            <div className={styles.innerContent}>
+              <header className={styles.pageHeader}>
+                <h1 className={styles.pageTitle}>Email Preferences</h1>
+                <p className={styles.pageSubtitle}>Manage how and when we communicate with you.</p>
+              </header>
 
-            <div className={styles.contentLayout}>
-              <UnsubscribeFromEmailSection
-                emailKey="newsletters"
-                isSubscribed={preferences.newsletters}
-                loading={emailKeyState === "loading"}
-                success={emailKeyState === "success"}
-                error={emailKeyState === "error"}
-                onUnsubscribe={() => {
-                  simulateAction(setEmailKeyState, () => {
-                    setPreferences((prev) => ({ ...prev, newsletters: false }));
-                  });
-                }}
-              />
-
-              <UnsubscribeFromAllSection
-                loading={allState === "loading"}
-                success={allState === "success"}
-                error={allState === "error"}
-                onUnsubscribe={() => {
-                  simulateAction(setAllState, () => {
-                    setPreferences({
-                      newsletters: false,
-                      event_emails: false,
-                      milestone_emails: false,
-                      activity_emails: false
+              <div className={styles.contentLayout}>
+                <UnsubscribeFromEmailSection
+                  emailKey="newsletters"
+                  isSubscribed={preferences.newsletters}
+                  loading={emailKeyState === "loading"}
+                  success={emailKeyState === "success"}
+                  error={emailKeyState === "error"}
+                  onUnsubscribe={() => {
+                    simulateAction(setEmailKeyState, () => {
+                      setPreferences((prev) => ({ ...prev, newsletters: false }));
                     });
-                  });
-                }}
-              />
+                  }}
+                />
 
-              <ManageNotificationsSection
-                preferences={preferences}
-                loading={preferencesState === "loading"}
-                onSave={(newPreferences) => {
-                  simulateAction(setPreferencesState, () => {
-                    setPreferences(newPreferences);
-                  });
-                }}
-              />
+                <UnsubscribeFromAllSection
+                  loading={allState === "loading"}
+                  success={allState === "success"}
+                  error={allState === "error"}
+                  onUnsubscribe={() => {
+                    simulateAction(setAllState, () => {
+                      setPreferences({
+                        newsletters: false,
+                        event_emails: false,
+                        milestone_emails: false,
+                        activity_emails: false
+                      });
+                    });
+                  }}
+                />
+
+                <ManageNotificationsSection
+                  preferences={preferences}
+                  loading={preferencesState === "loading"}
+                  onSave={(newPreferences) => {
+                    simulateAction(setPreferencesState, () => {
+                      setPreferences(newPreferences);
+                    });
+                  }}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/app/components/unsubscribe/UnsubscribePage.module.css
+++ b/app/components/unsubscribe/UnsubscribePage.module.css
@@ -25,10 +25,18 @@
     line-height: 1.6;
 }
 
-/* Page wrapper with left-aligned content */
+/* Page wrapper - blog-style centered container */
 .pageWrapper {
+    width: 100%;
+    max-width: 1300px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 40px 5%;
+}
+
+/* Inner content stays narrow for readability */
+.innerContent {
     max-width: 660px;
-    padding: 40px;
 }
 
 /* Page header */

--- a/app/components/unsubscribe/UnsubscribePage.tsx
+++ b/app/components/unsubscribe/UnsubscribePage.tsx
@@ -43,37 +43,39 @@ export default function UnsubscribePage({ token, emailKey }: UnsubscribePageProp
 
   return (
     <div className={styles.pageWrapper}>
-      <header className={styles.pageHeader}>
-        <h1 className={styles.pageTitle}>Email Preferences</h1>
-        <p className={styles.pageSubtitle}>Manage how and when we communicate with you.</p>
-      </header>
+      <div className={styles.innerContent}>
+        <header className={styles.pageHeader}>
+          <h1 className={styles.pageTitle}>Email Preferences</h1>
+          <p className={styles.pageSubtitle}>Manage how and when we communicate with you.</p>
+        </header>
 
-      <div className={styles.contentLayout}>
-        {emailKey && preferences && (
-          <UnsubscribeFromEmailSection
-            emailKey={emailKey}
-            isSubscribed={currentKeyValue ?? false}
-            loading={actionStates.emailKey === "loading"}
-            success={actionStates.emailKey === "success"}
-            error={actionStates.emailKey === "error"}
-            onUnsubscribe={() => handleUpdatePreference(emailKey as keyof EmailPreferences, false)}
+        <div className={styles.contentLayout}>
+          {emailKey && preferences && (
+            <UnsubscribeFromEmailSection
+              emailKey={emailKey}
+              isSubscribed={currentKeyValue ?? false}
+              loading={actionStates.emailKey === "loading"}
+              success={actionStates.emailKey === "success"}
+              error={actionStates.emailKey === "error"}
+              onUnsubscribe={() => handleUpdatePreference(emailKey as keyof EmailPreferences, false)}
+            />
+          )}
+
+          <UnsubscribeFromAllSection
+            loading={actionStates.all === "loading"}
+            success={actionStates.all === "success"}
+            error={actionStates.all === "error"}
+            onUnsubscribe={handleUnsubscribeAll}
           />
-        )}
 
-        <UnsubscribeFromAllSection
-          loading={actionStates.all === "loading"}
-          success={actionStates.all === "success"}
-          error={actionStates.all === "error"}
-          onUnsubscribe={handleUnsubscribeAll}
-        />
-
-        {isAuthenticated && preferences && (
-          <ManageNotificationsSection
-            preferences={preferences}
-            loading={actionStates.preferences === "loading"}
-            onSave={handleSavePreferences}
-          />
-        )}
+          {isAuthenticated && preferences && (
+            <ManageNotificationsSection
+              preferences={preferences}
+              loading={actionStates.preferences === "loading"}
+              onSave={handleSavePreferences}
+            />
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Wraps the external email preferences (`/unsubscribe`) page in the same `max-width: 1300px` / `margin: auto` / `padding: 40px 5%` container used by the blog and articles pages, so the layout is consistent across external pages.
- Adds an inner `max-width: 660px` wrapper so the form cards stay readable inside the wider container.
- Mirrors the same structure change in the dev preview at `/dev/unsubscribe`.

## Test plan
- [ ] Visit `/unsubscribe?token=...` and confirm the page is centered like `/blog` and `/articles`.
- [ ] Visit `/dev/unsubscribe` and confirm the preview still renders correctly.
- [ ] Verify card widths still feel right at desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)