### PR TITLE
Use content images for OG metadata on blog posts and concepts

### DIFF
--- a/app/components/blog/BlogPostPage.tsx
+++ b/app/components/blog/BlogPostPage.tsx
@@ -23,7 +23,8 @@ export function getBlogPostMetadata(slug: string, locale: string = "en"): Metada
     return {
       title: post.title,
       description: post.seo.description,
-      keywords: post.seo.keywords.join(", ")
+      keywords: post.seo.keywords.join(", "),
+      ...(post.coverImage ? { openGraph: { images: [{ url: post.coverImage }] } } : {})
     };
   } catch {
     return { title: "Post Not Found" };

--- a/app/lib/concepts/metadata.ts
+++ b/app/lib/concepts/metadata.ts
@@ -5,6 +5,7 @@ interface ConceptMetaEntry {
   slug: string;
   title: string;
   description: string;
+  image: string | null;
 }
 
 const concepts = conceptMetaServer as ConceptMetaEntry[];
@@ -16,6 +17,7 @@ export function getConceptMetadata(slug: string): Metadata {
   }
   return {
     title: concept.title,
-    description: concept.description
+    description: concept.description,
+    ...(concept.image ? { openGraph: { images: [{ url: concept.image }] } } : {})
   };
 }

--- a/app/scripts/generate-concept-cache.js
+++ b/app/scripts/generate-concept-cache.js
@@ -56,6 +56,14 @@ const CONCEPTS_DIR = path.join(__dirname, "../../curriculum/src/concepts");
 const EXERCISE_MAP_PATH = path.join(__dirname, "../../curriculum/dist/concepts/exercise-map.json");
 const STATIC_DIR = path.join(__dirname, "../public/static/concepts");
 const GENERATED_DIR = path.join(__dirname, "../lib/generated");
+const ICONS_DIR = path.join(__dirname, "../public/static/icons/concepts");
+
+/**
+ * Returns the public OG image path for a concept's icon, or null if no icon exists.
+ */
+function conceptImage(slug) {
+  return fs.existsSync(path.join(ICONS_DIR, `${slug}.webp`)) ? `/static/icons/concepts/${slug}.webp` : null;
+}
 
 /**
  * Compute a 12-char SHA-256 hash of content
@@ -211,6 +219,7 @@ function buildStaticFiles(concepts) {
         slug,
         title: localeData.title,
         description: localeData.description,
+        image: conceptImage(slug),
         parentSlug: concept.config.parent || null,
         order: concept.config.order || 0,
         category: concept.config.category || false,
@@ -268,7 +277,8 @@ function writeServerMeta(byLocale) {
   const serverMeta = enConcepts.map((c) => ({
     slug: c.slug,
     title: c.title,
-    description: c.description
+    description: c.description,
+    image: c.image
   }));
 
   writeFile(path.join(GENERATED_DIR, "concept-meta-server.json"), JSON.stringify(serverMeta, null, 2));


### PR DESCRIPTION
## What

OG (OpenGraph) social-share images previously fell back to the site-wide default for every blog post and concept page. This wires each page's own content image into its OG metadata.

- **Blog posts** (`getBlogPostMetadata`): use the post's existing `coverImage` (e.g. `/static/images/blog/hello-world.webp`).
- **Concepts** (`getConceptMetadata`): use the concept's icon at `/static/icons/concepts/{slug}.webp`.

## How

- `scripts/generate-concept-cache.js` resolves each concept's icon at build time and bakes the public path into `concept-meta-server.json` **only when the icon file actually exists** (37/50 concepts), so concepts without an icon don't end up with a 404'd OG image.
- Pages with no available image continue to fall back to the site-wide default `og-image.png`.
- Both rely on the root layout's `metadataBase`, so the relative `/static/...` URLs resolve to absolute OG URLs automatically.

## Testing

- `tsc --noEmit` passes.
- Full app test suite (1716 tests) and pre-commit hooks pass.
- Verified referenced blog `.webp` and concept icon files exist on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)