### PR TITLE
Rewrite relational-sun to match snowman/traffic-lights pattern

### DIFF
--- a/curriculum/src/exercises/relational-sun/index.ts
+++ b/curriculum/src/exercises/relational-sun/index.ts
@@ -22,19 +22,25 @@ const exerciseDefinition: VisualExerciseCore = {
   functions,
   readonlyRanges: {
     javascript: [
-      { fromLine: 1, toLine: 2 },
-      { fromLine: 3, toLine: 3, toChar: 10 },
-      { fromLine: 4, toLine: 4, toChar: 13 }
+      { fromLine: 1, toLine: 6 },
+      { fromLine: 7, toLine: 7, toChar: 10 },
+      { fromLine: 8, toLine: 8, toChar: 13 },
+      { fromLine: 9, toLine: 10 },
+      { fromLine: 12, toLine: 12 }
     ],
     python: [
-      { fromLine: 1, toLine: 2 },
-      { fromLine: 3, toLine: 3, toChar: 6 },
-      { fromLine: 4, toLine: 4, toChar: 9 }
+      { fromLine: 1, toLine: 6 },
+      { fromLine: 7, toLine: 7, toChar: 6 },
+      { fromLine: 8, toLine: 8, toChar: 9 },
+      { fromLine: 9, toLine: 10 },
+      { fromLine: 12, toLine: 12 }
     ],
     jikiscript: [
-      { fromLine: 1, toLine: 2 },
-      { fromLine: 3, toLine: 3, toChar: 11 },
-      { fromLine: 4, toLine: 4, toChar: 14 }
+      { fromLine: 1, toLine: 6 },
+      { fromLine: 7, toLine: 7, toChar: 11 },
+      { fromLine: 8, toLine: 8, toChar: 14 },
+      { fromLine: 9, toLine: 10 },
+      { fromLine: 12, toLine: 12 }
     ]
   }
 };

