### PR TITLE
Stack concepts list vertically instead of two-column grid

### DIFF
--- a/app/components/coding-exercise/ui/instructions-panel/instructions-panel.module.css
+++ b/app/components/coding-exercise/ui/instructions-panel/instructions-panel.module.css
@@ -382,8 +382,8 @@
 }
 
 .conceptsList {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
+    flex-direction: column;
     gap: 16px;
     margin-bottom: 16px;
 }


### PR DESCRIPTION
Changes the `.conceptsList` layout in the instructions panel from a two-column grid to a single vertical flex column. Concepts now stack top-to-bottom, keeping the existing 16px gap and bottom margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)