### PR TITLE
Allow Cloudflare Web Analytics beacon in CSP

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -11,12 +11,12 @@ function setCSP(response: NextResponse): void {
   // Allow unsafe-inline for Next.js inline scripts (required for RSC flight data)
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
+    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
     style-src 'self' 'unsafe-inline' https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self';
     media-src 'self' blob: https://*.mux.com;
-    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
+    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
     frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
     worker-src 'self' blob:;
     object-src 'none';


### PR DESCRIPTION
## Summary
- Adds `static.cloudflareinsights.com` to `script-src` (beacon script)
- Adds `cloudflareinsights.com` to `connect-src` (beacon POST endpoint)

Pairs with the Terraform change enabling Cloudflare Web Analytics on the jiki.io zone. `'unsafe-inline'` is already present in `script-src`, so the inline injection added by the Cloudflare proxy works without a nonce.

## Test plan
- [ ] Deploy and load any page on jiki.io
- [ ] DevTools → Console: no CSP violations
- [ ] DevTools → Network: `beacon.min.js` loads (200) and a POST to `cloudflareinsights.com/cdn-cgi/rum` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)