### PR TITLE
Lock un-unlocked exercises on concepts page

### DIFF
--- a/app/components/concepts/ConceptLeafView.tsx
+++ b/app/components/concepts/ConceptLeafView.tsx
@@ -21,7 +21,7 @@ interface ConceptLeafViewProps {
   relatedProjects: ProjectInfo[];
   videoData: VideoSource[] | null;
   isConceptUnlocked: (slug: string) => boolean;
-  getExerciseStatus: (slug: string) => LessonStatus | "locked";
+  getExerciseStatus: (slug: string) => LessonStatus;
   getProjectStatus: (slug: string) => ProjectStatus | "locked";
   isAuthenticated: boolean;
 }

--- a/app/components/concepts/ConceptSidebar.tsx
+++ b/app/components/concepts/ConceptSidebar.tsx
@@ -15,7 +15,7 @@ interface ConceptSidebarProps {
   relatedProjects: ProjectInfo[];
   videoData: VideoSource[] | null;
   isConceptUnlocked: (slug: string) => boolean;
-  getExerciseStatus: (slug: string) => LessonStatus | "locked";
+  getExerciseStatus: (slug: string) => LessonStatus;
   getProjectStatus: (slug: string) => ProjectStatus | "locked";
   isAuthenticated: boolean;
 }

