### PR TITLE
Add conceptSlugs to alien-detector

### DIFF
--- a/curriculum/src/exercises/alien-detector/index.ts
+++ b/curriculum/src/exercises/alien-detector/index.ts
@@ -56,7 +56,8 @@ const exerciseDefinition: VisualExerciseCore = {
   ExerciseClass,
   tasks,
   scenarios,
-  functions
+  functions,
+  conceptSlugs: ["arrays", "variables", "conditionals", "repeat", "using-functions-with-return-values"]
 };
 
 export default exerciseDefinition;


### PR DESCRIPTION
## Summary

- Add \`conceptSlugs: [\"arrays\", \"variables\", \"conditionals\", \"repeat\", \"using-functions-with-return-values\"]\` to alien-detector.

The exercise is at the \"lists\" level and the solution centres on storing returned rows in array variables, indexing into them by the cannon's position, and iterating with conditional shoot logic.

## Test plan

- [ ] \`pnpm typecheck\` passes
- [ ] \`pnpm test\` passes
- [ ] Concept library shows alien-detector under each linked concept

🤖 Generated with [Claude Code](https://claude.com/claude-code)