### PR TITLE
Allow PostHog endpoints in CSP

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -11,12 +11,12 @@ function setCSP(response: NextResponse): void {
   // Allow unsafe-inline for Next.js inline scripts (required for RSC flight data)
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
+    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com https://*.i.posthog.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
     style-src 'self' 'unsafe-inline' https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self';
     media-src 'self' blob: https://*.mux.com;
-    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
+    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com https://*.i.posthog.com ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
     frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
     worker-src 'self' blob:;
     object-src 'none';


### PR DESCRIPTION
## Summary

- Production CSP blocks all PostHog requests: `script-src` rejects loading the `array/phc_*` bundle from `eu-assets.i.posthog.com`, and `connect-src` rejects events/flags POSTs to `eu.i.posthog.com`.
- Adds `https://*.i.posthog.com` to both directives — covers `eu.i.posthog.com`, `eu-assets.i.posthog.com`, and any future region switch (`us.i.posthog.com`).

## Test plan

- [ ] After deploy, visit jiki.io signed-out, check DevTools console — no CSP violations for `*.posthog.com`.
- [ ] Confirm `array/phc_*` loads (200) from `eu-assets.i.posthog.com` and `$pageview` POST to `eu.i.posthog.com` succeeds.
- [ ] Confirm pageview appears in PostHog dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)