### PR TITLE
Show error widget when error frame is the first frame

### DIFF
--- a/app/components/coding-exercise/lib/orchestrator/store.ts
+++ b/app/components/coding-exercise/lib/orchestrator/store.ts
@@ -259,7 +259,7 @@ export function createOrchestratorStore(
           });
 
           const errorFrame = test.frames.find((frame) => frame.status === "ERROR");
-          const shouldAutoPlay = state.shouldPlayOnTestChange && !!test.animationTimeline;
+          const shouldAutoPlay = state.shouldPlayOnTestChange && (test.animationTimeline?.duration ?? 0) > 0;
 
           if (errorFrame && !shouldAutoPlay) {
             // Not auto-playing: jump directly to error (or breakpoint before it)

--- a/app/tests/unit/components/coding-exercise/orchestrator/store-animation-replay.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/store-animation-replay.test.ts
@@ -44,7 +44,8 @@ describe("Store Animation Replay Bug", () => {
       clearUpdateCallbacks: jest.fn(),
       clearCompleteCallbacks: jest.fn(),
       completed: false,
-      currentTime: 0
+      currentTime: 0,
+      duration: 100
     } as any
   });
 

--- a/app/tests/unit/components/coding-exercise/orchestrator/store-auto-play.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/store-auto-play.test.ts
@@ -70,7 +70,8 @@ describe("Store Auto-Play Behavior", () => {
       clearUpdateCallbacks: jest.fn(),
       clearCompleteCallbacks: jest.fn(),
       completed: false,
-      currentTime: 0
+      currentTime: 0,
+      duration: 200
     } as any
   });
 
@@ -123,7 +124,42 @@ describe("Store Auto-Play Behavior", () => {
       clearUpdateCallbacks: jest.fn(),
       clearCompleteCallbacks: jest.fn(),
       completed: false,
-      currentTime: time
+      currentTime: time,
+      duration: 100
+    } as any
+  });
+
+  const createMockErrorAtStartTest = (slug: string): TestResult => ({
+    type: "visual" as const,
+    slug,
+    name: slug,
+    status: "fail" as const,
+    expects: [],
+    view: document.createElement("div"),
+    frames: [
+      {
+        time: 0,
+        timeInMs: 0,
+        line: 1,
+        code: "not_a_function()",
+        status: "ERROR" as const,
+        generateDescription: () => "Error frame",
+        error: { message: "Function does not exist" }
+      }
+    ],
+    logLines: [],
+    lintErrors: [],
+    animationTimeline: {
+      play: jest.fn(),
+      pause: jest.fn(),
+      seek: jest.fn(),
+      onUpdate: jest.fn(),
+      onComplete: jest.fn(),
+      clearUpdateCallbacks: jest.fn(),
+      clearCompleteCallbacks: jest.fn(),
+      completed: false,
+      currentTime: 0,
+      duration: 0
     } as any
   });
 
@@ -338,6 +374,23 @@ describe("Store Auto-Play Behavior", () => {
       // Widget should now be visible with the error
       expect(store.getState().shouldShowInformationWidget).toBe(true);
       expect(store.getState().isPlaying).toBe(false);
+    });
+
+    it("should show information widget immediately when error is the first frame and timeline has nothing to play", () => {
+      // Regression: when an error occurs before any animations are produced (e.g. `not_a_function()`
+      // on the first line), the animation timeline has duration 0. Autoplay through onComplete would
+      // never fire, silently swallowing the error. Treat a zero-duration timeline as not autoplayable
+      // and jump straight to the error frame with the widget shown.
+      const exercise = createMockExercise({ slug: "test-uuid", stubs: { javascript: "", python: "", jikiscript: "" } });
+      const store = createOrchestratorStore(exercise, "jikiscript", { type: "lesson", slug: "test-lesson" });
+      const test = createMockErrorAtStartTest("test-1");
+      store.getState().setShouldPlayOnTestChange(true);
+
+      store.getState().setCurrentTest(test);
+
+      expect(store.getState().isPlaying).toBe(false);
+      expect(test.animationTimeline!.play).not.toHaveBeenCalled();
+      expect(store.getState().shouldShowInformationWidget).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- An error on the first line (e.g. `not_a_function()` before any rectangles are drawn) was silently swallowed by the UI: no error popup, no jump to the error frame.
- Cause: in `setCurrentTest` (store.ts:262), `shouldAutoPlay` was true whenever `animationTimeline` existed, so the explicit "errorFrame → show widget" branch was skipped. But the timeline had zero animations, so `play()` produced no `onComplete` and the widget toggle gated on that callback never fired.
- Fix: treat a zero-duration timeline as not autoplayable. `shouldAutoPlay` now also requires `(animationTimeline?.duration ?? 0) > 0`. With no animations, the existing error-frame branch handles it: jump to the error frame and show the widget.

## Test plan

- [x] New regression unit test in `store-auto-play.test.ts` covering error-as-first-frame with `duration: 0` — asserts widget shows, `play()` is not called.
- [x] Existing autoplay tests updated to include `duration` on their `animationTimeline` mocks; all 1676 unit tests pass.
- [x] `pnpm typecheck` clean.
- [ ] Manually verify in browser: paste `not_a_function()` as the first line of a visual exercise; confirm the error popup appears, same as when the error is at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)