--- a/curriculum/src/exercises/relational-sun/index.ts
+++ b/curriculum/src/exercises/relational-sun/index.ts
@@ -19,7 +19,21 @@ const exerciseDefinition: VisualExerciseCore = {
   ExerciseClass,
   tasks,
   scenarios,
-  functions
+  functions,
+  readonlyRanges: {
+    javascript: [
+      { fromLine: 1, toLine: 1, toChar: 10 },
+      { fromLine: 2, toLine: 2, toChar: 13 }
+    ],
+    python: [
+      { fromLine: 1, toLine: 1, toChar: 6 },
+      { fromLine: 2, toLine: 2, toChar: 9 }
+    ],
+    jikiscript: [
+      { fromLine: 1, toLine: 1, toChar: 11 },
+      { fromLine: 2, toLine: 2, toChar: 14 }
+    ]
+  }
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/relational-sun/index.ts
+++ b/curriculum/src/exercises/relational-sun/index.ts
@@ -22,16 +22,19 @@ const exerciseDefinition: VisualExerciseCore = {
   functions,
   readonlyRanges: {
     javascript: [
-      { fromLine: 1, toLine: 1, toChar: 10 },
-      { fromLine: 2, toLine: 2, toChar: 13 }
+      { fromLine: 1, toLine: 2 },
+      { fromLine: 3, toLine: 3, toChar: 10 },
+      { fromLine: 4, toLine: 4, toChar: 13 }
     ],
     python: [
-      { fromLine: 1, toLine: 1, toChar: 6 },
-      { fromLine: 2, toLine: 2, toChar: 9 }
+      { fromLine: 1, toLine: 2 },
+      { fromLine: 3, toLine: 3, toChar: 6 },
+      { fromLine: 4, toLine: 4, toChar: 9 }
     ],
     jikiscript: [
-      { fromLine: 1, toLine: 1, toChar: 11 },
-      { fromLine: 2, toLine: 2, toChar: 14 }
+      { fromLine: 1, toLine: 2 },
+      { fromLine: 3, toLine: 3, toChar: 11 },
+      { fromLine: 4, toLine: 4, toChar: 14 }
     ]
   }
 };

--- a/curriculum/src/exercises/relational-sun/instructions/en.md
+++ b/curriculum/src/exercises/relational-sun/instructions/en.md
@@ -26,6 +26,8 @@ Draw a circle using `sunX`, `sunY`, `radius`, and `color`.
 
 ## Flexibility
 
-To pass the exercise, `sunX` and `sunY` can't be set to plain numbers — only calculations involving other variables.
+If your code is correct, you will see the circle appear in the correct place on the page. However, to pass the exercise you can't just "hard-code" the value (meaning set it to a single number), `sunX` and `sunY` must be calculations involving other variables.
 
-If you connect everything up correctly, you can change the values for `gap` and `radius` at the top of the file, and rerun your code to see the sun grow or shift while staying in the corner.
+Once you've passed the exercise, click "Tidy my code" and try changing the values for `gap` and `radius` at the top of the file, and rerun your code to see the sun grow or shift while staying in the corner.
+
+When you're done, you can hit "Dashboard" at the top right to continue on as normal.

--- a/curriculum/src/exercises/relational-sun/instructions/en.md
+++ b/curriculum/src/exercises/relational-sun/instructions/en.md
@@ -3,31 +3,34 @@ title: "Relational Sun"
 description: "Position a sun where everything's calculated from variables."
 ---
 
-In this exercise, your task is to position a sun in the top-right corner of the sky using arithmetic and variables. The key constraint is that the edge of the sun should always be a fixed **gap** away from the edge.
+In this exercise, your task is to position a sun in the top-right corner of the sky using arithmetic and variables. The key constraint is that the edge of the sun should always be a fixed **gap** away from the edge of the canvas, no matter what size the sun is.
+
+We've preset two variables for you at the top of the file:
+
+- `gap`: how far the sun's edge sits from the top and right edges of the canvas.
+- `radius`: the sun's radius.
+
+You can change these values to experiment — the sun should stay tucked into the top-right corner no matter what you pick.
 
 ### A Three-step Process
 
 This exercise has three steps.
 
-#### 1. Define your fact variables
+#### 1. Define your other fact variables
 
 Define variables for:
 
-- `canvasSize`: The size of the canvas (which is `100`)
-- `gap`: How far from the top-right edge the sun's edge should be.
-- `radius`: The sun's radius.
-- `color`: Set it to `"yellow"`.
-
-You can work out the gap and radius by hovering over the area and measuring. They're both divisible by 5. If you can't work it out, check the hints.
+- `canvasSize`: the size of the canvas, which is `100`.
+- `color`: set it to `"yellow"`.
 
 #### 2. Define calculated variables
 
-Define `sunX` and `sunY` variables that use the gap and radius and the size of the canvas to set the central point of the sun to the top right of the image.
+Define `sunX` and `sunY` variables that use `gap`, `radius`, and `canvasSize` to set the centre of the sun in the top-right corner.
 
-To pass the exercise, `sunX` and `sunY` can't be set to any numbers - only calculations involving other variables.
+To pass the exercise, `sunX` and `sunY` can't be set to plain numbers — only calculations involving other variables.
 
 #### 3. Draw the circle
 
-Draw a circle using `sunX`, `sunY`, `radius` and `color`.
+Draw a circle using `sunX`, `sunY`, `radius`, and `color`.
 
-If you connect everything up correctly, you should be able to change radius and gap and rerun your code to see the sun get larger in the sky!
+If you connect everything up correctly, you can change `gap` and `radius` at the top of the file and rerun your code to see the sun grow or shift while staying in the corner.

--- a/curriculum/src/exercises/relational-sun/instructions/en.md
+++ b/curriculum/src/exercises/relational-sun/instructions/en.md
@@ -5,32 +5,27 @@ description: "Position a sun where everything's calculated from variables."
 
 In this exercise, your task is to position a sun in the top-right corner of the sky using arithmetic and variables. The key constraint is that the edge of the sun should always be a fixed **gap** away from the edge of the canvas, no matter what size the sun is.
 
-We've preset two variables for you at the top of the file:
-
-- `gap`: how far the sun's edge sits from the top and right edges of the canvas.
-- `radius`: the sun's radius.
-
-You can change these values to experiment — the sun should stay tucked into the top-right corner no matter what you pick.
-
-### A Three-step Process
-
-This exercise has three steps.
-
-#### 1. Define your other fact variables
-
-Define variables for:
+We've preset four variables for you at the top of the file:
 
 - `canvasSize`: the size of the canvas, which is `100`.
 - `color`: set it to `"yellow"`.
+- `gap`: how far the sun's edge sits from the top and right edges of the canvas.
+- `radius`: the sun's radius.
 
-#### 2. Define calculated variables
+### A two-step Process
+
+To solve this exercise, do two things
+
+#### 1. Define derived variables
 
 Define `sunX` and `sunY` variables that use `gap`, `radius`, and `canvasSize` to set the centre of the sun in the top-right corner.
 
-To pass the exercise, `sunX` and `sunY` can't be set to plain numbers — only calculations involving other variables.
-
-#### 3. Draw the circle
+#### 2. Draw the circle
 
 Draw a circle using `sunX`, `sunY`, `radius`, and `color`.
 
-If you connect everything up correctly, you can change `gap` and `radius` at the top of the file and rerun your code to see the sun grow or shift while staying in the corner.
+## Flexibility
+
+To pass the exercise, `sunX` and `sunY` can't be set to plain numbers — only calculations involving other variables.
+
+If you connect everything up correctly, you can change the values for `gap` and `radius` at the top of the file, and rerun your code to see the sun grow or shift while staying in the corner.

--- a/curriculum/src/exercises/relational-sun/metadata.json
+++ b/curriculum/src/exercises/relational-sun/metadata.json
@@ -3,20 +3,20 @@
   "levelId": "variables",
   "hints": [
     {
-      "question": "How do I work out the sun's x position?",
-      "answer": "Start from the right edge of the canvas and step inward by the gap and the radius: `sunX = canvasSize - gap - radius`."
+      "question": "How should I think about the sun's x position?",
+      "answer": "Picture the right edge of the canvas. The edge of the sun sits `gap` to the left of that edge. The *centre* of the sun is one more radius further in than that."
     },
     {
-      "question": "How do I work out the sun's y position?",
-      "answer": "Start from the top edge and step down by the gap and the radius: `sunY = gap + radius`."
+      "question": "How should I think about the sun's y position?",
+      "answer": "It's the same idea as the x position, but measured down from the top edge of the canvas instead of in from the right edge."
     },
     {
-      "question": "How do I draw the sky?",
-      "answer": "Draw a rectangle that covers the whole canvas, e.g. `rectangle(0, 0, canvasSize, canvasSize, skyColor)`."
+      "question": "How big is the canvas?",
+      "answer": "The canvas is `100` wide and `100` tall. The top-left corner is `0,0` and the bottom-right corner is `100,100`."
     },
     {
-      "question": "What order should I draw things in?",
-      "answer": "Draw the sky first, then the sun on top. Later drawings cover earlier ones, so the sun needs to come last."
+      "question": "Why can't I just write the numbers directly?",
+      "answer": "If you hardcode `sunX` and `sunY`, the sun will stay in one place when `gap` or `radius` change. Building them from `gap` and `radius` keeps the sun in the corner no matter what values you choose."
     }
   ]
 }

