### PR TITLE
Golf: roll through 29, hide answers in errors, audit golf-scenarios

### DIFF
--- a/curriculum/src/exercise-categories/golf/GolfExercise.ts
+++ b/curriculum/src/exercise-categories/golf/GolfExercise.ts
@@ -13,6 +13,7 @@ export default class GolfExercise extends VisualExercise {
   ballY: number = 75;
   fireworksFired: boolean = false;
   shotLength: number = 0;
+  visitedPositions: number[] = [];
   protected moveDuration = 15;
 
   constructor() {
@@ -46,6 +47,7 @@ export default class GolfExercise extends VisualExercise {
 
   rollRight(executionCtx: ExecutionContext) {
     this.ballX += 1;
+    this.visitedPositions.push(this.ballX);
     this.addAnimation({
       targets: `#${this.view.id} .ball`,
       offset: executionCtx.getCurrentTimeInMs(),
@@ -62,6 +64,7 @@ export default class GolfExercise extends VisualExercise {
       return executionCtx.logicError("x must be a number");
     }
     this.ballX = x.value;
+    this.visitedPositions.push(this.ballX);
     if (y !== undefined) {
       if (!isNumber(y)) {
         return executionCtx.logicError("y must be a number");

--- a/curriculum/src/exercises/golf-rolling-ball-loop/scenarios.ts
+++ b/curriculum/src/exercises/golf-rolling-ball-loop/scenarios.ts
@@ -27,10 +27,16 @@ export const scenarios: VisualScenario[] = [
 
     expectations(exercise) {
       const ex = exercise as GolfRollingBallLoopExercise;
+      const requiredPositions = [29, 40, 60, 88];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
           pass: ex.ballX === 88,
           errorHtml: `The ball rolled to ${ex.ballX}, which isn't 60 from where it started.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, starting from 29.`
         }
       ];
     },

--- a/curriculum/src/exercises/golf-rolling-ball-state/Exercise.ts
+++ b/curriculum/src/exercises/golf-rolling-ball-state/Exercise.ts
@@ -7,8 +7,6 @@ export default class GolfRollingBallStateExercise extends GolfExercise {
     return metadata.slug;
   }
 
-  public visitedPositions: number[] = [];
-
   public availableFunctions: ExternalFunction[] = [
     {
       name: "move_to",

--- a/curriculum/src/exercises/golf-scenarios/index.ts
+++ b/curriculum/src/exercises/golf-scenarios/index.ts
@@ -17,7 +17,7 @@ const functions: FunctionInfo[] = [
     signature: "getShotLength()",
     description: "Returns the **length of the shot** — how many units the ball travels to the right.",
     examples: ["let shotLength = getShotLength()"],
-    category: "Game"
+    category: "Information"
   }
 ];
 
@@ -28,7 +28,7 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["scenarios", "using-functions-with-inputs"]
+  conceptSlugs: ["scenarios", "using-functions-with-inputs", "using-functions-with-return-values"]
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/golf-scenarios/instructions/en.md
+++ b/curriculum/src/exercises/golf-scenarios/instructions/en.md
@@ -9,4 +9,6 @@ In each scenario, you need to roll the ball a different amount depending on how 
 
 You then need to roll the ball to that spot using the `rollTo(x)` function. As before, you need to roll it one step at a time, not just jump it to the end.
 
+As before, **the ball starts on the tee at position 28.**
+
 On this exercise, try and think through each step carefully and take things one step at a time. Good luck!

--- a/curriculum/src/exercises/golf-scenarios/instructions/en.md
+++ b/curriculum/src/exercises/golf-scenarios/instructions/en.md
@@ -3,12 +3,16 @@ title: "Golf: Scenarios"
 description: "Roll a ball to the correct spot in different scenarios."
 ---
 
-Welcome back to the golf course. In this exercise, you're going to build on the previous exercises but with a new twist.
+Welcome to your first exercise with scenarios.
 
-In each scenario, you need to roll the ball a different amount depending on how far the golfer has hit it. You can get that length by using the `getShotLength()` function - it'll give you a different number for each Scenario.
+We're back at the golf course. In this exercise, you're going to build on the previous exercises but with a new twist. As before you need to roll the ball using the `rollTo(x)` function, moving **one step at a time**, not just jumping it to the end. The ball **starts on the tee at position 28.**
 
-You then need to roll the ball to that spot using the `rollTo(x)` function. As before, you need to roll it one step at a time, not just jump it to the end.
+What's new is that rather than moving a fixed amount, we're going to move a different amount depending on how far the golfer has hit the ball. To get the distance the golfer has hit the ball, you can use the `getShotLength()` function which returns a number.
 
-As before, **the ball starts on the tee at position 28.**
+### Scenarios
 
-On this exercise, try and think through each step carefully and take things one step at a time. Good luck!
+On the left, you'll notice four grey dots for the four different scenarios. **Clicking on each dot** shows you a different scenario - where `getShotLength()` will return a different number. If you click `"Run Code"`, you'll see they all go red.
+
+Your job is to write one program that works for all the different possible values that `getShotLength()` might return.
+
+Good luck and have fun!

--- a/curriculum/src/exercises/golf-scenarios/llm-metadata.ts
+++ b/curriculum/src/exercises/golf-scenarios/llm-metadata.ts
@@ -19,8 +19,9 @@ export const llmMetadata: LLMMetadata = {
       description: `
         Students need to:
         1. Call getShotLength() and store the result in a variable
-        2. Track x position starting at 29
-        3. Use a loop (shotLength + 1 times) to roll the ball right
+        2. Track x position starting at 28 (the tee)
+        3. Use a loop (shotLength times) to roll the ball right, incrementing x
+           before each rollTo so the ball passes through every position (29, 30, ...)
 
         Key functions:
         - rollTo(x): rolls the ball to position x

--- a/curriculum/src/exercises/golf-scenarios/metadata.json
+++ b/curriculum/src/exercises/golf-scenarios/metadata.json
@@ -4,7 +4,11 @@
   "hints": [
     {
       "question": "I'm not sure where to start",
-      "answer": "Firstly, repeat what you did previously. Roll the ball from its starting position to however far the `getShotLength()` function returns. Just remember to roll one step at a time. Once you've done that, think about how to animate it down."
+      "answer": "This is just like the previous golf exercise, where you rolled the ball a fixed number of steps. The only difference is that the number of steps is no longer a fixed value — it comes from `getShotLength()` instead. Wherever you used a number before, you can use the result of a function instead."
+    },
+    {
+      "question": "My ball stops one step short (or goes one too far)",
+      "answer": "Think carefully about your starting position and how many times you roll. The ball sits on the tee at 28, so its first roll should take it to 29. Count the steps from there to where it needs to end up."
     }
   ]
 }

--- a/curriculum/src/exercises/golf-scenarios/scenarios.ts
+++ b/curriculum/src/exercises/golf-scenarios/scenarios.ts
@@ -16,7 +16,7 @@ export const scenarios: VisualScenario[] = [
   {
     slug: "short-shot",
     name: "Short shot (20)",
-    description: "The golfer hits the ball 20 units.",
+    description: "In this scenario, `getShotLength()` will return 20. Roll the ball 20 steps from the tee.",
     taskId: "roll-and-celebrate",
 
     setup(exercise) {
@@ -45,7 +45,7 @@ export const scenarios: VisualScenario[] = [
   {
     slug: "medium-shot",
     name: "Medium shot (35)",
-    description: "The golfer hits the ball 35 units.",
+    description: "In this scenario, `getShotLength()` will return 35. Roll the ball 35 steps from the tee.",
     taskId: "roll-and-celebrate",
 
     setup(exercise) {
@@ -74,7 +74,7 @@ export const scenarios: VisualScenario[] = [
   {
     slug: "long-shot",
     name: "Long shot (50)",
-    description: "The golfer hits the ball 50 units.",
+    description: "In this scenario, `getShotLength()` will return 50. Roll the ball 50 steps from the tee.",
     taskId: "roll-and-celebrate",
 
     setup(exercise) {
@@ -103,7 +103,7 @@ export const scenarios: VisualScenario[] = [
   {
     slug: "very-long-shot",
     name: "Very long shot (60)",
-    description: "The golfer hits the ball 60 units.",
+    description: "In this scenario, `getShotLength()` will return 60. Roll the ball 60 steps from the tee.",
     taskId: "roll-and-celebrate",
 
     setup(exercise) {

--- a/curriculum/src/exercises/golf-scenarios/scenarios.ts
+++ b/curriculum/src/exercises/golf-scenarios/scenarios.ts
@@ -21,17 +21,23 @@ export const scenarios: VisualScenario[] = [
 
     setup(exercise) {
       const ex = exercise as GolfScenariosExercise;
-      ex.setupBallPosition(29, 75);
+      ex.setupBallPosition(28, 75);
       ex.setupShotLength(20);
       ex.setupBackground("/static/images/exercise-assets/golf-scenarios/background.webp");
     },
 
     expectations(exercise) {
       const ex = exercise as GolfScenariosExercise;
+      const requiredPositions = [29, 38, 48];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
-          pass: ex.ballX === 50,
-          errorHtml: `The ball should be at x=50 (29 + 21), but it's at x=${ex.ballX}.`
+          pass: ex.ballX === 48,
+          errorHtml: `The ball didn't end up in the right place for this shot. Check it travels the full shot length.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, not jump straight to the end.`
         }
       ];
     }
@@ -44,17 +50,23 @@ export const scenarios: VisualScenario[] = [
 
     setup(exercise) {
       const ex = exercise as GolfScenariosExercise;
-      ex.setupBallPosition(29, 75);
+      ex.setupBallPosition(28, 75);
       ex.setupShotLength(35);
       ex.setupBackground("/static/images/exercise-assets/golf-scenarios/background.webp");
     },
 
     expectations(exercise) {
       const ex = exercise as GolfScenariosExercise;
+      const requiredPositions = [29, 45, 63];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
-          pass: ex.ballX === 65,
-          errorHtml: `The ball should be at x=65 (29 + 36), but it's at x=${ex.ballX}.`
+          pass: ex.ballX === 63,
+          errorHtml: `The ball didn't end up in the right place for this shot. Check it travels the full shot length.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, not jump straight to the end.`
         }
       ];
     }
@@ -67,17 +79,23 @@ export const scenarios: VisualScenario[] = [
 
     setup(exercise) {
       const ex = exercise as GolfScenariosExercise;
-      ex.setupBallPosition(29, 75);
+      ex.setupBallPosition(28, 75);
       ex.setupShotLength(50);
       ex.setupBackground("/static/images/exercise-assets/golf-scenarios/background.webp");
     },
 
     expectations(exercise) {
       const ex = exercise as GolfScenariosExercise;
+      const requiredPositions = [29, 53, 78];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
-          pass: ex.ballX === 80,
-          errorHtml: `The ball should be at x=80 (29 + 51), but it's at x=${ex.ballX}.`
+          pass: ex.ballX === 78,
+          errorHtml: `The ball didn't end up in the right place for this shot. Check it travels the full shot length.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, not jump straight to the end.`
         }
       ];
     }
@@ -90,17 +108,23 @@ export const scenarios: VisualScenario[] = [
 
     setup(exercise) {
       const ex = exercise as GolfScenariosExercise;
-      ex.setupBallPosition(29, 75);
+      ex.setupBallPosition(28, 75);
       ex.setupShotLength(60);
       ex.setupBackground("/static/images/exercise-assets/golf-scenarios/background.webp");
     },
 
     expectations(exercise) {
       const ex = exercise as GolfScenariosExercise;
+      const requiredPositions = [29, 58, 88];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
-          pass: ex.ballX === 90,
-          errorHtml: `The ball should be at x=90 (29 + 61), but it's at x=${ex.ballX}.`
+          pass: ex.ballX === 88,
+          errorHtml: `The ball didn't end up in the right place for this shot. Check it travels the full shot length.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, not jump straight to the end.`
         }
       ];
     }

--- a/curriculum/src/exercises/golf-scenarios/solution.javascript
+++ b/curriculum/src/exercises/golf-scenarios/solution.javascript
@@ -1,7 +1,7 @@
-let x = 29
+let x = 28
 let shotLength = getShotLength()
 
-repeat(shotLength + 1) {
+repeat(shotLength) {
   x = x + 1
   rollTo(x)
 }

--- a/curriculum/src/exercises/golf-scenarios/solution.jiki
+++ b/curriculum/src/exercises/golf-scenarios/solution.jiki
@@ -1,7 +1,7 @@
-set x to 29
+set x to 28
 set shot_length to get_shot_length()
 
-repeat shot_length + 1 times do
+repeat shot_length times do
   change x to x + 1
   roll_to(x)
 end

--- a/curriculum/src/exercises/golf-scenarios/solution.py
+++ b/curriculum/src/exercises/golf-scenarios/solution.py
@@ -1,6 +1,6 @@
-x = 29
+x = 28
 shot_length = get_shot_length()
 
-repeat(shot_length + 1):
+repeat(shot_length):
     x = x + 1
     roll_to(x)

--- a/curriculum/src/exercises/golf-shot-checker/scenarios.ts
+++ b/curriculum/src/exercises/golf-shot-checker/scenarios.ts
@@ -35,14 +35,20 @@ export const scenarios: VisualScenario[] = [
 
     expectations(exercise) {
       const ex = exercise as GolfShotCheckerExercise;
+      const requiredPositions = [29, 40, 51];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
           pass: ex.ballX === 51,
-          errorHtml: `The ball should be at x=51 (28 + 23), but it's at x=${ex.ballX}.`
+          errorHtml: `The ball didn't roll the right distance for this shot. It should travel exactly the shot length from the tee.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, starting from 29.`
         },
         {
           pass: ex.ballY === 75,
-          errorHtml: `The ball should stay at y=75 (not over the hole), but it's at y=${ex.ballY}.`
+          errorHtml: `The ball should stay on the grass for this shot — it shouldn't drop into the hole.`
         },
         {
           pass: ex.fireworksFired === false,
@@ -66,14 +72,20 @@ export const scenarios: VisualScenario[] = [
 
     expectations(exercise) {
       const ex = exercise as GolfShotCheckerExercise;
+      const requiredPositions = [29, 57, 85];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
           pass: ex.ballX === 85,
-          errorHtml: `The ball should be at x=85 (28 + 57), but it's at x=${ex.ballX}.`
+          errorHtml: `The ball didn't roll the right distance for this shot. It should travel exactly the shot length from the tee.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, starting from 29.`
         },
         {
           pass: ex.ballY === 75,
-          errorHtml: `The ball should stay at y=75 (not in the hole), but it's at y=${ex.ballY}.`
+          errorHtml: `The ball should stay on the grass for this shot — it shouldn't drop into the hole.`
         },
         {
           pass: ex.fireworksFired === false,
@@ -97,14 +109,20 @@ export const scenarios: VisualScenario[] = [
 
     expectations(exercise) {
       const ex = exercise as GolfShotCheckerExercise;
+      const requiredPositions = [29, 60, 91];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
           pass: ex.ballX === 91,
-          errorHtml: `The ball should be at x=91 (28 + 63), but it's at x=${ex.ballX}.`
+          errorHtml: `The ball didn't roll the right distance for this shot. It should travel exactly the shot length from the tee.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, starting from 29.`
         },
         {
           pass: ex.ballY === 75,
-          errorHtml: `The ball should stay at y=75 (overshot the hole), but it's at y=${ex.ballY}.`
+          errorHtml: `The ball overshot the hole, so it should stay on the grass — it shouldn't drop in.`
         },
         {
           pass: ex.fireworksFired === false,
@@ -128,14 +146,20 @@ export const scenarios: VisualScenario[] = [
 
     expectations(exercise) {
       const ex = exercise as GolfShotCheckerExercise;
+      const requiredPositions = [29, 62, 96];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
           pass: ex.ballX === 96,
-          errorHtml: `The ball should be at x=96 (28 + 68), but it's at x=${ex.ballX}.`
+          errorHtml: `The ball didn't roll the right distance for this shot. It should travel exactly the shot length from the tee.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, starting from 29.`
         },
         {
           pass: ex.ballY === 75,
-          errorHtml: `The ball should stay at y=75 (overshot the hole), but it's at y=${ex.ballY}.`
+          errorHtml: `The ball overshot the hole, so it should stay on the grass — it shouldn't drop in.`
         },
         {
           pass: ex.fireworksFired === false,
@@ -159,14 +183,20 @@ export const scenarios: VisualScenario[] = [
 
     expectations(exercise) {
       const ex = exercise as GolfShotCheckerExercise;
+      const requiredPositions = [29, 57, 86];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
           pass: ex.ballX === 86,
-          errorHtml: `The ball should be at x=86 (28 + 58), but it's at x=${ex.ballX}.`
+          errorHtml: `The ball didn't roll the right distance for this shot. It should travel exactly the shot length from the tee.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, starting from 29.`
         },
         {
           pass: ex.ballY === 84,
-          errorHtml: `The ball should have sunk to y=84 (75 + 9), but it's at y=${ex.ballY}.`
+          errorHtml: `The ball reached the hole but didn't drop down into it correctly.`
         },
         {
           pass: ex.fireworksFired === true,
@@ -190,14 +220,20 @@ export const scenarios: VisualScenario[] = [
 
     expectations(exercise) {
       const ex = exercise as GolfShotCheckerExercise;
+      const requiredPositions = [29, 60, 90];
+      const missingPositions = requiredPositions.filter((p) => !ex.visitedPositions.includes(p));
       return [
         {
           pass: ex.ballX === 90,
-          errorHtml: `The ball should be at x=90 (28 + 62), but it's at x=${ex.ballX}.`
+          errorHtml: `The ball didn't roll the right distance for this shot. It should travel exactly the shot length from the tee.`
+        },
+        {
+          pass: missingPositions.length === 0,
+          errorHtml: `The ball must roll through each position one step at a time, starting from 29.`
         },
         {
           pass: ex.ballY === 84,
-          errorHtml: `The ball should have sunk to y=84 (75 + 9), but it's at y=${ex.ballY}.`
+          errorHtml: `The ball reached the hole but didn't drop down into it correctly.`
         },
         {
           pass: ex.fireworksFired === true,

--- a/curriculum/src/exercises/owners-bouquets/instructions/en.md
+++ b/curriculum/src/exercises/owners-bouquets/instructions/en.md
@@ -3,7 +3,7 @@ title: "Owner's Bouquets"
 description: "Plant flowers in different garden layouts."
 ---
 
-Welcome to your first exercise with scenarios.
+Welcome to your second exercise with scenarios.
 
 We're back with our automated gardening machine. Previously, we always planted 9 flowers, but now things are changing. We need our robot to be able to plant however many flowers its told to by the owner of the house.
 
@@ -13,7 +13,7 @@ We are under strict instructions to keep the garden neat, so we need to plant th
 
 ### Scenarios
 
-On the left, you'll notice four grey dots for the four different scenarios. **Clicking on each dot** shows you a different scenario - where `askNumberOfFlowers()` will return a different number. If you click `"Run Code"`, you'll see they all go red.
+As in the golf exercise you just solved, on the left you'll see four grey dots for the four different scenarios. **Clicking on each dot** shows you a different scenario, but this time it's the `askNumberOfFlowers()` that will return a different number each time.
 
 Your job is to write one program that works for all the different possible values `askNumberOfFlowers()` might return.
 


### PR DESCRIPTION
## Summary

Audit of **golf-scenarios** (via `/audit-exercise`) plus consistency work across the golf exercise family.

### golf-scenarios
- **Roll through 29:** aligned the solution with `golf-shot-checker` (`x = 28; repeat(shotLength)`) so the ball rolls 28→29→30… instead of jumping 28→30. Final targets are now `28 + shotLength` (48/63/78/88). Updated all three solution files.
- **Anti-cheat stepping checks:** each scenario now verifies `visitedPositions` includes `[29, …, target]`, so a single `rollTo(target)` no longer passes.
- **Error messages (Check 9):** rewrote `errorHtml` to stop revealing target coordinates and formulas (was `x=50 (29 + 21)`).
- **Hints (Check 5):** replaced the stale "animate it down" hint (leftover from the hole-sinking exercise) with a progressive pair.
- **Concepts (Check 8):** added `using-functions-with-return-values`; recategorised `getShotLength` as `Information`.
- **Instructions / llm-metadata:** ball starts on the tee at **28** (matching the other golf exercises).

### Cross-exercise consistency
- Track `visitedPositions` once in the base `GolfExercise` (`rollRight` + `rollTo`).
- `golf-rolling-ball-loop` and `golf-shot-checker`: added through-29 stepping checks. (`golf-rolling-ball-state` already checked `[29, …]`.)
- `golf-shot-checker`: rewrote x/y `errorHtml` to stop giving away coordinates (`x=51 (28 + 23)`, `y=84 (75 + 9)`).

## Testing
- `pnpm typecheck` — clean
- `pnpm test` — 661 passed (includes `all-exercises.test.ts`, which runs every JS solution against all scenarios, validating the new targets and stepping checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)