### PR TITLE
Trim unused font weights from root layout

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -15,19 +15,19 @@ import "./globals.css";
 const poppins = Poppins({
   variable: "--font-poppins",
   subsets: ["latin"],
-  weight: ["200", "300", "400", "500", "600", "700", "800", "900"]
+  weight: ["300", "400", "500", "600", "700", "800"]
 });
 
 const sourceCodePro = Source_Code_Pro({
   variable: "--font-source-code-pro",
   subsets: ["latin"],
-  weight: ["400", "500", "600"]
+  weight: ["400", "600"]
 });
 
 const baloo2 = Baloo_2({
   variable: "--font-baloo-2",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700", "800"]
+  weight: ["800"]
 });
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary
- Trim `next/font` weight lists in `app/app/layout.tsx` to only the weights actually used in the codebase.
- Poppins: drop `200` and `900` — no `font-thin`/`font-extralight`/`font-black` Tailwind classes anywhere; no CSS literals at those weights.
- Source Code Pro: drop `500` — only `400` (default mono) and `600` (one use in `FunctionsView`) are referenced.
- Baloo 2: drop `400`/`500`/`600`/`700` — only weight `800` is used (price displays in `PremiumUpsell`, `SubscriptionCheckoutModal`, `PremiumUpgradeModal`).

Drops the number of woff2 files preloaded on every page from 16 to 9, freeing up bandwidth that's currently competing with the LCP image (the hero video poster on `/`).

## Test plan
- [ ] Anon load of `/` — Network panel shows fewer woff2 fetches, no broken weights in Hero / landing typography.
- [ ] Logged-in pages render normally: headings, body, code (font-mono), bold/semibold/extrabold variants.
- [ ] Open Premium upsell + checkout modals — `.amount` price displays still render in Baloo 2 weight 800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)