### PR TITLE
Remove unnecessary type assertions flagged by lint

### DIFF
--- a/app/components/coding-exercise/lib/chatErrorHandler.ts
+++ b/app/components/coding-exercise/lib/chatErrorHandler.ts
@@ -45,7 +45,7 @@ export function formatChatError(error: unknown): string {
     if (error.status === 401) {
       // Check specific error type for better user messaging
       if (error.data && typeof error.data === "object") {
-        const errorData = error.data as any;
+        const errorData = error.data as { error?: string };
         if (errorData.error === "token_expired") {
           // This is shown after auto-retry has failed
           return "Session expired. Please try again.";
@@ -91,7 +91,7 @@ export function shouldRetryError(error: unknown): boolean {
   if (error instanceof ChatApiError) {
     // Don't retry expired tokens - they should be handled by refresh logic
     if (error.status === 401 && error.data && typeof error.data === "object") {
-      const errorData = error.data as any;
+      const errorData = error.data as { error?: string };
       if (errorData.error === "token_expired") {
         return false; // Refresh logic handles this
       }

--- a/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
+++ b/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
@@ -82,7 +82,7 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
         if (!enabled) {
           return;
         }
-        handleOnKeyDown(event as any, animationTimeline, frames);
+        handleOnKeyDown(event, animationTimeline, frames);
       },
       [enabled, animationTimeline, frames]
     );
@@ -92,7 +92,7 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
         if (!enabled) {
           return;
         }
-        handleOnKeyUp(event as any, animationTimeline);
+        handleOnKeyUp(event, animationTimeline);
       },
       [enabled, animationTimeline]
     );

--- a/app/lib/keyboard/PerformanceOptimizer.ts
+++ b/app/lib/keyboard/PerformanceOptimizer.ts
@@ -2,7 +2,7 @@
  * Performance optimization utilities for keyboard handling
  */
 
-interface ThrottledFunction<T extends (...args: any[]) => any> {
+export interface ThrottledFunction<T extends (...args: any[]) => any> {
   (...args: Parameters<T>): void;
   cancel: () => void;
   flush: () => void;

--- a/app/lib/keyboard/index.ts
+++ b/app/lib/keyboard/index.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { showModal } from "../modal";
 import { KeyboardHelpModal } from "./KeyboardHelpModal";
+import type { ThrottledFunction } from "./PerformanceOptimizer";
 import { PerformanceMonitor, debounce, throttle } from "./PerformanceOptimizer";
 import { ScopeManager } from "./ScopeManager";
 import { SequenceBuffer } from "./SequenceBuffer";
@@ -13,7 +14,10 @@ class KeyboardManager {
   private readonly scopes = new ScopeManager();
   private readonly sequence = new SequenceBuffer();
   private readonly performanceMonitor = new PerformanceMonitor();
-  private optimizedHandlers = new WeakMap<KeyboardHandler, KeyboardHandler>();
+  private optimizedHandlers = new WeakMap<
+    KeyboardHandler,
+    KeyboardHandler & Partial<ThrottledFunction<KeyboardHandler>>
+  >();
   private isEnabled = true;
   private isInitialized = false;
 
@@ -84,8 +88,8 @@ class KeyboardManager {
     return () => {
       // Clean up optimized handler if it exists
       const cached = this.optimizedHandlers.get(handler);
-      if (cached && "cancel" in cached) {
-        (cached as any).cancel();
+      if (cached && cached.cancel) {
+        cached.cancel();
         this.optimizedHandlers.delete(handler);
       }
       this.registry.unregister(normalizedKeys, id);

--- a/app/tests/unit/components/coding-exercise/ui/codemirror/hooks/useUnderlineRange.test.tsx
+++ b/app/tests/unit/components/coding-exercise/ui/codemirror/hooks/useUnderlineRange.test.tsx
@@ -107,6 +107,10 @@ describe("useUnderlineRange", () => {
 
   it("should handle transition from range to undefined", () => {
     const { rerender } = renderHook(({ range }) => useUnderlineRange(mockEditorView as EditorView, range), {
+      // ESLint thinks this assertion is unnecessary, but it widens the inferred initialProps type so
+      // the later rerender({ range: undefined }) typechecks. A plain annotation gets narrowed back by
+      // control-flow analysis, so the assertion is the only way to keep the union type here.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       initialProps: { range: { from: 10, to: 20 } as { from: number; to: number } | undefined }
     });
 

--- a/app/tests/unit/components/settings/SettingsPage.test.tsx
+++ b/app/tests/unit/components/settings/SettingsPage.test.tsx
@@ -66,7 +66,7 @@ describe("SettingsPage", () => {
       logout: jest.fn(),
       register: jest.fn(),
       checkAuth: jest.fn()
-    } as any);
+    });
   });
 
   it("renders settings page with account tab by default", () => {


### PR DESCRIPTION
## What

Clears the `@typescript-eslint/no-unnecessary-type-assertion` lint warnings that GitHub Actions surfaces on these files (visible as check annotations on other PRs, e.g. #707).

- `ScrubberInput.tsx` — drop `event as any`; `event` is already `React.KeyboardEvent`, which the handlers accept.
- `chatErrorHandler.ts` — replace `error.data as any` with `as { error?: string }`.
- `lib/keyboard/PerformanceOptimizer.ts` / `lib/keyboard/index.ts` — export `ThrottledFunction` and type the optimized-handler cache so the `cancel()` cast is no longer needed.
- `SettingsPage.test.tsx` — drop `as any` on the mocked auth store return value.
- `useUnderlineRange.test.tsx` — the assertion here is genuinely needed to widen the inferred `initialProps` type (a plain annotation gets narrowed back by control-flow analysis, and removing it breaks `rerender({ range: undefined })`). Kept with a documented `eslint-disable`.

## Testing

- `pnpm typecheck` passes.
- Lint passes on all changed files.
- Full app test suite passes (1711 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)