### PR TITLE
Fix landing-page SVG arrow sizing after SVGR migration

### DIFF
--- a/app/components/landing-page/Hero.module.css
+++ b/app/components/landing-page/Hero.module.css
@@ -78,7 +78,7 @@
 
     .watch-arrow {
         width: 88px;
-        height: auto;
+        height: 100px;
         transform: translateX(-50%) rotate(180deg);
         margin-bottom: 8px;
         filter: brightness(0) invert(1);

--- a/app/components/landing-page/WelcomeSection.module.css
+++ b/app/components/landing-page/WelcomeSection.module.css
@@ -111,6 +111,7 @@
     }
 
     .bootcamp-arrow-1 {
+        width: 80px;
         height: 168px;
     }
 }


### PR DESCRIPTION
## Summary

After PR #629 converted the landing-page arrow icons from `<Image>` (raw `<img>`) to SVGR React components (`<svg>`), two CSS rules that relied on `<img>` aspect-ratio behaviour broke. SVGR runs SVGO with `removeDimensions: true`, stripping the source SVG's width/height; with one CSS dimension `auto` and only the viewBox left, browsers compute the missing dimension unreliably and the arrows blew up.

- `.watch-arrow` (Hero) was `width: 88px; height: auto;` → set to `88x100`
- `.bootcamp-arrow-1` (WelcomeSection) was `height: 168px;` (no width) → set to `80x168`

The other SVG conversions in the same PR are fine:
- `RocketIcon` usages get size from JSX `width`/`height` props with no CSS sizing override
- `BootcampSection` icons (Understanding/Confidence/CodersMind/Build/Calendar) also get size from JSX props; the old `ul li img { width: 20px; height: 20px }` and `.h3-sideheading img { height: 20px }` rules in `BootcampSection.module.css` no longer match anything (they target `img`) but don't cause visible breakage. Left them as a follow-up cleanup.

## Test plan
- [ ] Hero "Reading not your thing?" prompt — arrow renders 88x100 (was huge)
- [ ] WelcomeSection section break arrow — renders 80x168 (was huge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)