### PR TITLE
Split modal manifest into core + (app); enable verbatimModuleSyntax

### DIFF
--- a/app/.context/modals.md
+++ b/app/.context/modals.md
@@ -12,16 +12,30 @@ Jiki uses a global modal system built with `react-modal` and Zustand state manag
 - **`lib/modal/GlobalModalProvider.tsx`** - Provider component that renders the active modal
 - **`lib/modal/BaseModal.tsx`** - Base modal wrapper handling overlay, close button, and accessibility
 - **`lib/modal/modals/`** - Directory containing all modal component implementations
+- **`lib/modal/modals/registry.ts`** - Runtime registry that `GlobalModalProvider` reads via `getModal(name)`
+- **`lib/modal/AppModalRegistrar.tsx`** - Client component that registers `(app)`-only modals on mount (rendered by `(app)/layout.tsx`)
 
 ### Modal Registry
 
-All modals must be registered in `lib/modal/modals/index.ts`:
+Modals are registered in two manifests, split by where they're used so the JS chunks for `(app)`-only modals don't ship to non-`(app)` routes (blog, articles, landing, premium marketing):
+
+- **`lib/modal/modals/core.ts`** — modals available on every route (confirmation, info, auth/connection/session errors, rate-limit, example). Seeded into the runtime registry at module load.
+- **`lib/modal/modals/app.ts`** — `(app)`-only modals (exercise, premium, subscription, payment, settings, badge, welcome, walkthrough). Registered when `AppModalRegistrar` mounts inside `(app)/layout.tsx`.
 
 ```typescript
-export const availableModals = {
+// lib/modal/modals/core.ts
+export const coreModals = {
   "example-modal": ExampleModal,
   "confirmation-modal": ConfirmationModal,
   "info-modal": InfoModal
+  // …
+};
+
+// lib/modal/modals/app.ts
+export const appModals = {
+  "premium-upgrade-modal": PremiumUpgradeModal,
+  "exercise-completion-modal": ExerciseCompletionModal
+  // …
 };
 ```
 
