### PR TITLE
Wrap ZWJ compound emojis in .ui-emoji to bypass Poppins

### DIFF
--- a/app/app/styles/components/ui-components.css
+++ b/app/app/styles/components/ui-components.css
@@ -172,3 +172,19 @@
 .ui-link:hover {
     text-decoration: underline;
 }
+
+/* ========================================
+   EMOJI
+   ======================================== */
+
+/* Wraps emoji characters in a font-family chain that excludes Poppins.
+   Compound emojis like 🧑‍🔬 contain ZWJ (U+200D), which sits in Poppins's
+   Devanagari unicode-range subset. When Poppins is in the cascade for an
+   element containing a compound emoji, Chrome speculatively fetches the
+   Poppins Devanagari woff2 (~40KB per weight) on the critical path to
+   try to render the ZWJ — even though the emoji glyph ultimately comes
+   from the system emoji font. Removing Poppins from the cascade for the
+   emoji span avoids the fetch entirely. */
+.ui-emoji {
+    font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", sans-serif;
+}

--- a/app/app/styles/theme/typography.css
+++ b/app/app/styles/theme/typography.css
@@ -3,26 +3,12 @@
  * Font families, sizes, and line heights
  */
 
-/* Routes ZWJ (U+200D), ZWNJ (U+200C) and emoji variation selectors to the
-   system emoji font. Without this the browser sees ZWJ inside compound
-   emoji (e.g. 🧑‍🔬), tries to resolve it via Poppins, matches Poppins's
-   Devanagari subset (which also covers U+200C-200D) and downloads ~80KB
-   of woff2 on the critical path. unicode-range is restricted to the
-   joiners and selectors only — broader emoji ranges would risk
-   overriding Poppins glyphs the design relies on (✓ ★ ❄ etc.). */
-@font-face {
-    font-family: "EmojiFallback";
-    src: local("Apple Color Emoji"), local("Segoe UI Emoji"), local("Segoe UI Symbol"), local("Noto Color Emoji");
-    unicode-range: U+200C-200D, U+FE0E-FE0F;
-    font-display: swap;
-}
-
 @theme inline {
     /* Font family configuration */
     --font-sans:
-        "EmojiFallback", var(--font-poppins), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-        Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-        "Segoe UI Symbol", "Noto Color Emoji";
+        var(--font-poppins), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+        "Noto Color Emoji";
     --font-poppins: var(--font-poppins);
     --font-mono:
         var(--font-source-code-pro), ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",

--- a/app/app/styles/utilities/body.css
+++ b/app/app/styles/utilities/body.css
@@ -17,7 +17,6 @@ body {
     background: var(--background);
     color: var(--foreground);
     font-family:
-        "EmojiFallback",
         var(--font-poppins),
         -apple-system,
         BlinkMacSystemFont,

--- a/app/components/landing-page/BootcampSection.tsx
+++ b/app/components/landing-page/BootcampSection.tsx
@@ -41,7 +41,7 @@ export function BootcampSection() {
               <div className="flex flex-row">
                 <div className={styles.lhs}>
                   <h3 className="mb-8">
-                    1. Coding Fundamentals 🧑‍🔬
+                    1. Coding Fundamentals <span className="ui-emoji">🧑‍🔬</span>
                     <div className={styles.bubble}>Absolute Beginners</div>
                   </h3>
                   <div className={`${styles["part-intro"]} mb-20`}>

--- a/app/components/landing-page/Exercism.tsx
+++ b/app/components/landing-page/Exercism.tsx
@@ -12,7 +12,9 @@ export function Exercism() {
         </p>
         <ul>
           <li>
-            <div className={styles.emoji}>🧑‍💻</div>
+            <div className={styles.emoji}>
+              <span className="ui-emoji">🧑‍💻</span>
+            </div>
             <div className={styles.count}>2,500,000</div>
             <div className={styles.title}>Exercism students</div>
             <p>We&apos;ve grown entirely by word of mouth. Good friends tell their friends about Exercism!</p>


### PR DESCRIPTION
## Summary

Follow-up to #658. That PR added an `EmojiFallback` `@font-face` with `local()` system emoji fonts and ZWJ in `unicode-range`, on the theory that Chrome would route `U+200D` to the local emoji font and skip Poppins's Devanagari subset. In practice it didn't work — on macOS Chrome and PSI's lab Chrome, the Poppins Devanagari woff2s are still in the critical chain.

**Why**: `unicode-range` only controls which `@font-face` Chrome *consults first*. It tries to actually render the codepoint with that font, and falls through to the next family if the loaded font's cmap has no glyph. Apple Color Emoji (and Noto/Segoe emoji) expose compound emojis as full glyph clusters but don't expose standalone ZWJ in their cmaps. So Chrome falls through `EmojiFallback` → Poppins → fetches Devanagari subset.

**Fix**: remove Poppins from the cascade for the two specific elements that contain compound emoji.

- Adds `.ui-emoji { font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", sans-serif; }` to `ui-components.css` — the ui-kit utility layer.
- Wraps `🧑‍🔬` in `BootcampSection` and `🧑‍💻` in `Exercism` with `<span class="ui-emoji">`.

With Poppins out of the cascade for those spans, the browser resolves the whole compound emoji via the system emoji font (which has the glyph cluster) and never consults Poppins, so the Devanagari woff2 is never fetched.

## Test plan

- [ ] Anon load of `/` — Network panel: no `034d78ad42e9620c-s.woff2` (Poppins 400 Devanagari) or `29e7bbdce9332268-s.woff2` (Poppins 600 Devanagari) requests.
- [ ] Both compound emojis render unchanged (single glyph, not two-pieces).
- [ ] PSI's "Avoid chaining critical requests" diagnostic drops the two woff2 entries.

## Future-proofing

This only covers the two known emojis. To prevent regression, future copy with compound emoji should use the same `<span class="ui-emoji">` wrapper. Worth considering a small `<Emoji>` component if more emoji land in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)