--- a/curriculum/src/exercises/relational-sun/metadata.json
+++ b/curriculum/src/exercises/relational-sun/metadata.json
@@ -11,10 +11,6 @@
       "answer": "It's the same idea as the x position, but measured down from the top edge of the canvas instead of in from the right edge."
     },
     {
-      "question": "How big is the canvas?",
-      "answer": "The canvas is `100` wide and `100` tall. The top-left corner is `0,0` and the bottom-right corner is `100,100`."
-    },
-    {
       "question": "Why can't I just write the numbers directly?",
       "answer": "If you hardcode `sunX` and `sunY`, the sun will stay in one place when `gap` or `radius` change. Building them from `gap` and `radius` keeps the sun in the corner no matter what values you choose."
     }

--- a/curriculum/src/exercises/relational-sun/scenarios.ts
+++ b/curriculum/src/exercises/relational-sun/scenarios.ts
@@ -5,7 +5,7 @@ export const tasks = [
   {
     id: "position-sun" as const,
     name: "Position the sun",
-    description: "Derive `sunX` and `sunY` from `gap` and `radius` so the sun scales correctly.",
+    description: "Derive `sunX` and `sunY` from `canvasSize`, `gap`, and `radius` so the sun scales correctly.",
     hints: [],
     requiredScenarios: ["position-sun"],
     bonus: false

--- a/curriculum/src/exercises/relational-sun/scenarios.ts
+++ b/curriculum/src/exercises/relational-sun/scenarios.ts
@@ -1,25 +1,66 @@
-import type { Task, VisualScenario } from "../types";
+import type { IsolatedCheck, Task, VisualScenario } from "../types";
 import type { RelationalSunExercise } from "./Exercise";
 
 export const tasks = [
   {
     id: "position-sun" as const,
     name: "Position the sun",
-    description: "Derive sunX and sunY using arithmetic, then draw the sky and sun using the variables.",
-    hints: [
-      { question: "I can't work out the radius of the sun", answer: "It's 15." },
-      { question: "I can't work out the gap", answer: "It's 10." }
-    ],
+    description: "Derive `sunX` and `sunY` from `gap` and `radius` so the sun scales correctly.",
+    hints: [],
     requiredScenarios: ["position-sun"],
     bonus: false
   }
 ] as const satisfies readonly Task[];
 
+function expectedAt(gap: number, radius: number, canvasSize = 100) {
+  return {
+    sun: [canvasSize - gap - radius, gap + radius, radius] as const
+  };
+}
+
+// Per-shape feedback at the stub's default gap/radius values.
+function detailedCheck(gap: number, radius: number): IsolatedCheck {
+  const e = expectedAt(gap, radius);
+  return {
+    secretConstants: { gap, radius },
+    expectations(exercise) {
+      const ex = exercise as RelationalSunExercise;
+      return [
+        {
+          pass: ex.hasCircleAt(...e.sun),
+          errorHtml:
+            "The sun is either in the wrong place or the wrong size. Check your `sunX` and `sunY` calculations, and make sure you're passing `radius` to `circle`."
+        }
+      ];
+    }
+  };
+}
+
+// Responsiveness check (gap/radius != stub defaults).
+function responsivenessCheck(gap: number, radius: number): IsolatedCheck {
+  const e = expectedAt(gap, radius);
+  return {
+    secretConstants: { gap, radius },
+    expectations(exercise) {
+      const ex = exercise as RelationalSunExercise;
+      const pass = ex.hasCircleAt(...e.sun);
+      return [
+        {
+          pass,
+          errorHtml: pass
+            ? undefined
+            : `Your code doesn't scale correctly when \`gap\` is ${gap} and \`radius\` is ${radius}. \`sunX\` and \`sunY\` should be derived from \`gap\` and \`radius\`, not hardcoded numbers.`
+        }
+      ];
+    }
+  };
+}
+
 export const scenarios: VisualScenario[] = [
   {
     slug: "position-sun",
     name: "Position the sun",
-    description: "Derive the sun position and draw the scene using variables.",
+    description: "Derive the sun's position from `gap` and `radius` so it scales.",
     taskId: "position-sun",
 
     setup(exercise) {
@@ -27,23 +68,12 @@ export const scenarios: VisualScenario[] = [
       ex.setupBackground("/static/images/exercise-assets/relational-sun/background.webp");
     },
 
-    expectations(exercise) {
-      const ex = exercise as RelationalSunExercise;
-
-      return [
-        {
-          pass: ex.hasCircleAt(75, 25, 15),
-          errorHtml:
-            "The sun is not positioned correctly. sunX should be canvasSize - gap - sunRadius, sunY should be gap + sunRadius."
-        }
-      ];
+    // No primary expectations — the canvas reflects the student's own gap/radius
+    // values. Correctness is owned by the isolated checks below.
+    expectations() {
+      return [];
     },
 
-    codeChecks: [
-      {
-        pass: (result) => result.assertors.assertNoLiteralNumbersInAssignments({ include: ["sun_x", "sun_y"] }),
-        errorHtml: "Variables like sunX and sunY should be calculated from other variables, not set to plain numbers."
-      }
-    ]
+    isolatedChecks: [detailedCheck(10, 15), responsivenessCheck(5, 10), responsivenessCheck(15, 20)]
   }
 ];

--- a/curriculum/src/exercises/relational-sun/stub.javascript
+++ b/curriculum/src/exercises/relational-sun/stub.javascript
@@ -1,5 +1,12 @@
+// These variables are fixed
 let canvasSize = 100
 let color = "yellow"
+
+// You can change the values of these variables
+// to see whether your code responds correctly.
 let gap = 10
 let radius = 15
 
+// Define the sunX and sunY variables
+
+// Draw the sun

--- a/curriculum/src/exercises/relational-sun/stub.javascript
+++ b/curriculum/src/exercises/relational-sun/stub.javascript
@@ -1,1 +1,3 @@
-// Draw the sun
+let gap = 10
+let radius = 15
+

--- a/curriculum/src/exercises/relational-sun/stub.javascript
+++ b/curriculum/src/exercises/relational-sun/stub.javascript
@@ -1,3 +1,5 @@
+let canvasSize = 100
+let color = "yellow"
 let gap = 10
 let radius = 15
 

--- a/curriculum/src/exercises/relational-sun/stub.jiki
+++ b/curriculum/src/exercises/relational-sun/stub.jiki
@@ -1,3 +1,5 @@
+set canvas_size to 100
+set color to "yellow"
 set gap to 10
 set radius to 15
 

--- a/curriculum/src/exercises/relational-sun/stub.jiki
+++ b/curriculum/src/exercises/relational-sun/stub.jiki
@@ -1,5 +1,12 @@
+// These variables are fixed
 set canvas_size to 100
 set color to "yellow"
+
+// You can change the values of these variables
+// to see whether your code responds correctly.
 set gap to 10
 set radius to 15
 
+// Define the sun_x and sun_y variables
+
+// Draw the sun

--- a/curriculum/src/exercises/relational-sun/stub.jiki
+++ b/curriculum/src/exercises/relational-sun/stub.jiki
@@ -1,1 +1,3 @@
-// Draw the sun
+set gap to 10
+set radius to 15
+

--- a/curriculum/src/exercises/relational-sun/stub.py
+++ b/curriculum/src/exercises/relational-sun/stub.py
@@ -1,1 +1,3 @@
-# Draw the sun
+gap = 10
+radius = 15
+

--- a/curriculum/src/exercises/relational-sun/stub.py
+++ b/curriculum/src/exercises/relational-sun/stub.py
@@ -1,3 +1,5 @@
+canvas_size = 100
+color = "yellow"
 gap = 10
 radius = 15
 

--- a/curriculum/src/exercises/relational-sun/stub.py
+++ b/curriculum/src/exercises/relational-sun/stub.py
@@ -1,5 +1,12 @@
+# These variables are fixed
 canvas_size = 100
 color = "yellow"
+
+# You can change the values of these variables
+# to see whether your code responds correctly.
 gap = 10
 radius = 15
 
+# Define the sun_x and sun_y variables
+
+# Draw the sun


### PR DESCRIPTION
## Summary

Brings `relational-sun` in line with the pattern established for `relational-snowman` and `relational-traffic-lights` in #632:

- Drops the pinned `hasCircleAt(75, 25, 15)` primary expectation and the errorHtml that leaked the full formulas (`sunX should be canvasSize - gap - sunRadius`, etc).
- Adds `isolatedChecks` with `secretConstants` at three gap/radius pairs — a detailed check at the stub default `(10, 15)` and responsiveness checks at `(5, 10)` and `(15, 20)` so hardcoded numbers are caught.
- Trims the stubs (JS/Python/Jiki) to just `gap = 10` / `radius = 15`. Adds `readonlyRanges` locking the `gap =` / `radius =` prefixes so the names stay fixed but students can change the values to experiment.
- Rewrites hints in `metadata.json` and the in-task hints in Q&A reasoning style — no formulas, no numeric answers ("It's 15." / "It's 10." → reasoning about where the centre sits relative to the edge).
- Rewrites `instructions/en.md` with a preface explaining gap/radius are preset and editable, restructures step 1 to cover only `canvasSize`/`color`, drops the "divisible by 5" giveaway and the sky/rectangle references that didn't match the available functions.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] Manually run the exercise in the app: confirm gap/radius value chars are editable but the names are locked, the canvas reflects student-chosen gap/radius, and changing either re-positions the sun correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)