### PR TITLE
Install Cloudflare Web Analytics beacon manually

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/lib/theme";
 import "@/lib/whyDidYouRender";
 import type { Metadata } from "next";
 import { Poppins, Source_Code_Pro, Baloo_2 } from "next/font/google";
+import Script from "next/script";
 import { ServerAuthProvider } from "../components/layout/auth/global/ServerAuthProvider";
 import "./globals.css";
 
@@ -64,6 +65,12 @@ export default function RootLayout({
             <ToasterProvider />
           </ThemeProvider>
         </ServerAuthProvider>
+        <Script
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "116ada30355346edb0a7e818b80ed2ae"}'
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Adds the Cloudflare Web Analytics beacon `<Script>` to the root layout (`app/app/layout.tsx`)
- Loaded with `strategy="afterInteractive"` so it doesn't block hydration

Auto-injection via the Cloudflare proxy doesn't fire on Worker-served HTML (confirmed by curling jiki.io after enabling auto-install — no beacon present in the response). The site has now been switched to "Enable with JS Snippet installation" mode in the Cloudflare dashboard.

CSP already allows `static.cloudflareinsights.com` (script-src) and `cloudflareinsights.com` (connect-src) via #643.

## Test plan
- [ ] Deploy
- [ ] `curl -sL https://jiki.io | grep cloudflareinsights` returns the beacon script tag
- [ ] DevTools → Network: `beacon.min.js` loads (200), POST to `cloudflareinsights.com/cdn-cgi/rum` succeeds
- [ ] Cloudflare dashboard → Web Analytics: traffic starts arriving within ~15min

🤖 Generated with [Claude Code](https://claude.com/claude-code)