### PR TITLE
Route PostHog via t.jiki.io, switch to auto-pageview with auth opt-out

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -59,8 +59,8 @@ export default function RootLayout({
       <body className={`${poppins.variable} ${sourceCodePro.variable} ${baloo2.variable} antialiased ui-body`}>
         <GlobalErrorHandler />
         <AttributionCapture />
-        <PostHogPageview />
         <ServerAuthProvider>
+          <PostHogPageview />
           <ThemeProvider>
             <main className="w-full">{children}</main>
             <GlobalModalProvider />

--- a/app/components/PostHogPageview.tsx
+++ b/app/components/PostHogPageview.tsx
@@ -2,22 +2,19 @@
 
 import { useAuthStore } from "@/lib/auth/authStore";
 import { initPostHog, posthog } from "@/lib/posthog";
-import { usePathname } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 export default function PostHogPageview() {
-  const pathname = usePathname();
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  const lastPath = useRef<string | null>(null);
 
   useEffect(() => {
-    if (isAuthenticated) return;
-
+    if (isAuthenticated) {
+      posthog.opt_out_capturing();
+      return;
+    }
     initPostHog();
-    if (!pathname || pathname === lastPath.current) return;
-    lastPath.current = pathname;
-    posthog.capture("$pageview", { $pathname: pathname });
-  }, [pathname, isAuthenticated]);
+    posthog.opt_in_capturing();
+  }, [isAuthenticated]);
 
   return null;
 }

--- a/app/lib/posthog.ts
+++ b/app/lib/posthog.ts
@@ -14,7 +14,7 @@ export function initPostHog() {
     ui_host: "https://eu.posthog.com",
     cookieless_mode: "always",
     autocapture: false,
-    capture_pageview: false,
+    capture_pageview: true,
     capture_pageleave: false,
     disable_session_recording: true,
     disable_surveys: true,

--- a/app/lib/posthog.ts
+++ b/app/lib/posthog.ts
@@ -10,7 +10,8 @@ export function initPostHog() {
   if (!key) return;
 
   posthog.init(key, {
-    api_host: "https://eu.i.posthog.com",
+    api_host: "https://t.jiki.io",
+    ui_host: "https://eu.posthog.com",
     cookieless_mode: "always",
     autocapture: false,
     capture_pageview: false,

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -11,12 +11,12 @@ function setCSP(response: NextResponse): void {
   // Allow unsafe-inline for Next.js inline scripts (required for RSC flight data)
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com https://*.i.posthog.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
+    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
     style-src 'self' 'unsafe-inline' https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self';
     media-src 'self' blob: https://*.mux.com;
-    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com https://*.i.posthog.com ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
+    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
     frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
     worker-src 'self' blob:;
     object-src 'none';


### PR DESCRIPTION
## Summary

Three related PostHog config changes, bundled because they all touch \`posthog.init\` and \`PostHogPageview\`:

1. **Route through \`t.jiki.io\` reverse proxy.** \`api_host\` -> \`https://t.jiki.io\` (proxied to \`eu.i.posthog.com\` via Cloudflare). \`ui_host\` -> \`https://eu.posthog.com\` so toolbar/links resolve to the real PostHog UI. Per https://posthog.com/docs/advanced/proxy.
2. **Drop \`*.i.posthog.com\` from CSP.** All PostHog traffic now flows through \`*.jiki.io\`, which is already covered by the existing \`script-src\`/\`connect-src\` entries.
3. **Use posthog-js' built-in pageview capture with auth gating.** Replace the manual \`posthog.capture("\$pageview")\` with \`capture_pageview: true\`. \`PostHogPageview\` now just calls \`opt_in_capturing()\` / \`opt_out_capturing()\` based on \`isAuthenticated\`.

## Why auto-pageview + opt-out (instead of manual capture)

- The original PR's manual approach wasn't firing the landing pageview correctly. \`capture_pageview: true\` fires once on init (landing page) and once per Next.js SPA navigation (history change). No double-count, one source of truth.
- \`opt_out_capturing()\` covers mid-session signup: the moment auth flips true, capturing stops. For already-authenticated sessions the SDK never inits at all (the call to \`opt_out_capturing\` on the uninit stub is a queued no-op).

## Test plan

- [ ] Verify cookieless mode is enabled in PostHog project settings (otherwise all cookieless events drop silently — confirmed enabled before merge).
- [ ] Load jiki.io signed-out; network tab shows \`array/phc_*\` loads from \`t.jiki.io\` and a \`/e/\` POST fires for the landing pageview.
- [ ] Navigate to a second route; second \`/e/\` POST fires.
- [ ] Sign up; subsequent navigation produces no \`/e/\` posts.
- [ ] PostHog dashboard receives \`\$pageview\` events for anonymous sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)