### PR TITLE
Allow *.jiki.io in script-src for PostHog config bundle

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -11,7 +11,7 @@ function setCSP(response: NextResponse): void {
   // Allow unsafe-inline for Next.js inline scripts (required for RSC flight data)
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
+    script-src 'self' 'unsafe-inline' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
     style-src 'self' 'unsafe-inline' https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self';


### PR DESCRIPTION
## Summary

posthog-js loads \`array/phc_*/config.js\` from \`api_host\` (\`t.jiki.io\`) as an external \`<script>\` during \`init()\`, even when the SDK is bundled via npm. CSP \`script-src\` didn't permit \`*.jiki.io\`, so the bundle was blocked, init failed silently, and no pageviews fired.

\`connect-src\` already covers \`*.jiki.io\` (for event POSTs). This adds the matching \`script-src\` entry.

## Test plan

- [ ] After deploy, load jiki.io signed-out and confirm DevTools console has no CSP violation for \`t.jiki.io/array/phc_*/config.js\`.
- [ ] Confirm the file loads (200) and \`/e/\` event POSTs follow.
- [ ] PostHog dashboard receives live \`\$pageview\` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)