### PR TITLE
Recent Projects: pad with completed before locked

### DIFF
--- a/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
+++ b/app/components/dashboard/projects-sidebar/ProjectsSidebar.tsx
@@ -80,14 +80,14 @@ function ProjectsSidebar({ onProjectClick, onViewAllProjectsClick, onUpgradeClic
       return active;
     }
     const usedSlugs = new Set(active.map((p) => p.slug));
-    const locked = projects.filter((p) => p.status === "locked" && !usedSlugs.has(p.slug));
-    const withLocked = [...active, ...locked.slice(0, 3 - active.length)];
-    if (withLocked.length >= 3) {
-      return withLocked;
-    }
-    withLocked.forEach((p) => usedSlugs.add(p.slug));
     const completed = projects.filter((p) => p.status === "completed" && !usedSlugs.has(p.slug));
-    return [...withLocked, ...completed.slice(0, 3 - withLocked.length)];
+    const withCompleted = [...active, ...completed.slice(0, 3 - active.length)];
+    if (withCompleted.length >= 3) {
+      return withCompleted;
+    }
+    withCompleted.forEach((p) => usedSlugs.add(p.slug));
+    const locked = projects.filter((p) => p.status === "locked" && !usedSlugs.has(p.slug));
+    return [...withCompleted, ...locked.slice(0, 3 - withCompleted.length)];
   }, [isPremium, projects]);
 
   // Count unlocked projects - only computed for premium users

--- a/app/tests/unit/components/dashboard/projects-sidebar/ProjectsSidebar.test.tsx
+++ b/app/tests/unit/components/dashboard/projects-sidebar/ProjectsSidebar.test.tsx
@@ -145,38 +145,72 @@ describe("ProjectsSidebar", () => {
       expect(screen.queryByTestId("project-c1")).not.toBeInTheDocument();
     });
 
-    it("pads with locked projects after active ones", async () => {
+    it("pads with completed projects after active ones", async () => {
+      mockProjects([
+        makeProject("s1", "started"),
+        makeProject("c1", "completed"),
+        makeProject("c2", "completed"),
+        makeProject("c3", "completed"),
+        makeProject("l1", "locked")
+      ]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-s1");
+      expect(screen.getByTestId("project-c1")).toBeInTheDocument();
+      expect(screen.getByTestId("project-c2")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-c3")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("project-l1")).not.toBeInTheDocument();
+    });
+
+    it("prefers completed over locked when both are available for padding", async () => {
+      // Regression: previously the widget padded with locked before completed,
+      // hiding recently-finished projects behind locked-but-not-started ones.
       mockProjects([
         makeProject("s1", "started"),
         makeProject("l1", "locked"),
         makeProject("l2", "locked"),
-        makeProject("l3", "locked"),
         makeProject("c1", "completed")
       ]);
 
       render(<ProjectsSidebar />);
 
       await screen.findByTestId("project-s1");
+      expect(screen.getByTestId("project-c1")).toBeInTheDocument();
       expect(screen.getByTestId("project-l1")).toBeInTheDocument();
-      expect(screen.getByTestId("project-l2")).toBeInTheDocument();
-      expect(screen.queryByTestId("project-l3")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("project-c1")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("project-l2")).not.toBeInTheDocument();
     });
 
-    it("pads with completed projects after locked when fewer than 3 active+locked exist", async () => {
+    it("pads with locked projects after completed when fewer than 3 active+completed exist", async () => {
       mockProjects([
         makeProject("s1", "started"),
-        makeProject("l1", "locked"),
         makeProject("c1", "completed"),
-        makeProject("c2", "completed")
+        makeProject("l1", "locked"),
+        makeProject("l2", "locked")
       ]);
 
       render(<ProjectsSidebar />);
 
       await screen.findByTestId("project-s1");
-      expect(screen.getByTestId("project-l1")).toBeInTheDocument();
       expect(screen.getByTestId("project-c1")).toBeInTheDocument();
-      expect(screen.queryByTestId("project-c2")).not.toBeInTheDocument();
+      expect(screen.getByTestId("project-l1")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-l2")).not.toBeInTheDocument();
+    });
+
+    it("falls back to locked projects only when nothing else exists", async () => {
+      mockProjects([
+        makeProject("l1", "locked"),
+        makeProject("l2", "locked"),
+        makeProject("l3", "locked"),
+        makeProject("l4", "locked")
+      ]);
+
+      render(<ProjectsSidebar />);
+
+      await screen.findByTestId("project-l1");
+      expect(screen.getByTestId("project-l2")).toBeInTheDocument();
+      expect(screen.getByTestId("project-l3")).toBeInTheDocument();
+      expect(screen.queryByTestId("project-l4")).not.toBeInTheDocument();
     });
 
     it("falls back to completed projects only when nothing else exists", async () => {


### PR DESCRIPTION
## Summary
- The Recent Projects sidebar widget was padding with `locked` projects before `completed` ones, so recently-finished projects (e.g. Sprouting Flower, Cityscape Skyline) were hidden behind locked-but-not-started ones when fewer than 3 active projects existed.
- New padding order: `started`/`unlocked` → `completed` → `locked`.
- Added a regression test plus updated existing padding tests for the new order.

## Test plan
- [x] `pnpm jest tests/unit/components/dashboard/projects-sidebar/ProjectsSidebar.test.tsx` (10 passed)
- [x] Full app test suite green via pre-commit (1678 passed)
- [ ] Spot-check the dashboard sidebar in-browser to confirm completed projects show before locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)