### PR TITLE
Fix project icon and label in coding exercise header

### DIFF
--- a/app/components/coding-exercise/ui/instructions-panel/DynamicHeader.tsx
+++ b/app/components/coding-exercise/ui/instructions-panel/DynamicHeader.tsx
@@ -1,12 +1,13 @@
 import { LessonIcon } from "@/components/icons/LessonIcon";
+import { ProjectIcon } from "@/components/icons/ProjectIcon";
 import NavigationButtons from "./NavigationButtons";
 import styles from "./instructions-panel.module.css";
 
 interface ExerciseData {
   title: string;
-  progress: string;
   level: string;
   exerciseSlug: string;
+  isProject: boolean;
 }
 
 interface DynamicHeaderProps {
@@ -36,12 +37,16 @@ export default function DynamicHeader({
         /* Expanded Header */
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-16">
-            <LessonIcon slug={exerciseData.exerciseSlug} width={54} height={54} />
+            {exerciseData.isProject ? (
+              <ProjectIcon slug={exerciseData.exerciseSlug} width={54} height={54} />
+            ) : (
+              <LessonIcon slug={exerciseData.exerciseSlug} width={54} height={54} />
+            )}
 
             <div className="flex flex-col gap-4">
               <h1 className={styles.exerciseTitle}>{exerciseData.title}</h1>
               <p className={styles.exerciseInfoText}>
-                Exercise {exerciseData.progress} • {exerciseData.level}
+                {exerciseData.isProject ? "Premium Project" : `Exercise • ${exerciseData.level}`}
               </p>
             </div>
           </div>

--- a/app/components/coding-exercise/ui/instructions-panel/InstructionsPanel.tsx
+++ b/app/components/coding-exercise/ui/instructions-panel/InstructionsPanel.tsx
@@ -43,9 +43,9 @@ export default function InstructionsPanel({
   // Build exercise data from props
   const exerciseData: ExerciseData = {
     title: exerciseTitle,
-    progress: "", // TODO: Get actual progress from API/orchestrator when available
     level: levelId.charAt(0).toUpperCase() + levelId.slice(1).replace(/-/g, " "),
-    exerciseSlug
+    exerciseSlug,
+    isProject
   };
 
   // Fetch concepts on mount - conceptSlugs are static for a given exercise


### PR DESCRIPTION
## Problem

When a **project** (e.g. Cityscape Skyline) is opened in the coding exercise, the instructions-panel header rendered the *lesson* icon. Project-only slugs have no icon in the lesson-icons directory, so it fell back to the "LOST" placeholder. The subtitle also showed the generic `Exercise • {level}` line.

The projects list page renders correctly because it uses `ProjectIcon` (project-icons dir).

## Fix

Thread the existing `orchestrator.isProject()` flag (already passed into `InstructionsPanel`) down into `DynamicHeader` via `ExerciseData`. When it's a project:

- render `ProjectIcon` instead of `LessonIcon` (correct curriculum icon dir, no placeholder)
- show **Premium Project** instead of `Exercise • {level}`

Also drops the unused `progress` field (was always `""` behind a TODO).

No icon files were duplicated — the icon dirs are symlinks into the curriculum package; we just point at the right one.

## Testing

- `pnpm typecheck` passes
- Pre-commit suite (1711 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)