### PR TITLE
Add per-shape draw delay for wall exercises

### DIFF
--- a/curriculum/src/exercise-categories/draw/DrawExercise.ts
+++ b/curriculum/src/exercise-categories/draw/DrawExercise.ts
@@ -47,6 +47,11 @@ export abstract class DrawExercise extends VisualExercise {
   protected strokeColor: string = "#333333";
   protected strokeWidth = 0;
   protected fixedColor: string | null = null;
+  protected drawDelayMs = 0;
+
+  public setDrawDelayMs(ms: number) {
+    this.drawDelayMs = ms;
+  }
 
   constructor() {
     super();
@@ -387,6 +392,9 @@ export abstract class DrawExercise extends VisualExercise {
 
   protected animateShapeIntoView(executionCtx: ExecutionContext, elem: SVGElement) {
     this.animateIntoView(executionCtx, `#${this.view.id} #${elem.id}`);
+    if (this.drawDelayMs > 0) {
+      executionCtx.fastForward(this.drawDelayMs);
+    }
   }
   protected animateShapeOutOfView(executionCtx: ExecutionContext, elem: SVGElement) {
     this.animateOutOfView(executionCtx, `#${this.view.id} #${elem.id}`);

--- a/curriculum/src/exercises/build-wall/scenarios.ts
+++ b/curriculum/src/exercises/build-wall/scenarios.ts
@@ -22,6 +22,7 @@ export const scenarios: VisualScenario[] = [
     setup(exercise) {
       const ex = exercise as BuildWallExercise;
       ex.setupStroke(0.4, "#7f3732");
+      ex.setDrawDelayMs(20);
     },
 
     expectations(exercise) {

--- a/curriculum/src/exercises/finish-wall/scenarios.ts
+++ b/curriculum/src/exercises/finish-wall/scenarios.ts
@@ -23,6 +23,7 @@ export const scenarios: VisualScenario[] = [
       const ex = exercise as FinishWallExercise;
       ex.setupBackground("/static/images/exercise-assets/finish-wall/topless-wall.webp");
       ex.setupStroke(0.4, "#7f3732");
+      ex.setDrawDelayMs(150);
     },
 
     expectations(exercise) {

--- a/curriculum/src/exercises/fix-wall/scenarios.ts
+++ b/curriculum/src/exercises/fix-wall/scenarios.ts
@@ -23,6 +23,7 @@ export const scenarios: VisualScenario[] = [
       const ex = exercise as FixWallExercise;
       ex.setupBackground("/static/images/exercise-assets/fix-wall/wall-to-fix.webp");
       ex.setupStroke(0.4, "#7f3732");
+      ex.setDrawDelayMs(200);
     },
 
     expectations(exercise) {


### PR DESCRIPTION
## Summary
- New `DrawExercise.setDrawDelayMs(ms)` lets scenarios pace shape rendering by fast-forwarding the timeline after each shape's fade-in.
- Wall scenarios opt in: fix-wall 200ms, finish-wall 150ms, build-wall 20ms (scaled to its 55 bricks).
- Default `drawDelayMs = 0` keeps every other draw exercise (sun, snowman, traffic-lights, etc.) unchanged.

## Test plan
- [ ] Run fix-wall in the app — bricks lay with a ~200ms pause between each
- [ ] Run finish-wall — 5 bricks at 150ms each feels deliberate, not slow
- [ ] Run build-wall — 55 bricks at 20ms still flows, no longer instant
- [ ] Sanity-check an unrelated draw exercise (e.g. snowman) hasn't changed pacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)