### PR TITLE
Render lists in hint answers

### DIFF
--- a/app/components/coding-exercise/ui/hints-panel.module.css
+++ b/app/components/coding-exercise/ui/hints-panel.module.css
@@ -122,11 +122,34 @@
     filter: blur(4px);
 }
 
-.hintAnswerContent p {
-    color: #2d3748;
+.hintAnswerContent p,
+.hintAnswerContent li {
+    color: var(--color-gray-700);
     font-size: 15px;
     line-height: 1.6;
+}
+
+.hintAnswerContent p,
+.hintAnswerContent ul,
+.hintAnswerContent ol {
     margin-bottom: 10px;
+}
+
+.hintAnswerContent ul,
+.hintAnswerContent ol {
+    margin-left: 16px;
+}
+
+.hintAnswerContent ul {
+    list-style: disc;
+}
+
+.hintAnswerContent ol {
+    list-style: decimal;
+}
+
+.hintAnswerContent li {
+    margin-bottom: 4px;
 }
 
 .hintAnswerContent > :last-child {

--- a/curriculum/src/exercises/space-invaders-nested-repeat/metadata.json
+++ b/curriculum/src/exercises/space-invaders-nested-repeat/metadata.json
@@ -4,7 +4,7 @@
   "hints": [
     {
       "question": "I can't get to 7 lines of code.",
-      "answer": "Think about what we do when we see repetitive code. You also don't need any variables in this exercise."
+      "answer": "Think about this level as two blocks of things that need to happen.\n\n- The first block is the inner one, where we shoot 4 times - make sure that is three lines long.\n- The outer block is the inner block with some movement either side. That outer block needs to be repeated a few times too.\n\nIf you structure your code in this way, it should naturally end up at 7 lines of code."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Style markdown lists in hint answers: `ul`/`ol` get disc/decimal markers and a 16px left indent; `li` gets its own color/sizing and 4px spacing.
- Consolidate `p`/`li` typography and replace the hardcoded `#2d3748` with `var(--color-gray-700)`.
- Use a markdown list in the `space-invaders-nested-repeat` hint answer to take advantage of the new rendering.

## Test plan
- Pre-commit suite (app + curriculum tests, typecheck, lint) passed.
- Verify the hint answer for `space-invaders-nested-repeat` renders as a bulleted list in the editor hints panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)