### PR TITLE
Add /roadmap to sitemap and link sitemap from footer

### DIFF
--- a/app/app/sitemap.ts
+++ b/app/app/sitemap.ts
@@ -4,7 +4,7 @@ import { getAllArticles } from "@/lib/content/getAllArticles";
 import { getAllBlogPosts } from "@/lib/content/getAllBlogPosts";
 import { SITE_URL } from "@/lib/site";
 
-const STATIC_ROUTES = ["", "/blog", "/articles", "/concepts", "/testimonials", "/premium"];
+const STATIC_ROUTES = ["", "/blog", "/articles", "/concepts", "/testimonials", "/premium", "/roadmap"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [...staticEntries(), ...blogEntries(), ...articleEntries(), ...conceptEntries()];

--- a/app/components/layout/ExternalFooter.tsx
+++ b/app/components/layout/ExternalFooter.tsx
@@ -58,6 +58,9 @@ export function ExternalFooter() {
             <Link href="/articles/report-abuse" className={styles.link}>
               Report abuse
             </Link>
+            <Link href="/sitemap.xml" className={styles.link}>
+              Sitemap
+            </Link>
           </div>
         </div>
         <div className={styles.section}>


### PR DESCRIPTION
## Summary
- Add `/roadmap` to `STATIC_ROUTES` in `app/sitemap.ts` (it was missing despite being linked from the footer).
- Add a Sitemap link under the footer's "Keep in Touch" section, pointing at `/sitemap.xml`.

## Test plan
- [ ] Footer renders new "Sitemap" link under Keep in Touch
- [ ] `/sitemap.xml` includes `/roadmap` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)