### PR TITLE
Cityscape-skyline: bug fixes, RNG decoupling, overdraw guard + hints

### DIFF
--- a/app/components/coding-exercise/CodingExercise.module.css
+++ b/app/components/coding-exercise/CodingExercise.module.css
@@ -612,6 +612,10 @@
     line-height: 1.4;
 }
 
+.testFeedback .message code {
+    white-space: nowrap;
+}
+
 .testDescription.stateFailed .testFeedback {
     background: var(--color-red-50);
 }

--- a/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/informationTooltip.module.css
+++ b/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/informationTooltip.module.css
@@ -50,6 +50,7 @@
 .informationTooltip :not(pre) > code {
     padding: 1px 6px;
     border-radius: 5px;
+    white-space: nowrap;
 }
 
 /* Code styling for description/normal tooltips */

--- a/curriculum/src/exercise-categories/cityscape/CityScapeExercise.ts
+++ b/curriculum/src/exercise-categories/cityscape/CityScapeExercise.ts
@@ -141,6 +141,8 @@ export default class CityScapeExercise extends VisualExercise {
     // Each quantity draws from its own stream so the Nth call to randomWidth()
     // always returns the Nth building's width, regardless of how it is
     // interleaved with randomNumFloors() calls.
+    // Unseeded (free-play) runs alias Math.random for both, which is fine:
+    // nothing reconstructs the sequence by position, so call order is irrelevant.
     this.widthRng = this.randomSeed === undefined ? Math.random : mulberry32(this.randomSeed);
     this.floorsRng = this.randomSeed === undefined ? Math.random : mulberry32(this.randomSeed ^ FLOORS_SEED_OFFSET);
   }

--- a/curriculum/src/exercise-categories/cityscape/CityScapeExercise.ts
+++ b/curriculum/src/exercise-categories/cityscape/CityScapeExercise.ts
@@ -3,6 +3,23 @@ import { VisualExercise } from "../../VisualExercise";
 
 type CellType = "wall" | "entrance" | "glass";
 
