### PR TITLE
Fix LHS canvas sizing and enforce 400px LHS min-width

### DIFF
--- a/app/components/coding-exercise/CodingExercise.module.css
+++ b/app/components/coding-exercise/CodingExercise.module.css
@@ -424,7 +424,6 @@
     align-items: stretch;
     flex: 1;
     overflow: hidden;
-    container-type: inline-size;
 }
 
 .leftColumnContent {
@@ -674,6 +673,7 @@
     border-left: 1px solid var(--color-gray-200);
     position: relative;
     overflow: hidden;
+    container-type: inline-size;
 }
 
 /* Stabilize Safari compositor during panel resize, but only when no spotlight

--- a/app/components/coding-exercise/ui/test-results-view/VisualTestCanvas.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/VisualTestCanvas.tsx
@@ -37,7 +37,7 @@ export function VisualTestCanvas({ view, isSpotlightActive = false }: VisualTest
 
   return (
     <div className={styles.rightVideoContainer}>
-      <div className="h-full aspect-square max-h-[calc(50cqi-17px)]">
+      <div className="h-full aspect-square max-h-[100cqi]">
         <div
           className={assembleClassNames(
             "w-full h-full aspect-square [container-type:inline-size] relative",

--- a/app/components/coding-exercise/useResize.tsx
+++ b/app/components/coding-exercise/useResize.tsx
@@ -4,6 +4,12 @@ import React, { useEffect, useRef } from "react";
 type Direction = "horizontal" | "vertical";
 
 const STORAGE_KEY = "coding-exercise-panel-sizes";
+const LHS_MIN_PIXELS = 400;
+
+function clampVerticalPercentage(percentage: number, containerWidth: number) {
+  const minPercentage = Math.max(30, (LHS_MIN_PIXELS / containerWidth) * 100);
+  return Math.min(Math.max(percentage, minPercentage), 70);
+}
 
 interface StoredPanelSizes {
   verticalPercentage?: number;
@@ -61,12 +67,13 @@ export function useResizablePanels() {
       return;
     }
     const stored = readStoredSizes();
-    const verticalPercentage =
+    const rawPercentage =
       typeof stored.verticalPercentage === "number" &&
       stored.verticalPercentage >= 30 &&
       stored.verticalPercentage <= 70
         ? stored.verticalPercentage
         : 50;
+    const verticalPercentage = clampVerticalPercentage(rawPercentage, container.getBoundingClientRect().width);
     applyVertical(container, verticalDividerRef.current, verticalPercentage);
 
     if (typeof stored.horizontalPixels === "number") {
@@ -118,12 +125,11 @@ export function useResizablePanels() {
 
       const containerRect = container.getBoundingClientRect();
       const offsetX = moveEvent.clientX - containerRect.left;
-      const percentage = (offsetX / containerRect.width) * 100;
+      const rawPercentage = (offsetX / containerRect.width) * 100;
+      const percentage = clampVerticalPercentage(rawPercentage, containerRect.width);
 
-      if (percentage >= 30 && percentage <= 70) {
-        latestPercentage = percentage;
-        applyVertical(container, verticalDivider, percentage);
-      }
+      latestPercentage = percentage;
+      applyVertical(container, verticalDivider, percentage);
     };
 
     const handleMouseUp = () => {

--- a/app/components/coding-exercise/useResize.tsx
+++ b/app/components/coding-exercise/useResize.tsx
@@ -7,7 +7,7 @@ const STORAGE_KEY = "coding-exercise-panel-sizes";
 const LHS_MIN_PIXELS = 400;
 
 function clampVerticalPercentage(percentage: number, containerWidth: number) {
-  const minPercentage = Math.max(30, (LHS_MIN_PIXELS / containerWidth) * 100);
+  const minPercentage = Math.min(70, Math.max(30, (LHS_MIN_PIXELS / containerWidth) * 100));
   return Math.min(Math.max(percentage, minPercentage), 70);
 }
 


### PR DESCRIPTION
## Summary

- Move `container-type: inline-size` from `.contentBelowTabs` (the grid grandparent) to `.rightVideoContainer`, and cap the visual-test canvas at `100cqi`. Previously `50cqi` mis-sized the canvas once the LHS panel shrank past ~620px, because `leftColumnContent`'s `min-width: 310px` made the right column narrower than half the grid.
- Enforce a 400px LHS minimum inside the vertical resize math itself (both initial restore and live drag). Using a CSS `min-width` would have desynced the percentage-positioned divider from the actual panel edge.

## Test plan

- [ ] Drag the vertical divider all the way left — LHS stops at 400px and the divider stays glued to the panel edge.
- [ ] Narrow the browser window — the visual-test canvas shrinks proportionally with the right column, no overflow.
- [ ] Wide layouts still render correctly (square canvas, centered).
- [ ] Saved panel sizes from localStorage still restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)