### PR TITLE
Split (app)-only modal helpers off store.ts; trim Sentry tracing

### DIFF
--- a/app/app/(app)/build/[slug]/EpisodeCard.tsx
+++ b/app/app/(app)/build/[slug]/EpisodeCard.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import LockIcon from "@/icons/lock.svg";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { tierIncludes } from "@/lib/pricing";
 import type { BuildEpisodeMeta, BuildSeriesMeta } from "@/lib/content/types";
 import styles from "./SeriesPage.module.css";

--- a/app/app/(app)/projects/PremiumProjectCard.tsx
+++ b/app/app/(app)/projects/PremiumProjectCard.tsx
@@ -1,7 +1,7 @@
 import { type ProjectData } from "@/lib/api/projects";
 import { ProjectIcon } from "@/components/icons/ProjectIcon";
 import LockIcon from "@/icons/lock.svg";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import styles from "./ProjectCard.module.css";
 
 interface PremiumProjectCardProps {

--- a/app/app/dev/premium-upgrade-modal-test/page.tsx
+++ b/app/app/dev/premium-upgrade-modal-test/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 
 export default function PremiumUpgradeModalTest() {
   const handleShowModal = () => {

--- a/app/app/dev/subscription-modal-test/page.tsx
+++ b/app/app/dev/subscription-modal-test/page.tsx
@@ -5,7 +5,7 @@ import {
   showPaymentProcessing,
   showPaymentVerificationFailed,
   showWelcomeToPremium
-} from "@/lib/modal";
+} from "@/lib/modal/app";
 
 export default function SubscriptionModalTest() {
   return (

--- a/app/app/dev/test-global-modals/page.tsx
+++ b/app/app/dev/test-global-modals/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { showConfirmation, showInfo, showModal, showSubscriptionModal, showSubscriptionSuccess } from "@/lib/modal";
+import { showConfirmation, showInfo, showModal } from "@/lib/modal";
+import { showSubscriptionModal, showSubscriptionSuccess } from "@/lib/modal/app";
 
 export default function TestGlobalModals() {
   return (

--- a/app/app/dev/test-global-modals/page.tsx
+++ b/app/app/dev/test-global-modals/page.tsx
@@ -283,13 +283,8 @@ export default function TestGlobalModals() {
       <div className="mt-8 p-4 bg-gray-100 rounded-lg">
         <h3 className="font-semibold mb-2">Usage Example:</h3>
         <pre className="bg-gray-800 text-white p-4 rounded overflow-x-auto">
-          {`import { 
-  showModal, 
-  showConfirmation, 
-  showInfo,
-  showSubscriptionModal,
-  showSubscriptionSuccess 
-} from '@/lib/modal';
+          {`import { showModal, showConfirmation, showInfo } from '@/lib/modal';
+import { showSubscriptionModal, showSubscriptionSuccess } from '@/lib/modal/app';
 
 // Anywhere in your component:
 showModal('example-modal', { title: 'Hello!' });

--- a/app/app/dev/welcome-modal-test/page.tsx
+++ b/app/app/dev/welcome-modal-test/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { showWelcomeModal } from "@/lib/modal";
+import { showWelcomeModal } from "@/lib/modal/app";
 import { clearFlagLocal } from "@/lib/api/flags";
 
 const WELCOME_FLAG_KEY = "welcome_modal";

--- a/app/components/WelcomeModalHandler.tsx
+++ b/app/components/WelcomeModalHandler.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showWelcomeModal } from "@/lib/modal";
+import { showWelcomeModal } from "@/lib/modal/app";
 import { checkFlag, setFlag } from "@/lib/api/flags";
 
 const WELCOME_FLAG_KEY = "welcome_modal";

--- a/app/components/build-episode/BuildEpisodeVideo.tsx
+++ b/app/components/build-episode/BuildEpisodeVideo.tsx
@@ -3,7 +3,7 @@
 import { CloseButton } from "@/components/ui-kit";
 import { useAuthStore } from "@/lib/auth/authStore";
 import type { BuildVideoProvider } from "@/lib/content/types";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { tierIncludes } from "@/lib/pricing";
 import MuxPlayer from "@/components/ui/JikiMuxPlayer";
 import { useRouter } from "next/navigation";

--- a/app/components/checkout/CheckoutReturnHandler.tsx
+++ b/app/components/checkout/CheckoutReturnHandler.tsx
@@ -10,7 +10,7 @@ import {
   showPaymentProcessing,
   showPaymentVerificationFailed,
   showWelcomeToPremium
-} from "@/lib/modal";
+} from "@/lib/modal/app";
 
 /**
  * Global handler for Stripe checkout returns

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react";
 import toast from "react-hot-toast";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import { useChatState } from "./useChatState";
 import { useChatContext } from "./useChatContext";

--- a/app/components/coding-exercise/ui/HintsPanel.tsx
+++ b/app/components/coding-exercise/ui/HintsPanel.tsx
@@ -10,7 +10,7 @@ import setupJavascript from "@jiki/highlightjs-javascript";
 import { PanelHeader } from "./PanelHeader";
 import EyeClosedIcon from "@/icons/eye-close.svg";
 import EyeOpenIcon from "@/icons/eye-open.svg";
-import { showWalkthroughConfirm } from "@/lib/modal/store";
+import { showWalkthroughConfirm } from "@/lib/modal/app";
 import { useWalkthroughProgress } from "@/lib/modal/modals/useWalkthroughProgress";
 import type { VideoSource } from "@/types/lesson";
 import type { Hint } from "@jiki/curriculum";

--- a/app/components/coding-exercise/ui/chat-panel-states/FreeUserCanStart.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/FreeUserCanStart.tsx
@@ -1,7 +1,8 @@
 import Image from "next/image";
 import ChatBubbleIcon from "@/icons/chat-bubble.svg";
 import CheckCircleFilledIcon from "@/icons/check-circle-filled.svg";
-import { showConfirmation, showPremiumUpgradeModal } from "@/lib/modal";
+import { showConfirmation } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import styles from "./FreeUserCanStart.module.css";
 import StuckHeader from "./StuckHeader";
 

--- a/app/components/coding-exercise/ui/chat-panel-states/FreeUserLimitReached.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/FreeUserLimitReached.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import styles from "./FreeUserCanStart.module.css";
 import StuckHeader from "./StuckHeader";
 

--- a/app/components/coding-exercise/ui/chat-panel-states/LockedFooter.tsx
+++ b/app/components/coding-exercise/ui/chat-panel-states/LockedFooter.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import styles from "./LockedFooter.module.css";
 
 type LockedFooterVariant = "free-limit-reached" | "premium-blocked";

--- a/app/components/concepts/VideoRecapCard.tsx
+++ b/app/components/concepts/VideoRecapCard.tsx
@@ -1,4 +1,4 @@
-import { showVideoWalkthrough } from "@/lib/modal/store";
+import { showVideoWalkthrough } from "@/lib/modal/app";
 import type { VideoSource } from "@/types/lesson";
 import styles from "./VideoRecapCard.module.css";
 

--- a/app/components/dashboard/exercise-path/ui/WalkthroughCard.tsx
+++ b/app/components/dashboard/exercise-path/ui/WalkthroughCard.tsx
@@ -1,6 +1,6 @@
 import WalkthroughIcon from "@/icons/walkthrough.svg";
 import type { LessonDisplayData } from "../types";
-import { showVideoWalkthrough } from "@/lib/modal/store";
+import { showVideoWalkthrough } from "@/lib/modal/app";
 import styles from "./WalkthroughCard.module.css";
 
 interface WalkthroughCardProps {

--- a/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
+++ b/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
@@ -4,7 +4,7 @@ import { fetchBadges, type BadgeData } from "@/lib/api/badges";
 import { fetchProfile, type ProfileData } from "@/lib/api/profile";
 import { fetchProjects, type ProjectData } from "@/lib/api/projects";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { tierIncludes } from "@/lib/pricing";
 import { useEffect, useMemo, useState } from "react";
 import styles from "./projects-sidebar.module.css";

--- a/app/components/dashboard/projects-sidebar/ui/UserProfile.tsx
+++ b/app/components/dashboard/projects-sidebar/ui/UserProfile.tsx
@@ -2,7 +2,7 @@
 
 import type { BadgeData } from "@/lib/api/badges";
 import { useDelayedLoading } from "@/lib/hooks/useDelayedLoading";
-import { showAvatarEditModal } from "@/lib/modal";
+import { showAvatarEditModal } from "@/lib/modal/app";
 import UserAvatar from "@/components/common/UserAvatar";
 import { Icon } from "@/components/ui-kit/Icon";
 import PencilIcon from "@/icons/pencil.svg";

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -9,7 +9,7 @@ import ProjectsIcon from "@/icons/projects.svg";
 import SettingsIcon from "@/icons/settings.svg";
 import type { ComponentType } from "react";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { tierIncludes } from "@/lib/pricing";
 import rocket from "@/components/landing-page/rocketLaunch.module.css";
 import { useRocketLaunch } from "@/components/landing-page/hooks/useRocketLaunch";

--- a/app/components/premium/CtaSection.tsx
+++ b/app/components/premium/CtaSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import styles from "./PremiumPage.module.css";
 
 export default function CtaSection() {

--- a/app/components/settings/sections/AvatarUploadSection.tsx
+++ b/app/components/settings/sections/AvatarUploadSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { showAvatarEditModal } from "@/lib/modal/store";
+import { showAvatarEditModal } from "@/lib/modal/app";
 import { useAuthStore } from "@/lib/auth/authStore";
 import AvatarPreview from "../ui/AvatarPreview";
 import PencilIcon from "@/icons/pencil.svg";

--- a/app/lib/modal/app.ts
+++ b/app/lib/modal/app.ts
@@ -1,0 +1,140 @@
+/**
+ * (app)-only modal trigger helpers.
+ *
+ * Most of these helpers need to forward an overlay/modal className to
+ * BaseModal so the modal renders with the right chrome (widths, branded
+ * backdrops, etc.). The hashed class names come from each modal's own
+ * .module.css, so the helper has to import that CSS module to read them.
+ *
+ * If these helpers lived in ./store.ts (which they used to), store.ts
+ * would statically depend on every (app)-only modal's CSS — and store.ts
+ * is imported everywhere via useModalStore(), GlobalModalProvider, etc.
+ * That meant the (app)-only modal CSS bundled into the global CSS chunk
+ * on every route, including blog/articles/landing/premium marketing where
+ * the modals never render. PSI flagged ~16 KB of "100% unused CSS" on
+ * the blog route from this leak.
+ *
+ * Splitting them into this file lets the CSS travel with the (app) JS
+ * bundle only. Non-(app) callsites should not need any of these — they
+ * trigger modals that only make sense post-login (premium upgrade,
+ * checkout, payment, exercise completion, avatar, walkthroughs, welcome).
+ *
+ * Callsites in (app) routes:    import from "@/lib/modal/app"
+ * Callsites everywhere else:    import from "@/lib/modal" (core only)
+ */
+
+import type { MembershipTier } from "@/lib/pricing";
+import type { ModalTrigger } from "@/lib/analytics";
+import paymentProcessingStyles from "./modals/PaymentProcessingModal.module.css";
+import premiumUpgradeStyles from "./modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
+import subscriptionCheckoutStyles from "./modals/SubscriptionCheckoutModal.module.css";
+import welcomeToPremiumStyles from "./modals/WelcomeToPremiumModal.module.css";
+import welcomeStyles from "./modals/WelcomeModal.module.css";
+import walkthroughConfirmStyles from "./modals/WalkthroughConfirmModal.module.css";
+import avatarEditStyles from "@/components/settings/modals/AvatarEditModal.module.css";
+import { showModal } from "./store";
+
+// Convenience function for subscription modals
+export const showSubscriptionModal = (props: {
+  triggerContext?: "chat-gate" | "feature-gate" | "general" | "settings";
+  suggestedTier?: "premium" | "max";
+  headline?: string;
+  description?: string;
+  featuresContext?: {
+    feature: string;
+    benefits: string[];
+  };
+  onSuccess?: (tier: MembershipTier) => void;
+  onCancel?: () => void;
+}) => {
+  showModal("subscription-modal", props);
+};
+
+// Convenience function for subscription success modals
+export const showSubscriptionSuccess = (props: {
+  tier: MembershipTier;
+  triggerContext?: string;
+  nextSteps?: {
+    title: string;
+    description: string;
+    action?: () => void;
+    buttonText?: string;
+  };
+  onClose?: () => void;
+}) => {
+  showModal("subscription-success-modal", props);
+};
+
+// Convenience function for subscription checkout modal
+export const showSubscriptionCheckout = (props: {
+  clientSecret: string;
+  selectedTier: MembershipTier;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+}) => {
+  showModal("subscription-checkout-modal", props, undefined, subscriptionCheckoutStyles.modal);
+};
+
+// Convenience function for payment processing modal
+export const showPaymentProcessing = (props?: { onClose?: () => void }) => {
+  showModal("payment-processing-modal", props ?? {}, undefined, paymentProcessingStyles.modal);
+};
+
+// Convenience function for the brief "confirming with Stripe" state shown
+// the moment a checkout return is detected, before verifyCheckoutSession resolves.
+export const showPaymentConfirming = () => {
+  showModal("payment-confirming-modal", {}, undefined, paymentProcessingStyles.modal);
+};
+
+// Convenience function shown when checkout verification itself errors
+// (network/server failure), distinct from a successful "unpaid" response.
+export const showPaymentVerificationFailed = (props?: { onClose?: () => void }) => {
+  showModal("payment-verification-failed-modal", props ?? {}, undefined, paymentProcessingStyles.modal);
+};
+
+// Convenience function for welcome to premium modal
+export const showWelcomeToPremium = (props?: { onClose?: () => void }) => {
+  showModal("welcome-to-premium-modal", props ?? {}, undefined, welcomeToPremiumStyles.modal);
+};
+
+// Convenience function for the premium upgrade modal. The `trigger` arg is
+// typed as `ModalTrigger`, a closed union of allowed values — keep that type
+// the single source of truth so the `premium_modal_shown` funnel data stays
+// consistent (new triggers must be added to the type before use).
+export const showPremiumUpgradeModal = (
+  trigger: ModalTrigger,
+  options?: {
+    contextType?: string;
+    contextSlug?: string;
+    contextUuid?: string;
+    onSuccess?: () => void;
+    onCancel?: () => void;
+  }
+) => {
+  showModal(
+    "premium-upgrade-modal",
+    { trigger, ...options },
+    premiumUpgradeStyles.premiumModalOverlay,
+    premiumUpgradeStyles.premiumModalWidth
+  );
+};
+
+// Convenience function for video walkthrough modal
+export const showVideoWalkthrough = (props: { playbackId: string; lessonSlug: string }) => {
+  showModal("video-walkthrough-modal", props);
+};
+
+// Convenience function for walkthrough confirmation modal
+export const showWalkthroughConfirm = (props: { onConfirm?: () => void }) => {
+  showModal("walkthrough-confirm-modal", props, undefined, walkthroughConfirmStyles.modal);
+};
+
+// Convenience function for avatar edit modal
+export const showAvatarEditModal = () => {
+  showModal("avatar-edit-modal", {}, undefined, avatarEditStyles.modal);
+};
+
+// Convenience function for welcome modal (shown once on first signup)
+export const showWelcomeModal = () => {
+  showModal("welcome-modal", {}, welcomeStyles.overlay, welcomeStyles.modal);
+};

--- a/app/lib/modal/index.ts
+++ b/app/lib/modal/index.ts
@@ -1,21 +1,8 @@
+// Public modal API for callsites outside (app).
+// See ./app.ts for the (app)-only show* helpers.
+
 // Export the provider component
 export { GlobalModalProvider } from "./GlobalModalProvider";
 
-// Export the modal functions for global usage
-export {
-  hideModal,
-  showConfirmation,
-  showInfo,
-  showModal,
-  showSubscriptionCheckout,
-  showSubscriptionModal,
-  showSubscriptionSuccess,
-  showPaymentProcessing,
-  showPaymentConfirming,
-  showPaymentVerificationFailed,
-  showPremiumUpgradeModal,
-  showWelcomeToPremium,
-  showAvatarEditModal,
-  showWelcomeModal,
-  useModalStore
-} from "./store";
+// Core modal trigger helpers — safe to import from any route.
+export { hideModal, showConfirmation, showInfo, showModal, useModalStore } from "./store";

--- a/app/lib/modal/store.ts
+++ b/app/lib/modal/store.ts
@@ -1,14 +1,21 @@
+/**
+ * Core modal store and trigger helpers.
+ *
+ * Pure state plus the small set of show* helpers that are safe to load
+ * everywhere (showConfirmation, showInfo, showModal, hideModal,
+ * useModalStore). This file is reached by every route that mounts
+ * GlobalModalProvider — i.e. the entire app — so it MUST NOT import
+ * CSS modules from (app)-only modals. Doing so would bundle those CSS
+ * modules into the global CSS chunk on blog/articles/landing/premium
+ * marketing routes that never render the corresponding modals.
+ *
+ * (app)-only show* helpers — anything that imports a modal's
+ * .module.css to forward a className through to BaseModal — live in
+ * ./app.ts. Callsites in (app) routes import from "@/lib/modal/app".
+ */
+
 import { create } from "zustand";
-import type { ModalTrigger } from "@/lib/analytics";
-import type { MembershipTier } from "@/lib/pricing";
 import confirmationStyles from "@/app/styles/components/confirmation-modal.module.css";
-import paymentProcessingStyles from "./modals/PaymentProcessingModal.module.css";
-import premiumUpgradeStyles from "./modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css";
-import subscriptionCheckoutStyles from "./modals/SubscriptionCheckoutModal.module.css";
-import welcomeToPremiumStyles from "./modals/WelcomeToPremiumModal.module.css";
-import welcomeStyles from "./modals/WelcomeModal.module.css";
-import walkthroughConfirmStyles from "./modals/WalkthroughConfirmModal.module.css";
-import avatarEditStyles from "@/components/settings/modals/AvatarEditModal.module.css";
 
 interface ModalState {
   isOpen: boolean;
@@ -87,109 +94,4 @@ export const showConfirmation = (props: {
 // Convenience function for info modals
 export const showInfo = (props: { title?: string; content: string | React.ReactNode; buttonText?: string }) => {
   showModal("info-modal", props);
-};
-
-// Convenience function for subscription modals
-export const showSubscriptionModal = (props: {
-  triggerContext?: "chat-gate" | "feature-gate" | "general" | "settings";
-  suggestedTier?: "premium" | "max";
-  headline?: string;
-  description?: string;
-  featuresContext?: {
-    feature: string;
-    benefits: string[];
-  };
-  onSuccess?: (tier: MembershipTier) => void;
-  onCancel?: () => void;
-}) => {
-  showModal("subscription-modal", props);
-};
-
-// Convenience function for subscription success modals
-export const showSubscriptionSuccess = (props: {
-  tier: MembershipTier;
-  triggerContext?: string;
-  nextSteps?: {
-    title: string;
-    description: string;
-    action?: () => void;
-    buttonText?: string;
-  };
-  onClose?: () => void;
-}) => {
-  showModal("subscription-success-modal", props);
-};
-
-// Convenience function for subscription checkout modal
-export const showSubscriptionCheckout = (props: {
-  clientSecret: string;
-  selectedTier: MembershipTier;
-  onCancel?: () => void;
-  onSuccess?: () => void;
-}) => {
-  showModal("subscription-checkout-modal", props, undefined, subscriptionCheckoutStyles.modal);
-};
-
-// Convenience function for payment processing modal
-export const showPaymentProcessing = (props?: { onClose?: () => void }) => {
-  showModal("payment-processing-modal", props ?? {}, undefined, paymentProcessingStyles.modal);
-};
-
-// Convenience function for the brief "confirming with Stripe" state shown
-// the moment a checkout return is detected, before verifyCheckoutSession resolves.
-export const showPaymentConfirming = () => {
-  showModal("payment-confirming-modal", {}, undefined, paymentProcessingStyles.modal);
-};
-
-// Convenience function shown when checkout verification itself errors
-// (network/server failure), distinct from a successful "unpaid" response.
-export const showPaymentVerificationFailed = (props?: { onClose?: () => void }) => {
-  showModal("payment-verification-failed-modal", props ?? {}, undefined, paymentProcessingStyles.modal);
-};
-
-// Convenience function for welcome to premium modal
-export const showWelcomeToPremium = (props?: { onClose?: () => void }) => {
-  showModal("welcome-to-premium-modal", props ?? {}, undefined, welcomeToPremiumStyles.modal);
-};
-
-// Convenience function for the premium upgrade modal. The `trigger` arg is
-// typed as `ModalTrigger`, a closed union of allowed values — keep that type
-// the single source of truth so the `premium_modal_shown` funnel data stays
-// consistent (new triggers must be added to the type before use).
-export const showPremiumUpgradeModal = (
-  trigger: ModalTrigger,
-  options?: {
-    contextType?: string;
-    contextSlug?: string;
-    contextUuid?: string;
-    onSuccess?: () => void;
-    onCancel?: () => void;
-  }
-) => {
-  showModal(
-    "premium-upgrade-modal",
-    { trigger, ...options },
-    premiumUpgradeStyles.premiumModalOverlay,
-    premiumUpgradeStyles.premiumModalWidth
-  );
-};
-
-// Convenience function for video walkthrough modal
-export const showVideoWalkthrough = (props: { playbackId: string; lessonSlug: string }) => {
-  showModal("video-walkthrough-modal", props);
-};
-
-// Convenience function for walkthrough confirmation modal
-export const showWalkthroughConfirm = (props: { onConfirm?: () => void }) => {
-  showModal("walkthrough-confirm-modal", props, undefined, walkthroughConfirmStyles.modal);
-};
-
-// Convenience function for avatar edit modal
-export const showAvatarEditModal = () => {
-  showModal("avatar-edit-modal", {}, undefined, avatarEditStyles.modal);
-};
-
-// Convenience function for welcome modal (shown once on first signup)
-export const showWelcomeModal = () => {
-  showModal("welcome-modal", {}, welcomeStyles.overlay, welcomeStyles.modal);
 };

--- a/app/lib/subscriptions/handlers.ts
+++ b/app/lib/subscriptions/handlers.ts
@@ -12,7 +12,8 @@ import {
 } from "@/lib/api/subscriptions";
 import { createCheckoutReturnUrl } from "@/lib/subscriptions/checkout";
 import { getApiUrl } from "@/lib/api/config";
-import { hideModal, showSubscriptionCheckout } from "@/lib/modal";
+import { hideModal } from "@/lib/modal";
+import { showSubscriptionCheckout } from "@/lib/modal/app";
 import toast from "react-hot-toast";
 
 // Types for handler functions

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -169,7 +169,12 @@ if (process.env.NODE_ENV === "production") {
     webpack: {
       automaticVercelMonitors: false,
       treeshake: {
-        removeDebugLogging: true
+        removeDebugLogging: true,
+        // Strip Sentry's tracing/performance SDK (BrowserTracing,
+        // startSpan, etc.). Big bundle win on every route (~30–40 KB
+        // off the shared Sentry chunk). We're not consuming Sentry
+        // tracing data — only error capture — so this is safe.
+        removeTracing: true
       }
     }
   });

--- a/app/tests/integration/settings/payment-verification.test.tsx
+++ b/app/tests/integration/settings/payment-verification.test.tsx
@@ -13,7 +13,7 @@ import {
   showPaymentProcessing,
   showPaymentConfirming,
   showPaymentVerificationFailed
-} from "@/lib/modal";
+} from "@/lib/modal/app";
 
 // Mock the API call
 jest.mock("@/lib/api/subscriptions", () => ({
@@ -26,7 +26,7 @@ jest.mock("@/lib/subscriptions/verification", () => ({
 }));
 
 // Mock the modal system
-jest.mock("@/lib/modal", () => ({
+jest.mock("@/lib/modal/app", () => ({
   showWelcomeToPremium: jest.fn(),
   showPaymentProcessing: jest.fn(),
   showPaymentConfirming: jest.fn(),

--- a/app/tests/unit/components/build-episode/BuildEpisodeVideo.test.tsx
+++ b/app/tests/unit/components/build-episode/BuildEpisodeVideo.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import BuildEpisodeVideo from "@/components/build-episode/BuildEpisodeVideo";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { showPremiumUpgradeModal } from "@/lib/modal";
+import { showPremiumUpgradeModal } from "@/lib/modal/app";
 
 jest.mock("@/lib/auth/authStore");
-jest.mock("@/lib/modal", () => ({
+jest.mock("@/lib/modal/app", () => ({
   showPremiumUpgradeModal: jest.fn()
 }));
 jest.mock("@/components/build-episode/lib/useBuildEpisodeProgress", () => ({

--- a/app/tests/unit/components/settings/subscription/handlers.test.ts
+++ b/app/tests/unit/components/settings/subscription/handlers.test.ts
@@ -4,13 +4,14 @@
 import * as subscriptionApi from "@/lib/api/subscriptions";
 import * as checkoutUtils from "@/lib/subscriptions/checkout";
 import * as handlers from "@/components/settings/subscription/handlers";
-import { showSubscriptionCheckout } from "@/lib/modal";
+import { showSubscriptionCheckout } from "@/lib/modal/app";
 import toast from "react-hot-toast";
 
 // Mock the external dependencies
 jest.mock("@/lib/api/subscriptions");
 jest.mock("@/lib/subscriptions/checkout");
 jest.mock("@/lib/modal");
+jest.mock("@/lib/modal/app");
 jest.mock("react-hot-toast");
 
 const mockSubscriptionApi = subscriptionApi as jest.Mocked<typeof subscriptionApi>;


### PR DESCRIPTION
## Summary

Two related bundle-size fixes.

### 1. Move (app)-only modal helpers (and their CSS imports) off \`store.ts\`

PSI flagged a ~16 KB "100% unused" premium CSS chunk on \`/blog\`. The trigger was \`lib/modal/store.ts\`: it statically imported CSS modules from \`PremiumUpgradeModal\`, \`SubscriptionCheckoutModal\`, \`PaymentProcessingModal\`, \`WelcomeToPremiumModal\`, \`WelcomeModal\`, \`WalkthroughConfirmModal\` and \`AvatarEditModal\`, because each \`show*\` helper needs to forward the modal's hashed overlay/wrapper class names to \`BaseModal\`.

Since \`store.ts\` is imported everywhere via \`useModalStore\` (mounted by \`GlobalModalProvider\` in the root layout), every blog / articles / landing / marketing route was bundling those CSS modules even though the modals never render there.

This PR:

- Adds \`lib/modal/app.ts\`: holds all the (app)-only \`show*\` helpers (\`showPremiumUpgradeModal\`, \`showSubscriptionCheckout\`, \`showPayment*\`, \`showWelcomeToPremium\`, \`showWelcomeModal\`, \`showWalkthroughConfirm\`, \`showAvatarEditModal\`, \`showVideoWalkthrough\`, \`showSubscriptionModal\`, \`showSubscriptionSuccess\`) along with the corresponding CSS module imports. Documented at the top of the file.
- Strips those helpers (and the CSS imports) out of \`store.ts\`. \`store.ts\` now holds only pure state + always-safe helpers (\`showModal\`, \`hideModal\`, \`useModalStore\`, \`showConfirmation\`, \`showInfo\`).
- Strips the (app)-only re-exports from \`lib/modal/index.ts\` so \`@/lib/modal\` is now a core-only public surface.
- Updates 25 callsites to import (app)-only helpers from \`@/lib/modal/app\` instead of \`@/lib/modal\` (or \`@/lib/modal/store\`).
- Updates the two jest.mock() targets in tests that mocked the modal module.

The premium CSS chunk should drop off non-(app) routes after deploy.

### 2. Sentry: \`removeTracing: true\`

Add \`removeTracing\` to the existing \`@sentry/nextjs\` \`webpack.treeshake\` config. We capture errors only — no tracing data is consumed — so stripping the BrowserTracing/performance SDK is safe and saves ~30–40 KB off the shared Sentry chunk on every route.

## Known limitation (separate PR)

This does NOT address the second "100% unused" chunk PSI flagged on \`/blog\` — the ~17 KB CSS chunk that contains \`CodingExercise.module.css\` styles. I traced that chunk: it actually contains **~28 CSS Modules** co-extracted into one (Badges, ChatPanel, CodingExercise, ExternalFooter, LandingPage, Pagination, Tooltip, etc.). Webpack's CSS-chunk grouping bundles them together, so the moment any one of them is reachable from a route (e.g. \`ExternalFooter\` from \`HeaderLayout\` on blog routes), the whole 17 KB chunk gets linked. Fixing it needs a focused \`next.config.ts\` \`splitChunks\` tweak — separate follow-up PR with bundle-analyzer running alongside.

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] All 1,676 Jest tests pass
- [ ] Anon load of \`/blog/the-backstory-of-jiki\` — Network panel: \`47398843813d34e8.css\` (or its post-deploy successor) no longer linked
- [ ] Logged-in load of an (app) route — Premium upgrade, checkout, payment, welcome, walkthrough, avatar-edit modals all open and render with correct chrome
- [ ] Sentry — errors still report from production (\`removeTracing\` keeps the error pipeline intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)