### PR TITLE
Handle failed/declined checkout returns gracefully

### DIFF
--- a/app/components/checkout/CheckoutReturnHandler.tsx
+++ b/app/components/checkout/CheckoutReturnHandler.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useEffect } from "react";
+import { CheckoutIncompleteError } from "@/lib/api/client";
 import { useAuthStore } from "@/lib/auth/authStore";
+import type { BillingInterval } from "@/lib/pricing";
 import { extractAndClearCheckoutSessionId } from "@/lib/subscriptions/verification";
 import { verifyCheckoutSession } from "@/lib/api/subscriptions";
+import { handleSubscribe } from "@/lib/subscriptions/handlers";
 import { reportError } from "@/lib/reportError";
 import {
   showPaymentConfirming,
@@ -11,6 +14,8 @@ import {
   showPaymentVerificationFailed,
   showWelcomeToPremium
 } from "@/lib/modal/app";
+
+const DEFAULT_DECLINE_MESSAGE = "Your last payment didn't go through. Please try again with a different card.";
 
 /**
  * Global handler for Stripe checkout returns
@@ -21,7 +26,7 @@ import {
  * Add this component to the app layout to handle checkout returns on any page.
  */
 export function CheckoutReturnHandler() {
-  const { refreshUser, hasCheckedAuth, isAuthenticated } = useAuthStore();
+  const { user, refreshUser, hasCheckedAuth, isAuthenticated } = useAuthStore();
 
   useEffect(() => {
     if (!hasCheckedAuth || !isAuthenticated) {
@@ -33,13 +38,37 @@ export function CheckoutReturnHandler() {
       return;
     }
 
+    // A failed payment — whether the session never completed (declined / abandoned /
+    // expired, surfaced as CheckoutIncompleteError) or completed and the first charge
+    // then failed (payment_state "failed") — is an expected outcome, not a bug. Reopen
+    // checkout in place with the decline shown and the original plan selected, without
+    // reporting it. The confirming modal stays up until handleSubscribe swaps in checkout.
+    const reopenCheckout = async (interval: BillingInterval, declineReason: string | null) => {
+      try {
+        await refreshUser();
+        await handleSubscribe({
+          interval,
+          userEmail: user?.email,
+          priorError: declineReason ?? DEFAULT_DECLINE_MESSAGE
+        });
+      } catch {
+        // handleSubscribe already toasted + logged; fall back to the failure modal so
+        // the confirming spinner doesn't hang.
+        showPaymentVerificationFailed();
+      }
+    };
+
     // Open the confirming modal immediately so there's no blank gap while
     // verifyCheckoutSession resolves.
     showPaymentConfirming();
 
     void verifyCheckoutSession(sessionId)
       .then((result) => {
-        if (result.payment_status === "paid") {
+        if (result.payment_state === "failed") {
+          void reopenCheckout(result.interval, result.decline_reason ?? null);
+          return;
+        }
+        if (result.payment_state === "paid") {
           showWelcomeToPremium();
         } else {
           showPaymentProcessing();
@@ -47,10 +76,14 @@ export function CheckoutReturnHandler() {
         void refreshUser();
       })
       .catch((error) => {
+        if (error instanceof CheckoutIncompleteError) {
+          void reopenCheckout(error.interval, error.declineReason);
+          return;
+        }
         reportError(error);
         showPaymentVerificationFailed();
       });
-  }, [hasCheckedAuth, isAuthenticated, refreshUser]);
+  }, [hasCheckedAuth, isAuthenticated, refreshUser, user]);
 
   return null;
 }

--- a/app/lib/api/client.ts
+++ b/app/lib/api/client.ts
@@ -5,6 +5,7 @@
  * Simple, type-safe API client for backend communication with session cookie support
  */
 
+import type { BillingInterval } from "@/lib/pricing";
 import { getApiUrl } from "./config";
 import { clearCriticalError, setCriticalError, useErrorHandlerStore } from "./errorHandlerStore";
 
@@ -56,6 +57,23 @@ export class RateLimitError extends ApiError {
   ) {
     super(429, statusText, data);
     this.name = "RateLimitError";
+  }
+}
+
+// Thrown by verifyCheckoutSession when the API reports `checkout_payment_incomplete`
+// — the Stripe checkout never completed (declined / abandoned / expired payment).
+// This is an expected outcome, not a bug, so callers surface it to the user (reopen
+// checkout) without reporting it to Sentry. `declineReason` is the customer-safe Stripe
+// reason when available, else null; `interval` is the plan they were buying.
+export class CheckoutIncompleteError extends ApiError {
+  constructor(
+    statusText: string,
+    data: unknown,
+    public declineReason: string | null,
+    public interval: BillingInterval
+  ) {
+    super(422, statusText, data);
+    this.name = "CheckoutIncompleteError";
   }
 }
 

--- a/app/lib/api/subscriptions.ts
+++ b/app/lib/api/subscriptions.ts
@@ -3,7 +3,7 @@
  * API functions for managing Stripe subscriptions
  */
 
-import { api } from "./client";
+import { ApiError, CheckoutIncompleteError, api } from "./client";
 import type {
   CheckoutSessionResponse,
   PortalSessionResponse,
@@ -49,10 +49,33 @@ export async function createPortalSession(): Promise<PortalSessionResponse> {
  * @returns Verification result with payment status and interval
  */
 export async function verifyCheckoutSession(sessionId: string): Promise<VerifyCheckoutResponse> {
-  const response = await api.post<VerifyCheckoutResponse>("/internal/subscriptions/verify_checkout", {
-    session_id: sessionId
-  });
-  return response.data;
+  try {
+    const response = await api.post<VerifyCheckoutResponse>("/internal/subscriptions/verify_checkout", {
+      session_id: sessionId
+    });
+    return response.data;
+  } catch (error) {
+    // A declined / abandoned / expired checkout (`checkout_payment_incomplete`) is an
+    // expected payment failure, not a bug — surface it as a typed error so callers can
+    // reopen checkout without reporting to Sentry. Everything else (invalid_session,
+    // unauthorized, verification_failed, 5xx, …) propagates unchanged.
+    if (error instanceof ApiError) {
+      const body = error.data as
+        | { error?: { type?: string; decline_reason?: string | null; interval?: BillingInterval } }
+        | undefined;
+      if (body?.error?.type === "checkout_payment_incomplete") {
+        // `interval` is absent only for the pre-deploy migration tail; default it so the
+        // retry can still reopen with a plan selected.
+        throw new CheckoutIncompleteError(
+          error.statusText,
+          error.data,
+          body.error.decline_reason ?? null,
+          body.error.interval ?? "annual"
+        );
+      }
+    }
+    throw error;
+  }
 }
 
 /**

--- a/app/lib/modal/app.ts
+++ b/app/lib/modal/app.ts
@@ -69,6 +69,7 @@ export const showSubscriptionSuccess = (props: {
 export const showSubscriptionCheckout = (props: {
   clientSecret: string;
   selectedTier: MembershipTier;
+  priorError?: string | null;
   onCancel?: () => void;
   onSuccess?: () => void;
 }) => {

--- a/app/lib/modal/modals/SubscriptionCheckoutModal.tsx
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal.tsx
@@ -9,10 +9,16 @@ import { ModalBody } from "./SubscriptionCheckoutModal/ModalBody";
 interface SubscriptionCheckoutModalProps {
   clientSecret: string;
   selectedTier: MembershipTier;
+  priorError?: string | null;
   onCancel?: () => void;
 }
 
-export function SubscriptionCheckoutModal({ clientSecret, selectedTier, onCancel }: SubscriptionCheckoutModalProps) {
+export function SubscriptionCheckoutModal({
+  clientSecret,
+  selectedTier,
+  priorError,
+  onCancel
+}: SubscriptionCheckoutModalProps) {
   const handleCancel = () => {
     onCancel?.();
     hideModal();
@@ -60,7 +66,7 @@ export function SubscriptionCheckoutModal({ clientSecret, selectedTier, onCancel
 
   return (
     <CheckoutProvider stripe={stripePromise} options={options}>
-      <ModalBody selectedTier={selectedTier} onCancel={handleCancel} />
+      <ModalBody selectedTier={selectedTier} priorError={priorError} onCancel={handleCancel} />
     </CheckoutProvider>
   );
 }

--- a/app/lib/modal/modals/SubscriptionCheckoutModal/ModalBody.tsx
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal/ModalBody.tsx
@@ -7,7 +7,15 @@ import { useCheckout } from "@stripe/react-stripe-js/checkout";
 import { PaymentForm } from "./PaymentForm";
 import styles from "../SubscriptionCheckoutModal.module.css";
 
-export function ModalBody({ selectedTier, onCancel }: { selectedTier: MembershipTier; onCancel: () => void }) {
+export function ModalBody({
+  selectedTier,
+  priorError,
+  onCancel
+}: {
+  selectedTier: MembershipTier;
+  priorError?: string | null;
+  onCancel: () => void;
+}) {
   const checkoutState = useCheckout();
   const tierInfo = PRICING_TIERS[selectedTier];
 
@@ -44,7 +52,7 @@ export function ModalBody({ selectedTier, onCancel }: { selectedTier: Membership
         </div>
       </div>
 
-      <PaymentForm />
+      <PaymentForm priorError={priorError} />
     </div>
   );
 }

--- a/app/lib/modal/modals/SubscriptionCheckoutModal/PaymentForm.tsx
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal/PaymentForm.tsx
@@ -7,8 +7,10 @@ import { PaymentElement, useCheckout } from "@stripe/react-stripe-js/checkout";
 import { useEffect, useRef, useState } from "react";
 import styles from "../SubscriptionCheckoutModal.module.css";
 
-export function PaymentForm() {
-  const [message, setMessage] = useState<string | null>(null);
+export function PaymentForm({ priorError }: { priorError?: string | null }) {
+  // Seed the error banner with a previous attempt's failure (e.g. a declined retry);
+  // it clears on the next submit like any other payment error.
+  const [message, setMessage] = useState<string | null>(priorError ?? null);
   const [isLoading, setIsLoading] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
 

--- a/app/lib/subscriptions/handlers.ts
+++ b/app/lib/subscriptions/handlers.ts
@@ -21,6 +21,7 @@ export interface SubscribeParams {
   interval: BillingInterval;
   userEmail?: string;
   returnPath?: string; // Optional return path, defaults to current location
+  priorError?: string | null; // A previous attempt's failure, shown in the checkout error banner
 }
 
 export interface CheckoutCancelParams {
@@ -39,7 +40,7 @@ export interface DeleteStripeHistoryParams {
 }
 
 // Core subscription handlers
-export async function handleSubscribe({ interval, userEmail, returnPath }: SubscribeParams) {
+export async function handleSubscribe({ interval, userEmail, returnPath, priorError }: SubscribeParams) {
   try {
     const returnUrl = createCheckoutReturnUrl(returnPath || window.location.pathname);
     const response = await createCheckoutSession(interval, returnUrl, userEmail);
@@ -51,6 +52,7 @@ export async function handleSubscribe({ interval, userEmail, returnPath }: Subsc
     showSubscriptionCheckout({
       clientSecret: response.client_secret,
       selectedTier: "premium",
+      priorError,
       onCancel: () => {
         // Modal cancelled - no need to do anything as modal state is managed internally
       }

--- a/app/tests/integration/settings/payment-verification.test.tsx
+++ b/app/tests/integration/settings/payment-verification.test.tsx
@@ -6,8 +6,10 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { CheckoutReturnHandler } from "@/components/checkout/CheckoutReturnHandler";
+import { CheckoutIncompleteError } from "@/lib/api/client";
 import { extractAndClearCheckoutSessionId } from "@/lib/subscriptions/verification";
 import { verifyCheckoutSession } from "@/lib/api/subscriptions";
+import { handleSubscribe } from "@/lib/subscriptions/handlers";
 import {
   showWelcomeToPremium,
   showPaymentProcessing,
@@ -18,6 +20,11 @@ import {
 // Mock the API call
 jest.mock("@/lib/api/subscriptions", () => ({
   verifyCheckoutSession: jest.fn()
+}));
+
+// Mock the subscribe handler (used to reopen checkout on a failed return)
+jest.mock("@/lib/subscriptions/handlers", () => ({
+  handleSubscribe: jest.fn().mockResolvedValue(undefined)
 }));
 
 // Mock the verification utilities
@@ -37,6 +44,7 @@ const mockExtractAndClearCheckoutSessionId = extractAndClearCheckoutSessionId as
   typeof extractAndClearCheckoutSessionId
 >;
 const mockVerifyCheckoutSession = verifyCheckoutSession as jest.MockedFunction<typeof verifyCheckoutSession>;
+const mockHandleSubscribe = handleSubscribe as jest.MockedFunction<typeof handleSubscribe>;
 const mockShowWelcomeToPremium = showWelcomeToPremium as jest.MockedFunction<typeof showWelcomeToPremium>;
 const mockShowPaymentProcessing = showPaymentProcessing as jest.MockedFunction<typeof showPaymentProcessing>;
 const mockShowPaymentConfirming = showPaymentConfirming as jest.MockedFunction<typeof showPaymentConfirming>;
@@ -48,6 +56,7 @@ const mockShowPaymentVerificationFailed = showPaymentVerificationFailed as jest.
 const mockRefreshUser = jest.fn().mockResolvedValue(undefined);
 jest.mock("@/lib/auth/authStore", () => ({
   useAuthStore: () => ({
+    user: { email: "test@example.com" },
     refreshUser: mockRefreshUser,
     hasCheckedAuth: true,
     isAuthenticated: true
@@ -80,6 +89,7 @@ describe("Payment Verification Integration", () => {
       success: true,
       interval: "monthly",
       payment_status: "paid",
+      payment_state: "paid",
       subscription_status: "active"
     });
 
@@ -94,6 +104,7 @@ describe("Payment Verification Integration", () => {
       success: true,
       interval: "monthly",
       payment_status: "paid",
+      payment_state: "paid",
       subscription_status: "active"
     });
 
@@ -113,6 +124,7 @@ describe("Payment Verification Integration", () => {
       success: true,
       interval: "monthly",
       payment_status: "unpaid",
+      payment_state: "processing",
       subscription_status: "incomplete"
     });
 
@@ -139,6 +151,45 @@ describe("Payment Verification Integration", () => {
     expect(mockShowPaymentProcessing).not.toHaveBeenCalled();
     expect(mockShowWelcomeToPremium).not.toHaveBeenCalled();
     expect(mockRefreshUser).not.toHaveBeenCalled();
+  });
+
+  it("reopens checkout (not the failure modal) for a failed payment, carrying the decline + interval", async () => {
+    mockExtractAndClearCheckoutSessionId.mockReturnValue("cs_test_failed");
+    mockVerifyCheckoutSession.mockResolvedValue({
+      success: true,
+      interval: "annual",
+      payment_status: "unpaid",
+      payment_state: "failed",
+      subscription_status: "incomplete",
+      decline_reason: "Your card has insufficient funds."
+    });
+
+    render(<CheckoutReturnHandler />);
+
+    await waitFor(() => {
+      expect(mockHandleSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ interval: "annual", priorError: "Your card has insufficient funds." })
+      );
+    });
+    expect(mockShowPaymentVerificationFailed).not.toHaveBeenCalled();
+    expect(mockShowWelcomeToPremium).not.toHaveBeenCalled();
+    expect(mockShowPaymentProcessing).not.toHaveBeenCalled();
+  });
+
+  it("reopens checkout for a declined session (CheckoutIncompleteError) without reporting", async () => {
+    mockExtractAndClearCheckoutSessionId.mockReturnValue("cs_test_incomplete");
+    mockVerifyCheckoutSession.mockRejectedValue(
+      new CheckoutIncompleteError("Unprocessable Entity", {}, "Your card was declined.", "monthly")
+    );
+
+    render(<CheckoutReturnHandler />);
+
+    await waitFor(() => {
+      expect(mockHandleSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ interval: "monthly", priorError: "Your card was declined." })
+      );
+    });
+    expect(mockShowPaymentVerificationFailed).not.toHaveBeenCalled();
   });
 
   it("does nothing when no checkout_return param present", () => {

--- a/app/tests/unit/lib/api/subscriptions.test.ts
+++ b/app/tests/unit/lib/api/subscriptions.test.ts
@@ -3,14 +3,14 @@
  */
 
 import { createCheckoutSession, createPortalSession, verifyCheckoutSession } from "@/lib/api/subscriptions";
-import { api } from "@/lib/api/client";
+import { ApiError, CheckoutIncompleteError, api } from "@/lib/api/client";
 
-// Mock the API client
-jest.mock("@/lib/api/client", () => ({
-  api: {
-    post: jest.fn()
-  }
-}));
+// Mock only api.post; keep the real error classes so instanceof checks and
+// CheckoutIncompleteError construction in verifyCheckoutSession still work.
+jest.mock("@/lib/api/client", () => {
+  const actual = jest.requireActual("@/lib/api/client");
+  return { ...actual, api: { post: jest.fn() } };
+});
 
 const mockedApiPost = api.post as jest.MockedFunction<typeof api.post>;
 
@@ -107,5 +107,44 @@ describe("verifyCheckoutSession", () => {
     mockedApiPost.mockRejectedValue(new Error("Session not found"));
 
     await expect(verifyCheckoutSession("cs_test_invalid")).rejects.toThrow("Session not found");
+  });
+
+  it("throws CheckoutIncompleteError carrying the decline reason and interval for an incomplete payment", async () => {
+    mockedApiPost.mockRejectedValue(
+      new ApiError(422, "Unprocessable Entity", {
+        error: {
+          type: "checkout_payment_incomplete",
+          message: "Your payment wasn't completed. Please try again.",
+          decline_reason: "Your card has insufficient funds.",
+          interval: "monthly"
+        }
+      })
+    );
+
+    const error = await verifyCheckoutSession("cs_test_decline").catch((e) => e);
+    expect(error).toBeInstanceOf(CheckoutIncompleteError);
+    expect(error.declineReason).toBe("Your card has insufficient funds.");
+    expect(error.interval).toBe("monthly");
+  });
+
+  it("defaults the interval to annual and the reason to null when the API omits them", async () => {
+    mockedApiPost.mockRejectedValue(
+      new ApiError(422, "Unprocessable Entity", { error: { type: "checkout_payment_incomplete" } })
+    );
+
+    const error = await verifyCheckoutSession("cs_test_decline").catch((e) => e);
+    expect(error).toBeInstanceOf(CheckoutIncompleteError);
+    expect(error.declineReason).toBeNull();
+    expect(error.interval).toBe("annual");
+  });
+
+  it("rethrows a plain ApiError (not CheckoutIncompleteError) for a genuine invalid session", async () => {
+    mockedApiPost.mockRejectedValue(
+      new ApiError(422, "Unprocessable Entity", { error: { type: "invalid_session", message: "Invalid session" } })
+    );
+
+    const error = await verifyCheckoutSession("cs_test_invalid").catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).not.toBeInstanceOf(CheckoutIncompleteError);
   });
 });

--- a/app/types/subscription.ts
+++ b/app/types/subscription.ts
@@ -45,9 +45,20 @@ export interface ReactivateSubscriptionResponse {
   subscription_valid_until: string; // ISO 8601 date string
 }
 
+export type CheckoutPaymentState = "paid" | "processing" | "failed";
+
 export interface VerifyCheckoutResponse {
   success: boolean;
   interval: BillingInterval;
+  /** @deprecated raw Stripe value, kept during transition — branch on `payment_state` instead. */
   payment_status: "paid" | "unpaid";
+  // Derived server-side from the first invoice's PaymentIntent. Best-effort: falls back
+  // to "processing" (never "failed") when the PaymentIntent can't be read.
+  payment_state: CheckoutPaymentState;
   subscription_status: "active" | "incomplete";
+  // Customer-safe Stripe reason, only set when payment_state === "failed" (may still be null).
+  decline_reason?: string | null;
+  // Informational — the currency the session used. Currency is derived server-side from
+  // the user on checkout creation, so the FE doesn't echo this back.
+  currency?: string;
 }


### PR DESCRIPTION
Mirrors gikiUK/front-end#261 for Jiki. Pairs with the API changes in jiki-education/api#476.

## Summary
A returning checkout whose payment was declined/incomplete previously surfaced as a generic "we couldn't confirm your payment" verification error — paging Sentry and offering no recovery. That's an **expected payment failure**, not a bug.

Branch on the API's new `payment_state` and the typed `checkout_payment_incomplete` error:

- **paid** → welcome; **processing** → processing modal (unchanged).
- **failed** (200 `payment_state: "failed"`) / **incomplete** (422 `checkout_payment_incomplete`) → **reopen the checkout modal in place** (no redirect — Jiki's checkout is a global modal), seeding the decline into the **existing** "Payment failed" banner and preselecting the user's **original interval**. The confirming modal stays up until `handleSubscribe` swaps in the checkout modal, so there's no flash.
- Genuine errors (`invalid_session`, `unauthorized`, `verification_failed`, 5xx, network) **still report to Sentry**. Branch on `type`, not status code.

### Jiki-specific notes
- **User-scoped** (`/internal/subscriptions/...`), **no tier** (premium-only).
- **Currency stays server-side** — `checkout_session` derives it from `current_user.currency`, so the FE retries with `interval` only; the response's `currency` is kept as informational context, not echoed back.
- Simpler than Giki: the global modal system means **no redirect, no settings tab, no carry-over-spinner machinery** — `handleSubscribe` keeps the confirming modal up during session creation, then replaces it with checkout.

### Notable pieces
- `CheckoutIncompleteError` (typed 422 carrying `declineReason` + `interval`); `verifyCheckoutSession` catches the `ApiError` and rethrows it for `checkout_payment_incomplete`, else propagates.
- `priorError` threaded `handleSubscribe → showSubscriptionCheckout → SubscriptionCheckoutModal → ModalBody → PaymentForm`, seeding the existing `message` banner.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm run lint`
- [x] Unit: `verifyCheckoutSession` parsing (CheckoutIncompleteError + `interval`/`decline_reason`, migration-tail default, genuine-error passthrough)
- [x] Integration: `payment-verification.test.tsx` — paid/processing/verify-error modals, failed→reopen-checkout, declined(422)→reopen-checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)