+// Mulberry32 - a simple, fast seeded PRNG (matches interpreters/src/shared/random.ts).
+// The width and floors sequences are kept independent so a student's results
+// don't depend on the order in which they call randomWidth()/randomNumFloors().
+function mulberry32(seed: number): () => number {
+  let state = seed | 0;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Offset applied to the seed for the floors stream so it is independent of the
+// width stream. The test suite (scenarios.ts) mirrors this constant.
+export const FLOORS_SEED_OFFSET = 0x9e3779b9;
+
 export default class CityScapeExercise extends VisualExercise {
   protected get slug() {
     return "cityscape";
@@ -16,6 +33,8 @@ export default class CityScapeExercise extends VisualExercise {
   private numFloors = 3;
   private numBuildings = 1;
   private gridContainer!: HTMLElement;
+  private widthRng?: () => number;
+  private floorsRng?: () => number;
 
   constructor() {
     super();
@@ -58,8 +77,26 @@ export default class CityScapeExercise extends VisualExercise {
     const xVal = x.value;
     const yVal = y.value;
 
+    if (!Number.isInteger(xVal)) {
+      return executionCtx.logicError(
+        `You must use whole numbers for \`x\` and \`y\`. You provided \`x\` as \`${xVal}\`, which isn't allowed.`
+      );
+    }
+    if (!Number.isInteger(yVal)) {
+      return executionCtx.logicError(
+        `You must use whole numbers for \`x\` and \`y\`. You provided \`y\` as \`${yVal}\`, which isn't allowed.`
+      );
+    }
+
     if (xVal < 1 || xVal > this.COLS || yVal < 1 || yVal > this.ROWS) {
       return executionCtx.logicError(`Position (${xVal}, ${yVal}) is outside the grid`);
+    }
+
+    const existing = this.grid.get(`${xVal},${yVal}`);
+    if (existing !== undefined) {
+      return executionCtx.logicError(
+        `The builders are stuck. There's already a ${existing} at the coordinates \`(${xVal}, ${yVal})\` so they can't build here!`
+      );
     }
 
     this.grid.set(`${xVal},${yVal}`, type);
@@ -97,13 +134,26 @@ export default class CityScapeExercise extends VisualExercise {
     return this.numBuildings;
   }
 
-  getRandomWidth(executionCtx: ExecutionContext): number {
-    // Returns 3, 5, or 7 (odd widths only, so entrance is always centered)
-    return Math.floor(executionCtx.random() * 3) * 2 + 3;
+  private ensureRngs() {
+    if (this.widthRng && this.floorsRng) {
+      return;
+    }
+    // Each quantity draws from its own stream so the Nth call to randomWidth()
+    // always returns the Nth building's width, regardless of how it is
+    // interleaved with randomNumFloors() calls.
+    this.widthRng = this.randomSeed === undefined ? Math.random : mulberry32(this.randomSeed);
+    this.floorsRng = this.randomSeed === undefined ? Math.random : mulberry32(this.randomSeed ^ FLOORS_SEED_OFFSET);
   }
 
-  getRandomNumFloors(executionCtx: ExecutionContext): number {
-    return Math.floor(executionCtx.random() * 12) + 1;
+  getRandomWidth(_executionCtx: ExecutionContext): number {
+    this.ensureRngs();
+    // Returns 3, 5, or 7 (odd widths only, so entrance is always centered)
+    return Math.floor(this.widthRng!() * 3) * 2 + 3;
+  }
+
+  getRandomNumFloors(_executionCtx: ExecutionContext): number {
+    this.ensureRngs();
+    return Math.floor(this.floorsRng!() * 12) + 1;
   }
 
   setupNumFloors(n: number) {

--- a/curriculum/src/exercises/cityscape-skyline/llm-metadata.ts
+++ b/curriculum/src/exercises/cityscape-skyline/llm-metadata.ts
@@ -31,15 +31,29 @@ export const llmMetadata: LLMMetadata = {
               - Wall at x, glass up to entrance, entrance at x + entranceOffset,
                 glass after entrance, wall at x + width - 1
               - Uses two repeat loops for glass on each side of entrance (entranceOffset - 1 each)
-           e. Build upper floors (y=3 upward) with nested repeat:
+           e. Build upper floors (y=3 upward) with nested repeat. The ground
+              floor already counts as the first floor, so this loop runs
+              floors - 1 times (NOT floors):
               - Wall at x, glass across middle (width - 2 cells), wall at x + width - 1
-           f. Build roof at final y: all walls across width
+           f. Build roof at final y (floors + 2): all walls across width. The
+              roof is a cap, not a floor.
            g. Move x by width + 1 for the next building (1-column gap)
 
         The solution uses a col variable to track horizontal position within each row,
         resetting it for each new row.
 
         Common mistakes:
+        - Off-by-one on the floor count: drawing floors upper floors instead of
+          floors - 1. randomNumFloors() is the TOTAL number of floors including
+          the ground floor; the roof on top is not a floor. A building with
+          floors=N is N+1 rows tall (ground + (N-1) upper + roof).
+        - Drawing two cells on the same square now raises a logic error
+          ("The builders are stuck. There's already a <type> at ..."). Usually
+          caused by not advancing the building's left column between buildings,
+          or by overlapping rows.
+        - Using width / 2 instead of (width - 1) / 2 for the entrance column —
+          width / 2 is fractional for odd widths and raises a "must use whole
+          numbers" logic error.
         - Not resetting y to 3 for each building
         - Forgetting the 1-column gap between buildings (x += width + 1, not x += width)
         - Wrong entrance position — must be centered using (width - 1) / 2

--- a/curriculum/src/exercises/cityscape-skyline/metadata.json
+++ b/curriculum/src/exercises/cityscape-skyline/metadata.json
@@ -3,8 +3,28 @@
   "levelId": "functions-that-return-things",
   "hints": [
     {
-      "question": "This is hard!",
-      "answer": "It is a challenge! Break it down. One step at a time. Get the first scenario passing, then the second, etc."
+      "question": "Where do I start with such a big exercise?",
+      "answer": "Break it down. The outer shape is one loop per building. Inside that loop, you draw three things in turn: the ground floor (with the entrance), the upper floors (just walls and glass), and the flat roof. Get the first scenario passing for a single building before worrying about multiple buildings."
+    },
+    {
+      "question": "How do I know what each building should look like?",
+      "answer": "Call `randomWidth()` and `randomNumFloors()` once at the start of each building's iteration and store both in local variables. Calling them again gives you the *next* building's values, so don't call them again inside the rows."
+    },
+    {
+      "question": "How do I track where the next building goes?",
+      "answer": "Keep a single variable for the current building's left-hand column. Start it at the spec's left gap. After you've finished a building, advance it by that building's width plus the gap between buildings. That one variable is all the horizontal positioning state you need."
+    },
+    {
+      "question": "How do I lay out the ground floor with the entrance in the middle?",
+      "answer": "Walk across the building one column at a time. The first and last columns are walls; everything in between is glass; one middle column is the entrance. The entrance's column is derived from the building's left edge and its width."
+    },
+    {
+      "question": "How do I draw the upper floors and the roof?",
+      "answer": "Each upper floor is the same pattern as the ground floor without the entrance: walls at the sides, glass in between. Repeat that `floors` times, stacking upward in `y`. The roof is then one solid row of walls spanning the full width on top."
+    },
+    {
+      "question": "My second building draws on top of the first one. What's wrong?",
+      "answer": "You're probably not advancing your column tracker between buildings. After drawing each building, increase it by `width + gap` before the next iteration starts. If you forget, every building draws from the same left edge."
     }
   ]
 }

--- a/curriculum/src/exercises/cityscape-skyline/metadata.json
+++ b/curriculum/src/exercises/cityscape-skyline/metadata.json
@@ -20,11 +20,11 @@
     },
     {
       "question": "How do I draw the upper floors and the roof?",
-      "answer": "Each upper floor is the same pattern as the ground floor without the entrance: walls at the sides, glass in between. Repeat that `floors` times, stacking upward in `y`. The roof is then one solid row of walls spanning the full width on top."
+      "answer": "Each upper floor is the same pattern as the ground floor without the entrance: walls at the sides, glass in between. Remember the ground floor already counts as one of the floors, so you only stack the remaining ones above it, climbing in `y`. The roof is then one solid row of walls spanning the full width on top, and isn't counted as a floor."
     },
     {
-      "question": "My second building draws on top of the first one. What's wrong?",
-      "answer": "You're probably not advancing your column tracker between buildings. After drawing each building, increase it by `width + gap` before the next iteration starts. If you forget, every building draws from the same left edge."
+      "question": "My second building errors with \"the builders are stuck, there's already a wall here\". What's wrong?",
+      "answer": "Your second building is trying to build on top of the first one, because you're not advancing your column tracker between buildings. After drawing each building, increase it by `width + gap` before the next iteration starts. If you forget, every building starts from the same left edge and collides with the one before it."
     }
   ]
 }

--- a/curriculum/src/exercises/cityscape-skyline/scenarios.ts
+++ b/curriculum/src/exercises/cityscape-skyline/scenarios.ts
@@ -1,4 +1,5 @@
 import type { Task, VisualScenario } from "../types";
+import { FLOORS_SEED_OFFSET } from "../../exercise-categories/cityscape/CityScapeExercise";
 import type CityScapeSkylineExercise from "./Exercise";
 
 export const tasks = [
@@ -25,13 +26,16 @@ function mulberry32(seed: number): () => number {
 }
 
 function getExpectedBuildings(numBuildings: number, seed: number): { width: number; floors: number }[] {
-  const rng = mulberry32(seed);
+  // Width and floors draw from independent streams (mirroring CityScapeExercise),
+  // so the expected values don't depend on the order the student calls the helpers.
+  const widthRng = mulberry32(seed);
+  const floorsRng = mulberry32(seed ^ FLOORS_SEED_OFFSET);
   const buildings: { width: number; floors: number }[] = [];
   for (let i = 0; i < numBuildings; i++) {
     // randomWidth: Math.floor(rng() * 3) * 2 + 3 gives 3, 5, or 7
-    const width = Math.floor(rng() * 3) * 2 + 3;
+    const width = Math.floor(widthRng() * 3) * 2 + 3;
     // randomNumFloors: Math.floor(rng() * 12) + 1 gives 1-12
-    const floors = Math.floor(rng() * 12) + 1;
+    const floors = Math.floor(floorsRng() * 12) + 1;
     buildings.push({ width, floors });
   }
   return buildings;
@@ -42,7 +46,7 @@ function skylineExpectations(exercise: CityScapeSkylineExercise, numBuildings: n
   const expects = [];
 
   // Check total cell count
-  const expectedTotal = expectedBuildings.reduce((sum, b) => sum + (b.floors + 2) * b.width, 0);
+  const expectedTotal = expectedBuildings.reduce((sum, b) => sum + (b.floors + 1) * b.width, 0);
   expects.push({
     pass: exercise.totalCells() === expectedTotal,
     errorHtml: `Expected ${expectedTotal} total cells but found ${exercise.totalCells()}.`
@@ -53,27 +57,31 @@ function skylineExpectations(exercise: CityScapeSkylineExercise, numBuildings: n
   for (let b = 0; b < numBuildings; b++) {
     const { width, floors } = expectedBuildings[b];
     const entranceOffset = (width - 1) / 2;
-    const roofY = floors + 3;
+    const roofY = floors + 2;
 
     // Ground floor: centered entrance
     expects.push({
       pass: exercise.hasCellAt(x + entranceOffset, 2, "entrance"),
-      errorHtml: `Building ${b + 1}: Expected an entrance at (${x + entranceOffset}, 2).`
+      errorHtml: `Building ${b + 1}: the entrance isn't in the right place.`
     });
 
     // Ground floor: walls at edges
     expects.push({
       pass: exercise.hasCellAt(x, 2, "wall") && exercise.hasCellAt(x + width - 1, 2, "wall"),
-      errorHtml: `Building ${b + 1}: Expected walls at (${x}, 2) and (${x + width - 1}, 2).`
+      errorHtml: `Building ${b + 1}: the ground-floor side walls aren't right.`
     });
 
-    // Roof: all walls
+    // Roof: all walls across the full width
+    let roofComplete = true;
     for (let c = 0; c < width; c++) {
-      expects.push({
-        pass: exercise.hasCellAt(x + c, roofY, "wall"),
-        errorHtml: `Building ${b + 1}: Expected a wall on the roof at (${x + c}, ${roofY}).`
-      });
+      if (!exercise.hasCellAt(x + c, roofY, "wall")) {
+        roofComplete = false;
+      }
     }
+    expects.push({
+      pass: roofComplete,
+      errorHtml: `Building ${b + 1}: the roof isn't complete.`
+    });
 
     x += width + 1;
   }

--- a/curriculum/src/exercises/cityscape-skyline/solution.javascript
+++ b/curriculum/src/exercises/cityscape-skyline/solution.javascript
@@ -21,7 +21,7 @@ repeat(buildings) {
   buildWall(x + width - 1, 2)
 
   let y = 3
-  repeat(floors) {
+  repeat(floors - 1) {
     buildWall(x, y)
     col = x + 1
     repeat(width - 2) {

--- a/curriculum/src/exercises/cityscape-skyline/solution.jiki
+++ b/curriculum/src/exercises/cityscape-skyline/solution.jiki
@@ -26,7 +26,7 @@ repeat buildings times do
   build_wall(x + width - 1, 2)
 
   change y to 3
-  repeat floors times do
+  repeat floors - 1 times do
     build_wall(x, y)
     change col to x + 1
     repeat width - 2 times do

--- a/curriculum/src/exercises/cityscape-skyline/solution.py
+++ b/curriculum/src/exercises/cityscape-skyline/solution.py
@@ -19,7 +19,7 @@ repeat(buildings):
     build_wall(x + width - 1, 2)
 
     y = 3
-    repeat(floors):
+    repeat(floors - 1):
         build_wall(x, y)
         col = x + 1
         repeat(width - 2):


### PR DESCRIPTION
## Summary

Evolves the **Skyline** exercise. Started as a progressive-hints rewrite, then expanded to fix four bugs surfaced in forum reports plus the related UI polish.

### Hints
Replaced the single placeholder hint with six progressive hints (decompose → when to call the random helpers → column tracking → ground-floor layout → upper floors + roof → debugging building overlap).

### Bug fixes (from forum reports)

- **Crash on fractional coordinates.** `buildEntrance(cx + w/2, 2)` with an odd width produced an id like `cell-4.5-2`, and `querySelectorAll("#cell-4.5-2")` threw a raw JS `SyntaxError`, killing the run. `buildCell` now returns a friendly logic error naming the offending argument ("You must use whole numbers for `x` and `y`…").
- **Off-by-one floor count.** The roof was counted as a floor, so `randomNumFloors() == N` drew `N+1` floors, contradicting the worked example in the instructions. Aligned both solutions and the test to the prose: the ground floor is floor 1, then `floors - 1` upper floors, with the roof as a cap on top.
- **Call-order coupling in the RNG.** `randomWidth()` and `randomNumFloors()` drew from a single shared PRNG stream, so results depended on the order/interleaving of calls. This caused the "swap the order and it works" report and the "expected 63 cells, not divisible by width 5" report (the student's displayed width differed from the test's expected width). Each helper now draws from its own seed-derived stream (`seed` for width, `seed ^ FLOORS_SEED_OFFSET` for floors); the test's reconstruction mirrors this. Call order and interleaving no longer matter.
- **Silent overdraw.** Drawing two cells on one square silently stacked a second element with a duplicate id (the "buildGlass shows an entrance" confusion — the entrance was painted over the glass). `buildCell` now balks with a logic error: "The builders are stuck. There's already a `<type>` at the coordinates `(x, y)` so they can't build here!"

### Feedback & UI polish

- Softened scenario `errorHtml` to name the building and feature ("Building 2: the entrance isn't in the right place.") instead of leaking exact coordinates; consolidated the per-column roof check into a single message.
- Added `white-space: nowrap` to inline `code` in test-feedback messages and the error tooltip so values like `(2, 2)` don't wrap mid-token.

### Files
- `curriculum/src/exercise-categories/cityscape/CityScapeExercise.ts` — integer guard, overdraw guard, independent RNG streams, `FLOORS_SEED_OFFSET`
- `curriculum/src/exercises/cityscape-skyline/scenarios.ts` — off-by-one, decoupled reconstruction, softened/consolidated error messages
- `curriculum/src/exercises/cityscape-skyline/solution.{javascript,jiki,py}` — `repeat(floors - 1)` for upper floors
- `app/components/coding-exercise/CodingExercise.module.css` and `.../end-line-information/informationTooltip.module.css` — inline-code nowrap

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test all-exercises` — 100/100, stable across multiple fresh-seed runs
- [ ] In-app: paste `buildWall(2, 2)` then `buildGlass(2, 2)` and confirm the overdraw logic error renders with `(2, 2)` un-wrapped
- [ ] In-app: submit a wrong build and confirm scenario feedback names the building/feature without coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)