@@ -86,8 +100,8 @@ showModal("exercise-success-modal", {
 ## Adding New Modals
 
 1. Create component in `lib/modal/modals/YourModal.tsx`
-2. Register in `lib/modal/modals/index.ts`
-3. Optionally add convenience function in `lib/modal/store.ts`
+2. Register the dynamic import in either `lib/modal/modals/core.ts` (if the modal should be available on every route) or `lib/modal/modals/app.ts` (if it should only ship to `(app)` routes)
+3. Optionally add a convenience function: in `lib/modal/store.ts` for core modals, or in `lib/modal/app.ts` for `(app)`-only modals
 
 ## Implementation Details
 

--- a/app/app/(app)/layout.tsx
+++ b/app/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { ClientAuthGuard } from "../../components/layout/auth/internal/ClientAuthGuard";
 import { CheckoutReturnHandler } from "@/components/checkout/CheckoutReturnHandler";
 import { WelcomeModalHandler } from "@/components/WelcomeModalHandler";
+import { AppModalRegistrar } from "@/lib/modal/AppModalRegistrar";
 
 /**
  * Internal App Layout with Client-Side Authentication
@@ -32,6 +33,7 @@ export default function AppLayout({
 }>) {
   return (
     <ClientAuthGuard>
+      <AppModalRegistrar />
       {children}
       <CheckoutReturnHandler />
       <WelcomeModalHandler />

--- a/app/lib/modal/AppModalRegistrar.tsx
+++ b/app/lib/modal/AppModalRegistrar.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { appModals } from "./modals/app";
+import { registerModals } from "./modals/registry";
+
+// Side-effect: register (app) modals when this client-component module
+// loads. Hoisted to module scope (not useEffect) so the registry is
+// populated before GlobalModalProvider tries to read it, even on the
+// first render after hydration.
+registerModals(appModals);
+
+export function AppModalRegistrar(): null {
+  return null;
+}

--- a/app/lib/modal/GlobalModalProvider.tsx
+++ b/app/lib/modal/GlobalModalProvider.tsx
@@ -38,7 +38,6 @@ export function GlobalModalProvider() {
   const ModalComponent = getModal(modalName);
 
   // Handle unknown modal names
-   
   if (!ModalComponent) {
     console.warn(`Unknown modal name: ${modalName}`);
     return null;

--- a/app/lib/modal/GlobalModalProvider.tsx
+++ b/app/lib/modal/GlobalModalProvider.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { BaseModal } from "./BaseModal";
-import { availableModals } from "./modals";
+import { getModal } from "./modals/registry";
 import { hideModal, useModalStore } from "./store";
 import CrossIcon from "@/icons/cross.svg";
 import styles from "./GlobalModalProvider.module.css";
@@ -32,11 +32,13 @@ export function GlobalModalProvider() {
     return null;
   }
 
-  // Get the current modal component
-  const ModalComponent = availableModals[modalName as keyof typeof availableModals];
+  // Get the current modal component from the registry. Core modals are
+  // available everywhere; (app)-only modals are registered by
+  // AppModalRegistrar when an (app) route mounts.
+  const ModalComponent = getModal(modalName);
 
   // Handle unknown modal names
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+   
   if (!ModalComponent) {
     console.warn(`Unknown modal name: ${modalName}`);
     return null;

--- a/app/lib/modal/index.ts
+++ b/app/lib/modal/index.ts
@@ -19,6 +19,3 @@ export {
   showWelcomeModal,
   useModalStore
 } from "./store";
-
-// Export modal types if needed
-export type { availableModals } from "./modals";

--- a/app/lib/modal/modals/app.ts
+++ b/app/lib/modal/modals/app.ts
@@ -1,17 +1,16 @@
 import dynamic from "next/dynamic";
 
-const ConfirmationModal = dynamic(() => import("./ConfirmationModal").then((m) => m.ConfirmationModal));
-const ConnectionErrorModal = dynamic(() => import("./ConnectionErrorModal").then((m) => m.ConnectionErrorModal));
-const AuthErrorModal = dynamic(() => import("./AuthErrorModal").then((m) => m.AuthErrorModal));
-const ExampleModal = dynamic(() => import("./ExampleModal").then((m) => m.ExampleModal));
+// (app)-only modals: triggered exclusively from authenticated routes
+// (exercise flows, premium upgrade, subscription/payment, settings,
+// badges, welcome). Registered by (app)/layout.tsx via AppModalRegistrar
+// so the corresponding JS chunks aren't shipped to /blog, /articles,
+// /, /premium etc.
+
 const ExerciseSuccessModal = dynamic(() => import("./ExerciseSuccessModal").then((m) => m.ExerciseSuccessModal));
 const ExerciseCompletionModal = dynamic(() =>
   import("./ExerciseCompletionModal").then((m) => m.ExerciseCompletionModal)
 );
 const LevelMilestoneModal = dynamic(() => import("./LevelMilestoneModal").then((m) => m.LevelMilestoneModal));
-const InfoModal = dynamic(() => import("./InfoModal").then((m) => m.InfoModal));
-const SessionExpiredModal = dynamic(() => import("./SessionExpiredModal").then((m) => m.SessionExpiredModal));
-const RateLimitModal = dynamic(() => import("./RateLimitModal").then((m) => m.RateLimitModal));
 const SubscriptionModal = dynamic(() => import("./SubscriptionModal").then((m) => m.SubscriptionModal));
 const SubscriptionSuccessModal = dynamic(() =>
   import("./SubscriptionSuccessModal").then((m) => m.SubscriptionSuccessModal)
@@ -51,18 +50,10 @@ const WalkthroughConfirmModal = dynamic(() =>
 );
 const WelcomeModal = dynamic(() => import("./WelcomeModal").then((m) => m.WelcomeModal));
 
-// Available modals registry
-export const availableModals = {
-  "example-modal": ExampleModal,
-  "confirmation-modal": ConfirmationModal,
-  "connection-error-modal": ConnectionErrorModal,
-  "auth-error-modal": AuthErrorModal,
-  "info-modal": InfoModal,
+export const appModals = {
   "exercise-success-modal": ExerciseSuccessModal,
   "exercise-completion-modal": ExerciseCompletionModal,
   "level-milestone-modal": LevelMilestoneModal,
-  "session-expired-modal": SessionExpiredModal,
-  "rate-limit-modal": RateLimitModal,
   "subscription-modal": SubscriptionModal,
   "subscription-success-modal": SubscriptionSuccessModal,
   "subscription-checkout-modal": SubscriptionCheckoutModal,

--- a/app/lib/modal/modals/core.ts
+++ b/app/lib/modal/modals/core.ts
@@ -1,0 +1,23 @@
+import dynamic from "next/dynamic";
+
+// Always-available modals: triggered from anywhere (global error handler,
+// auth flow, generic confirm/info dialogs). Registered by the root layout
+// via GlobalModalProvider, so they ship to every route.
+
+const ExampleModal = dynamic(() => import("./ExampleModal").then((m) => m.ExampleModal));
+const ConfirmationModal = dynamic(() => import("./ConfirmationModal").then((m) => m.ConfirmationModal));
+const ConnectionErrorModal = dynamic(() => import("./ConnectionErrorModal").then((m) => m.ConnectionErrorModal));
+const AuthErrorModal = dynamic(() => import("./AuthErrorModal").then((m) => m.AuthErrorModal));
+const InfoModal = dynamic(() => import("./InfoModal").then((m) => m.InfoModal));
+const SessionExpiredModal = dynamic(() => import("./SessionExpiredModal").then((m) => m.SessionExpiredModal));
+const RateLimitModal = dynamic(() => import("./RateLimitModal").then((m) => m.RateLimitModal));
+
+export const coreModals = {
+  "example-modal": ExampleModal,
+  "confirmation-modal": ConfirmationModal,
+  "connection-error-modal": ConnectionErrorModal,
+  "auth-error-modal": AuthErrorModal,
+  "info-modal": InfoModal,
+  "session-expired-modal": SessionExpiredModal,
+  "rate-limit-modal": RateLimitModal
+};

--- a/app/lib/modal/modals/registry.ts
+++ b/app/lib/modal/modals/registry.ts
@@ -1,0 +1,16 @@
+import type { ComponentType } from "react";
+import { coreModals } from "./core";
+
+// Runtime modal registry. Core modals are registered eagerly; (app)-only
+// modals are registered by AppModalRegistrar when an (app) route mounts.
+// This lets non-(app) routes (blog, articles, landing, premium marketing)
+// avoid bundling the (app) modal JS chunks.
+const registry: Record<string, ComponentType<any>> = { ...coreModals };
+
+export function registerModals(modals: Record<string, ComponentType<any>>): void {
+  Object.assign(registry, modals);
+}
+
+export function getModal(name: string): ComponentType<any> | undefined {
+  return registry[name];
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "jsx": "preserve",
     "incremental": true,
     "plugins": [


### PR DESCRIPTION
## Summary

Two related changes investigated as a follow-up to PSI's "100% unused CSS" finding on the blog route (a 15.7 KB premium CSS chunk + a 17.4 KB coding-exercise CSS chunk shipped to every page).

### 1. \`verbatimModuleSyntax: true\`

TS flag that forces every type-only import to use \`import type\` syntax. Zero errors trigger across the monorepo — the codebase already follows this convention — but the flag locks the discipline in so future regressions get caught at typecheck time. Guards against accidentally pulling runtime code through what was meant to be a type-only path (which was one of the suspects for how coding-exercise CSS was leaking into the blog bundle).

### 2. Modal manifest split

Previously \`lib/modal/modals/index.ts\` registered all 27 modals in a single \`availableModals\` object imported by \`GlobalModalProvider\` in the root layout. Even with each modal wrapped in \`next/dynamic()\`, Next.js still pulled the modals' JS chunks into routes that never render them (blog, articles, landing, premium marketing) because the manifest was statically loaded everywhere.

Replace with a runtime registry split into:

- \`modals/core.ts\` — 7 always-loaded modals (example, confirmation, info, auth/connection/session errors, rate-limit). Seeded into the registry at module load.
- \`modals/app.ts\` — 21 (app)-only modals (exercise, premium, subscription, payment, settings, badge, welcome, walkthrough).
- \`modals/registry.ts\` — module-level registry with \`registerModals()\` and \`getModal()\`.
- \`AppModalRegistrar.tsx\` — client component that calls \`registerModals(appModals)\` as a side effect at module load.

\`(app)/layout.tsx\` mounts \`<AppModalRegistrar />\`, so the (app) bundle picks up the app modals on hydration. Non-(app) routes never import \`modals/app.ts\` and never pay for the 21 modal chunks.

\`GlobalModalProvider\` now reads from the registry via \`getModal()\` instead of the static manifest.

## Known follow-up

\`lib/modal/store.ts\` still imports CSS modules from several (app)-only modals at the top level (PremiumUpgrade, SubscriptionCheckout, Payment\*, WelcomeToPremium, Welcome, WalkthroughConfirm, AvatarEdit). The store is loaded globally via \`useModalStore\`, so those CSS modules continue to bundle into the global CSS chunk. The JS split lands here; decoupling \`store.ts\` from modal CSS is a separate refactor (the natural approach is to move the app-only \`show*\` helpers into a sibling \`app-actions.ts\` module and update ~25 callsites).

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] All 1,676 Jest tests pass
- [ ] Anon load of \`/blog/the-backstory-of-jiki\` — Network panel: 21 fewer \`next/dynamic\` modal chunks
- [ ] Logged-in load of \`/dashboard\` — Premium upgrade, exercise completion, settings modals all open correctly
- [ ] PSI \`/blog/...\` — "Reduce unused JavaScript" no longer flags the (app) modal chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)