--- a/app/components/concepts/RelatedExercises.tsx
+++ b/app/components/concepts/RelatedExercises.tsx
@@ -10,7 +10,7 @@ interface ExerciseItem {
 
 interface RelatedExercisesProps {
   exercises: ExerciseItem[];
-  getStatus: (slug: string) => LessonStatus | "locked";
+  getStatus: (slug: string) => LessonStatus;
 }
 
 export function RelatedExercises({ exercises, getStatus }: RelatedExercisesProps) {
@@ -31,7 +31,7 @@ export function RelatedExercises({ exercises, getStatus }: RelatedExercisesProps
   );
 }
 
-function ExerciseItem({ exercise, status }: { exercise: ExerciseItem; status: LessonStatus | "locked" }) {
+function ExerciseItem({ exercise, status }: { exercise: ExerciseItem; status: LessonStatus }) {
   const stateClass = statusToClass(status);
   const className = `${styles.item} ${stateClass}`;
 
@@ -52,7 +52,7 @@ function ExerciseItem({ exercise, status }: { exercise: ExerciseItem; status: Le
   );
 }
 
-function statusToClass(status: LessonStatus | "locked"): string {
+function statusToClass(status: LessonStatus): string {
   switch (status) {
     case "completed":
       return styles.completed;

--- a/app/components/concepts/lib/useConceptDetailData.ts
+++ b/app/components/concepts/lib/useConceptDetailData.ts
@@ -194,7 +194,7 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
     if (!isAuthenticated) {
       return "locked";
     }
-    return exerciseStatuses[exerciseSlug] ?? "not_started";
+    return exerciseStatuses[exerciseSlug] ?? "locked";
   };
 
   const getProjectStatus = (projectSlug: string): ProjectStatus | "locked" => {

--- a/app/components/concepts/lib/useConceptDetailData.ts
+++ b/app/components/concepts/lib/useConceptDetailData.ts
@@ -28,7 +28,7 @@ interface ConceptDetailData {
   error: string | null;
   isAuthenticated: boolean;
   isConceptUnlocked: (slug: string) => boolean;
-  getExerciseStatus: (slug: string) => LessonStatus | "locked";
+  getExerciseStatus: (slug: string) => LessonStatus;
   getProjectStatus: (slug: string) => ProjectStatus | "locked";
 }
 
@@ -190,7 +190,7 @@ export function useConceptDetailData(slug: string): ConceptDetailData {
 
   const isConceptUnlocked = (conceptSlug: string) => !isAuthenticated || unlockedConceptSlugs.has(conceptSlug);
 
-  const getExerciseStatus = (exerciseSlug: string): LessonStatus | "locked" => {
+  const getExerciseStatus = (exerciseSlug: string): LessonStatus => {
     if (!isAuthenticated) {
       return "locked";
     }

--- a/app/components/dashboard/exercise-path/hooks/useLevels.ts
+++ b/app/components/dashboard/exercise-path/hooks/useLevels.ts
@@ -43,24 +43,9 @@ export function filterToPublishedLevels(
 
 export function buildLevelSections(levels: LevelWithProgress[]): LevelSectionData[] {
   return levels.map((level, levelIndex): LevelSectionData => {
-    const lessons: LessonDisplayData[] = level.lessons.map((lesson, lessonIndex) => {
-      let locked: boolean;
-      switch (lesson.status) {
-        case "completed":
-        case "started":
-          locked = false;
-          break;
-        case "not_started":
-          if (levelIndex === 0 && lessonIndex === 0) {
-            locked = false;
-          } else if (lessonIndex === 0) {
-            locked = levelIndex > 0 && levels[levelIndex - 1].status !== "completed";
-          } else {
-            locked = level.lessons[lessonIndex - 1].status !== "completed";
-          }
-          break;
-      }
-
+    // Lock state is driven by the API: a lesson is locked when the user hasn't
+    // unlocked it yet (absent from their progress, surfaced as a "locked" status).
+    const lessons: LessonDisplayData[] = level.lessons.map((lesson) => {
       return {
         lesson: {
           slug: lesson.slug,
@@ -70,7 +55,7 @@ export function buildLevelSections(levels: LevelWithProgress[]): LevelSectionDat
           walkthrough_video_data: lesson.walkthrough_video_data
         },
         completed: lesson.status === "completed",
-        locked,
+        locked: lesson.status === "locked",
         route: `/lesson/${lesson.slug}`,
         walkthroughVideoWatchedPercentage: lesson.walkthrough_video_watched_percentage
       };

--- a/app/lib/api/lesson-progress.ts
+++ b/app/lib/api/lesson-progress.ts
@@ -1,11 +1,11 @@
 import { fetchLevelsWithProgress } from "./levels";
 
-export type LessonStatus = "not_started" | "started" | "completed";
+export type LessonStatus = "not_started" | "started" | "completed" | "locked";
 
 /**
  * Fetch lesson statuses for a set of slugs.
  * Returns a record mapping slug to status.
- * Lessons not found in any level default to "not_started".
+ * Lessons the user hasn't unlocked (absent from their progress) are "locked".
  */
 export async function fetchLessonStatusesBySlugs(slugs: string[]): Promise<Record<string, LessonStatus>> {
   const levels = await fetchLevelsWithProgress();
@@ -20,10 +20,10 @@ export async function fetchLessonStatusesBySlugs(slugs: string[]): Promise<Recor
     }
   }
 
-  // Default missing slugs to not_started
+  // Any slug not present in a level the user has progressed into is locked.
   for (const slug of slugs) {
     if (!(slug in statuses)) {
-      statuses[slug] = "not_started";
+      statuses[slug] = "locked";
     }
   }
 

--- a/app/lib/api/levels.ts
+++ b/app/lib/api/levels.ts
@@ -43,12 +43,15 @@ export async function fetchLevelsWithProgress(): Promise<LevelWithProgress[]> {
     // Process lessons with their status
     const lessons: LessonWithProgress[] = level.lessons.map((lesson) => {
       const userLesson = lessonProgressMap.get(lesson.slug);
+      // The API returns a row for every completed/started lesson plus at most one
+      // not_started "frontier" lesson. Any lesson absent from the user's progress
+      // is one they haven't unlocked yet, so it's locked.
       return {
         slug: lesson.slug,
         title: lesson.title,
         type: lesson.type,
         description: lesson.description,
-        status: userLesson?.status || "not_started",
+        status: userLesson?.status || "locked",
         walkthrough_video_data: lesson.walkthrough_video_data,
         walkthrough_video_watched_percentage: userLesson?.walkthrough_video_watched_percentage ?? 0
       };

--- a/app/tests/unit/components/dashboard/exercise-path/buildLevelSections.test.ts
+++ b/app/tests/unit/components/dashboard/exercise-path/buildLevelSections.test.ts
@@ -25,96 +25,60 @@ function createLevel(overrides: Partial<LevelWithProgress> = {}): LevelWithProgr
 
 describe("buildLevelSections", () => {
   describe("locking logic", () => {
-    it("unlocks the first lesson of the first level when not_started", () => {
-      const levels = [createLevel()];
+    // Lock state mirrors the API status directly: the backend returns
+    // completed/started lessons plus at most one not_started "frontier" lesson,
+    // and anything the user hasn't unlocked is surfaced as "locked".
+    it("locks a lesson with locked status", () => {
+      const levels = [createLevel({ lessons: [createLesson({ status: "locked" })] })];
+      const result = buildLevelSections(levels);
+      expect(result[0].lessons[0].locked).toBe(true);
+    });
+
+    it("unlocks a not_started (frontier) lesson", () => {
+      const levels = [createLevel({ lessons: [createLesson({ status: "not_started" })] })];
       const result = buildLevelSections(levels);
       expect(result[0].lessons[0].locked).toBe(false);
     });
 
-    it("unlocks a started lesson regardless of position", () => {
-      const levels = [
-        createLevel({
-          slug: "level-one",
-          status: "not_started",
-          lessons: [
-            createLesson({ slug: "lesson-one", status: "not_started" }),
-            createLesson({ slug: "lesson-two", status: "started" })
-          ]
-        })
-      ];
+    it("unlocks a started lesson", () => {
+      const levels = [createLevel({ lessons: [createLesson({ status: "started" })] })];
       const result = buildLevelSections(levels);
-      expect(result[0].lessons[1].locked).toBe(false);
+      expect(result[0].lessons[0].locked).toBe(false);
     });
 
-    it("unlocks a completed lesson regardless of position", () => {
-      const levels = [
-        createLevel({
-          slug: "level-one",
-          status: "not_started",
-          lessons: [
-            createLesson({ slug: "lesson-one", status: "not_started" }),
-            createLesson({ slug: "lesson-two", status: "completed" })
-          ]
-        })
-      ];
+    it("unlocks a completed lesson", () => {
+      const levels = [createLevel({ lessons: [createLesson({ status: "completed" })] })];
       const result = buildLevelSections(levels);
-      expect(result[0].lessons[1].locked).toBe(false);
+      expect(result[0].lessons[0].locked).toBe(false);
     });
 
-    it("locks a not_started lesson when previous lesson is not completed", () => {
-      const levels = [
-        createLevel({
-          lessons: [
-            createLesson({ slug: "lesson-one", status: "started" }),
-            createLesson({ slug: "lesson-two", status: "not_started" })
-          ]
-        })
-      ];
-      const result = buildLevelSections(levels);
-      expect(result[0].lessons[1].locked).toBe(true);
-    });
-
-    it("unlocks a not_started lesson when previous lesson is completed", () => {
+    it("locks only the locked lessons within a level", () => {
       const levels = [
         createLevel({
           lessons: [
             createLesson({ slug: "lesson-one", status: "completed" }),
-            createLesson({ slug: "lesson-two", status: "not_started" })
+            createLesson({ slug: "lesson-two", status: "not_started" }),
+            createLesson({ slug: "lesson-three", status: "locked" })
           ]
         })
       ];
       const result = buildLevelSections(levels);
+      expect(result[0].lessons[0].locked).toBe(false);
       expect(result[0].lessons[1].locked).toBe(false);
+      expect(result[0].lessons[2].locked).toBe(true);
     });
 
-    it("locks first lesson of a new level when previous level is not completed", () => {
+    it("locks lessons in a not-yet-reached level", () => {
       const levels = [
         createLevel({ slug: "level-one", status: "started" }),
         createLevel({
           slug: "level-two",
           status: "not_started",
-          lessons: [createLesson({ slug: "lesson-three", status: "not_started" })]
+          lessons: [createLesson({ slug: "lesson-three", status: "locked" })]
         })
       ];
       const result = buildLevelSections(levels);
       expect(result[1].lessons[0].locked).toBe(true);
-    });
-
-    it("unlocks first lesson of a new level when previous level is completed", () => {
-      const levels = [
-        createLevel({
-          slug: "level-one",
-          status: "completed",
-          lessons: [createLesson({ slug: "lesson-one", status: "completed" })]
-        }),
-        createLevel({
-          slug: "level-two",
-          status: "not_started",
-          lessons: [createLesson({ slug: "lesson-two", status: "not_started" })]
-        })
-      ];
-      const result = buildLevelSections(levels);
-      expect(result[1].lessons[0].locked).toBe(false);
     });
   });
 

--- a/app/tests/unit/components/dashboard/exercise-path/buildLevelSections.test.ts
+++ b/app/tests/unit/components/dashboard/exercise-path/buildLevelSections.test.ts
@@ -130,11 +130,17 @@ describe("buildLevelSections", () => {
           slug: "level-two",
           status: "not_started",
           lessons: [createLesson({ slug: "lesson-one", status: "not_started" })]
+        }),
+        createLevel({
+          slug: "level-three",
+          status: "not_started",
+          lessons: [createLesson({ slug: "lesson-two", status: "locked" })]
         })
       ];
       const result = buildLevelSections(levels);
-      expect(result[0].isLocked).toBe(false); // no lessons -> false
-      expect(result[1].isLocked).toBe(false); // previous level completed -> unlocked
+      expect(result[0].isLocked).toBe(false); // empty lessons -> false
+      expect(result[1].isLocked).toBe(false); // first lesson not_started -> unlocked
+      expect(result[2].isLocked).toBe(true); // first lesson locked -> locked
     });
 
     it("maps ready_for_completion level status to started", () => {

--- a/app/types/levels.ts
+++ b/app/types/levels.ts
@@ -8,7 +8,7 @@ export interface LessonWithProgress {
   title: string;
   type: LessonType;
   description: string;
-  status: "not_started" | "started" | "completed";
+  status: "not_started" | "started" | "completed" | "locked";
   walkthrough_video_data: VideoSource[] | null;
   walkthrough_video_watched_percentage: number;
 }


### PR DESCRIPTION
## Problem

Reported in [Skip ahead via concepts](https://forum.jiki.io/t/skip-ahead-via-concepts/25): the **Related Exercises** on a concept page rendered as clickable links even when the user hadn't unlocked them, letting students jump straight into future lessons.

The exercises *looked* greyed out but were live `<Link>`s. Root cause: the lesson status data only encoded progress (`not_started` / `started` / `completed`) with no notion of "locked". Any un-reached exercise fell through to `not_started`, which renders as a clickable link. Related concepts and related projects were already gated correctly; exercises were the only section without an unlock source.

## Approach

The API now returns `completed`/`started` lessons plus at most one `not_started` "frontier" lesson; anything **absent** from the user's progress is locked. The frontend synthesises `"locked"` for absent lessons.

- `lib/api/levels.ts` — the levels/progress merge defaults absent lessons to `"locked"` (single place the "absent = locked" rule lives).
- `types/levels.ts` / `lib/api/lesson-progress.ts` — `LessonWithProgress.status` and `LessonStatus` gain `"locked"`. The raw `UserLesson` wire type keeps the three real values (the API never *sends* `"locked"`; it's synthesised).
- `lib/api/lesson-progress.ts` + `components/concepts/lib/useConceptDetailData.ts` — unknown slugs default to `"locked"`. **This is the actual bug fix** — un-reached related exercises now render as non-clickable locked spans.
- `components/dashboard/exercise-path/hooks/useLevels.ts` — `buildLevelSections` derives lock state straight from the API status instead of recomputing it positionally, making the backend the single source of truth.

It's also fail-closed: if a lesson is ever wrongly omitted, the failure mode is "wrongly locked", not "wrongly skippable".

## Notes

- **Unlocking animation is unaffected** — its target slug comes from backend `lesson_unlocked` events, not the positional logic removed here. The backend invariant to hold: the `lesson_unlocked` slug must equal the new `not_started` frontier returned by `/internal/user_levels`.
- This fixes the UI link only. Blocking `/lesson/{slug}` loaded directly by URL needs a guard on `Internal::LessonsController#show` in the api repo (separate change).

## Testing

- `pnpm typecheck`: clean
- Full unit + integration suite: 1677 tests pass (pre-commit hook)
- ESLint on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)