### PR TITLE
Gold panning: align sell() signature with instructions

### DIFF
--- a/curriculum/src/exercises/gold-panning/index.ts
+++ b/curriculum/src/exercises/gold-panning/index.ts
@@ -13,9 +13,9 @@ const functions: FunctionInfo[] = [
   },
   {
     name: "sell",
-    signature: "sell(nuggets)",
+    signature: "sell(numberOfNuggets)",
     description: "Sells your gold nuggets at the trading post.",
-    examples: ["sell(nuggets)"],
+    examples: ["sell(numberOfNuggets)"],
     category: "Action"
   }
 ];


### PR DESCRIPTION
## Summary

A learner reported that the **gold-panning** exercise documents the `sell` function two different ways: the instructions say `sell(numberOfNuggets)` while the function panel (`index.ts`) showed `sell(nuggets)`. That mismatch is a real barrier for beginners.

Standardised on the clearer `numberOfNuggets` in the function panel's `signature` and `examples` so both user-facing references agree.

Note: the `sell(nuggets)` calls in the solution files are unchanged and correct — there `nuggets` is the student's accumulator variable (`let nuggets = 0`), not the parameter name.

## Testing
- `pnpm typecheck` — clean
- `pnpm test` — 661 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)