### PR TITLE
Digital Clock: zero-pad minutes in displayed time

### DIFF
--- a/curriculum/src/exercises/digital-clock/Exercise.ts
+++ b/curriculum/src/exercises/digital-clock/Exercise.ts
@@ -60,7 +60,7 @@ export default class DigitalClockExercise extends VisualExercise {
       executionCtx.logicError("indicator must be a string");
       return;
     }
-    this.displayedTime = `${hour.value}:${minutes.value}${indicator.value}`;
+    this.displayedTime = `${hour.value}:${String(minutes.value).padStart(2, "0")}${indicator.value}`;
 
     const [h1, h2] = String(hour.value).padStart(2, "0").split("");
     const [m1, m2] = String(minutes.value).padStart(2, "0").split("");

--- a/curriculum/src/exercises/digital-clock/metadata.json
+++ b/curriculum/src/exercises/digital-clock/metadata.json
@@ -4,10 +4,10 @@
   "hints": [
     {
       "question": "I don't know how to get started",
-      "answer": "Use `currentTimeHour()` and `currentTimeMinute()` to get the current time, then use `displayTime(hour, minute, \"am\")` with their values to see what happens. Then work out how to set the correct meridien and the correct hour display."
+      "answer": "Use `currentTimeHour()` and `currentTimeMinute()` to get the current time, then use `displayTime(hour, minutes, \"am\")` with their values to see what happens. Then work out how to set the correct meridiem and the correct hour display."
     },
     {
-      "question": "How does the meridien work?",
+      "question": "How does the meridiem work?",
       "answer": "Hours 0-11 are 'am', hours 12-23 are 'pm'. Midnight (hour 0) should display as 12am. Noon (hour 12) should display as 12pm."
     },
     {

--- a/curriculum/src/exercises/digital-clock/scenarios.ts
+++ b/curriculum/src/exercises/digital-clock/scenarios.ts
@@ -21,7 +21,7 @@ function computeExpectedTime(hour: number, minute: number): string {
   } else if (hour > 12) {
     displayHour = hour - 12;
   }
-  return `${displayHour}:${minute}${indicator}`;
+  return `${displayHour}:${String(minute).padStart(2, "0")}${indicator}`;
 }
 
 export const scenarios: VisualScenario[] = [
@@ -53,7 +53,7 @@ export const scenarios: VisualScenario[] = [
   {
     slug: "morning-2",
     name: "Late morning",
-    description: 'Display 11:04 as "11:4am"',
+    description: 'Display 11:04 as "11:04am"',
     taskId: "display-time",
 
     setup(exercise) {
@@ -69,8 +69,8 @@ export const scenarios: VisualScenario[] = [
           errorHtml: "The clock didn't get updated. Make sure you use the <code>displayTime</code> function."
         },
         {
-          pass: ex.displayedTime === "11:4am",
-          errorHtml: `Expected "11:4am" but got "${ex.displayedTime}"`
+          pass: ex.displayedTime === "11:04am",
+          errorHtml: `Expected "11:04am" but got "${ex.displayedTime}"`
         }
       ];
     }
@@ -128,7 +128,7 @@ export const scenarios: VisualScenario[] = [
   {
     slug: "midnight",
     name: "Midnight",
-    description: 'Display midnight as "12:0am"',
+    description: 'Display midnight as "12:00am"',
     taskId: "display-time",
 
     setup(exercise) {
@@ -144,8 +144,8 @@ export const scenarios: VisualScenario[] = [
           errorHtml: "The clock didn't get updated. Make sure you use the <code>displayTime</code> function."
         },
         {
-          pass: ex.displayedTime === "12:0am",
-          errorHtml: `Expected "12:0am" but got "${ex.displayedTime}"`
+          pass: ex.displayedTime === "12:00am",
+          errorHtml: `Expected "12:00am" but got "${ex.displayedTime}"`
         }
       ];
     }
@@ -153,7 +153,7 @@ export const scenarios: VisualScenario[] = [
   {
     slug: "noon",
     name: "Noon",
-    description: 'Display noon as "12:0pm"',
+    description: 'Display noon as "12:00pm"',
     taskId: "display-time",
 
     setup(exercise) {
@@ -169,8 +169,8 @@ export const scenarios: VisualScenario[] = [
           errorHtml: "The clock didn't get updated. Make sure you use the <code>displayTime</code> function."
         },
         {
-          pass: ex.displayedTime === "12:0pm",
-          errorHtml: `Expected "12:0pm" but got "${ex.displayedTime}"`
+          pass: ex.displayedTime === "12:00pm",
+          errorHtml: `Expected "12:00pm" but got "${ex.displayedTime}"`
         }
       ];
     }


### PR DESCRIPTION
## Problem

Reported on the forum by glennj: the Midnight scenario message reads `Display midnight as "12:0am"`, with the same unpadded minutes in the Late morning (`11:4am`) and Noon (`12:0pm`) scenarios.

The on-screen clock face already zero-pads minutes (via `padStart` in the animation path), but the `displayedTime` string used for scenario assertions did not. When this exercise was ported from bootcamp, the scenario descriptions and `errorHtml` were changed to template the raw unpadded value, surfacing inconsistent text (`12:0am`) to students while the clock showed `12:00`. In the bootcamp original this value lived only in a hidden internal matcher; the user-facing copy was hand-written and padded.

## Fix

- Zero-pad minutes when building `displayedTime` in `Exercise.ts`.
- Align the scenario descriptions, expected values, and `errorHtml` to match: `12:00am`, `11:04am`, `12:00pm` (and the live "now" scenario via `computeExpectedTime`).
- Fix two cosmetic nits in the hints surfaced by `/audit-exercise`: `minute` -> `minutes` and `meridien` -> `meridiem`.

Now the clock face, the expected text, and the "but got" actual text all agree on `12:00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)