### PR TITLE
JS: error on same-scope let/const redeclaration

### DIFF
--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -1,5 +1,19 @@
 # JavaScript Interpreter Evolution
 
+## 2026-06-22: Same-scope redeclaration error (VariableAlreadyDeclared)
+
+Redeclaring a `let`/`const` binding in the same scope (e.g. `let x = 1; let x = 2;`) now raises a `VariableAlreadyDeclared` runtime error instead of silently overwriting. This matches real JavaScript, which raises a SyntaxError for that code. (Detected at execution rather than parse time, so it surfaces as a runtime error frame following the shared error-handling pattern.)
+
+### Mechanism
+
+- `VariableMetadata` in `src/javascript/environment.ts` gains an `isLexical` flag. `Environment.define` takes a new `isLexical` parameter (default `false`); when a lexical declaration targets a name whose current-scope binding is also lexical, it throws `VariableAlreadyDeclared`.
+- `executeVariableDeclaration` passes `isLexical: true`; all built-in injections (console, Math, Object, Number, String, custom functions/classes, secret constants) keep the default `false`.
+- New `RuntimeErrorType` `VariableAlreadyDeclared` with translations in both `system` and `en` locale files.
+
+### Why the `isLexical` flag
+
+Built-ins live in the global environment, so a naive "name already exists in this scope" check would wrongly reject `let console = 1` (legal shadowing of a global in real JS). Only student `let`/`const` declarations are marked lexical, so only declaration-vs-declaration collisions error; declaring over a built-in stays allowed. Cross-scope cases (inner blocks) are unaffected and continue to flow through the existing `ShadowingDisabled` path.
+
 ## 2026-05-12: Guard bare function references (UnexpectedUncalledFunction)
 
 A bare callable identifier used as a value (e.g. `circle;` as a statement, or `let g = circle;`) now raises `UnexpectedUncalledFunction` instead of silently stepping. Mirrors JikiScript's `UnexpectedUncalledFunctionInExpression` so semantics match across interpreters.

--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -6,13 +6,13 @@ Redeclaring a `let`/`const` binding in the same scope (e.g. `let x = 1; let x = 
 
 ### Mechanism
 
-- `VariableMetadata` in `src/javascript/environment.ts` gains an `isLexical` flag. `Environment.define` takes a new `isLexical` parameter (default `false`); when a lexical declaration targets a name whose current-scope binding is also lexical, it throws `VariableAlreadyDeclared`.
-- `executeVariableDeclaration` passes `isLexical: true`; all built-in injections (console, Math, Object, Number, String, custom functions/classes, secret constants) keep the default `false`.
+- `Environment.define` takes a new `isDeclaration` parameter (default `false`); when a declaration targets a name that already exists in the current scope, it throws `VariableAlreadyDeclared`.
+- `executeVariableDeclaration` passes `isDeclaration: true`; built-in injections (console, Math, Object, Number, String, custom functions/classes, secret constants) keep the default `false`, so registering them never trips the check.
 - New `RuntimeErrorType` `VariableAlreadyDeclared` with translations in both `system` and `en` locale files.
 
-### Why the `isLexical` flag
+### Built-ins are protected too
 
-Built-ins live in the global environment, so a naive "name already exists in this scope" check would wrongly reject `let console = 1` (legal shadowing of a global in real JS). Only student `let`/`const` declarations are marked lexical, so only declaration-vs-declaration collisions error; declaring over a built-in stays allowed. Cross-scope cases (inner blocks) are unaffected and continue to flow through the existing `ShadowingDisabled` path.
+Unlike real JS, redeclaring an injected built-in (e.g. `let console = 1`, `let Math = 1`) also errors. In real JS those globals are not lexical bindings, so `let console = 1` is legal shadowing, but in this educational interpreter such a redeclaration is virtually always an unintentional student mistake, so erroring is more helpful than silently shadowing the built-in. Cross-scope cases (inner blocks) are unaffected and continue to flow through the existing `ShadowingDisabled` path. The secret-constant top-level path in `executeVariableDeclaration` still returns before `define`, so those remain silently ignored.
 
 ## 2026-05-12: Guard bare function references (UnexpectedUncalledFunction)
 

--- a/interpreters/src/javascript/environment.ts
+++ b/interpreters/src/javascript/environment.ts
@@ -7,6 +7,11 @@ import { translate } from "./translator";
 interface VariableMetadata {
   value: JikiObject;
   isConst: boolean;
+  // True when the binding was introduced by a student `let`/`const` declaration,
+  // as opposed to an injected built-in (console, Math, secret constants, etc.).
+  // Only lexical bindings trigger same-scope redeclaration errors, mirroring real
+  // JS where `let console = 1` is legal but `let x = 1; let x = 2;` is not.
+  isLexical: boolean;
 }
 
 export class Environment {
@@ -22,7 +27,24 @@ export class Environment {
     this.languageFeatures = languageFeatures;
   }
 
-  public define(name: string, value: JikiObject, location: Location, isConst: boolean = false): void {
+  public define(
+    name: string,
+    value: JikiObject,
+    location: Location,
+    isConst: boolean = false,
+    isLexical: boolean = false
+  ): void {
+    // A lexical declaration (`let`/`const`) cannot redeclare another lexical
+    // binding in the same scope. This matches real JavaScript, which raises a
+    // SyntaxError for `let x = 1; let x = 2;`.
+    if (isLexical) {
+      const existing = this.variables.get(name);
+      if (existing?.isLexical) {
+        const message = translate(`error.runtime.VariableAlreadyDeclared`, { name });
+        throw new RuntimeError(message, location, "VariableAlreadyDeclared", { name });
+      }
+    }
+
     // Check for shadowing if disabled
     if (!this.languageFeatures.allowShadowing) {
       if (this.isDefinedInEnclosingScope(name)) {
@@ -30,7 +52,7 @@ export class Environment {
         throw new RuntimeError(message, location, "ShadowingDisabled", { name });
       }
     }
-    this.variables.set(name, { value, isConst });
+    this.variables.set(name, { value, isConst, isLexical });
   }
 
   public isDefinedInEnclosingScope(name: string): boolean {

--- a/interpreters/src/javascript/environment.ts
+++ b/interpreters/src/javascript/environment.ts
@@ -7,11 +7,6 @@ import { translate } from "./translator";
 interface VariableMetadata {
   value: JikiObject;
   isConst: boolean;
-  // True when the binding was introduced by a student `let`/`const` declaration,
-  // as opposed to an injected built-in (console, Math, secret constants, etc.).
-  // Only lexical bindings trigger same-scope redeclaration errors, mirroring real
-  // JS where `let console = 1` is legal but `let x = 1; let x = 2;` is not.
-  isLexical: boolean;
 }
 
 export class Environment {
@@ -32,17 +27,16 @@ export class Environment {
     value: JikiObject,
     location: Location,
     isConst: boolean = false,
-    isLexical: boolean = false
+    isDeclaration: boolean = false
   ): void {
-    // A lexical declaration (`let`/`const`) cannot redeclare another lexical
-    // binding in the same scope. This matches real JavaScript, which raises a
-    // SyntaxError for `let x = 1; let x = 2;`.
-    if (isLexical) {
-      const existing = this.variables.get(name);
-      if (existing?.isLexical) {
-        const message = translate(`error.runtime.VariableAlreadyDeclared`, { name });
-        throw new RuntimeError(message, location, "VariableAlreadyDeclared", { name });
-      }
+    // A `let`/`const` declaration cannot reuse a name that already exists in the
+    // same scope. This matches real JavaScript, which raises a SyntaxError for
+    // `let x = 1; let x = 2;`. We also forbid redeclaring an injected built-in
+    // (e.g. `let console = 1`): that is virtually always a student mistake rather
+    // than an intentional shadow, so erroring is more helpful than allowing it.
+    if (isDeclaration && this.variables.has(name)) {
+      const message = translate(`error.runtime.VariableAlreadyDeclared`, { name });
+      throw new RuntimeError(message, location, "VariableAlreadyDeclared", { name });
     }
 
     // Check for shadowing if disabled
@@ -52,7 +46,7 @@ export class Environment {
         throw new RuntimeError(message, location, "ShadowingDisabled", { name });
       }
     }
-    this.variables.set(name, { value, isConst, isLexical });
+    this.variables.set(name, { value, isConst });
   }
 
   public isDefinedInEnclosingScope(name: string): boolean {

--- a/interpreters/src/javascript/executor.ts
+++ b/interpreters/src/javascript/executor.ts
@@ -103,6 +103,7 @@ export type RuntimeErrorType =
   | "InvalidUnaryExpression"
   | "UnsupportedOperation"
   | "VariableNotDeclared"
+  | "VariableAlreadyDeclared"
   | "ShadowingDisabled"
   | "AssignmentToConstant"
   | "ComparisonRequiresNumber"

--- a/interpreters/src/javascript/executor/executeVariableDeclaration.ts
+++ b/interpreters/src/javascript/executor/executeVariableDeclaration.ts
@@ -37,7 +37,7 @@ export function executeVariableDeclaration(executor: Executor, statement: Variab
 
   // Shadowing and same-scope redeclaration checks are handled inside environment.define()
   const isConst = statement.kind === "const";
-  executor.environment.define(name, jikiObject, statement.name.location, isConst, /* isLexical */ true);
+  executor.environment.define(name, jikiObject, statement.name.location, isConst, /* isDeclaration */ true);
   return {
     type: "VariableDeclaration",
     kind: statement.kind,

--- a/interpreters/src/javascript/executor/executeVariableDeclaration.ts
+++ b/interpreters/src/javascript/executor/executeVariableDeclaration.ts
@@ -35,9 +35,9 @@ export function executeVariableDeclaration(executor: Executor, statement: Variab
     };
   }
 
-  // Shadowing check is now handled inside environment.define()
+  // Shadowing and same-scope redeclaration checks are handled inside environment.define()
   const isConst = statement.kind === "const";
-  executor.environment.define(name, jikiObject, statement.name.location, isConst);
+  executor.environment.define(name, jikiObject, statement.name.location, isConst, /* isLexical */ true);
   return {
     type: "VariableDeclaration",
     kind: statement.kind,

--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -85,6 +85,7 @@
       "InvalidUnaryExpression": "Invalid unary operation.",
       "PropertyNotFound": "Property `{{property}}` does not exist on arrays.",
       "ShadowingDisabled": "Variable shadowing is disabled. The variable `{{name}}` is already declared in an outer scope.",
+      "VariableAlreadyDeclared": "The variable `{{name}}` has already been declared in this scope. Use a different name or assign to the existing variable instead.",
       "AssignmentToConstant": "Cannot reassign constant variable `{{name}}`. Constants cannot be changed after they are declared.",
       "TruthinessDisabled": "Only boolean values are allowed in conditions, but got `{{value}}`.",
       "TypeError": "{{message}}",

--- a/interpreters/src/javascript/locales/system/translation.json
+++ b/interpreters/src/javascript/locales/system/translation.json
@@ -85,6 +85,7 @@
       "InvalidUnaryExpression": "InvalidUnaryExpression",
       "PropertyNotFound": "PropertyNotFound: property: {{property}}",
       "ShadowingDisabled": "ShadowingDisabled: name: {{name}}",
+      "VariableAlreadyDeclared": "VariableAlreadyDeclared: name: {{name}}",
       "AssignmentToConstant": "AssignmentToConstant: name: {{name}}",
       "TruthinessDisabled": "TruthinessDisabled: value: {{value}}",
       "TypeError": "TypeError: {{message}}",

--- a/interpreters/tests/javascript/runtimeErrors.test.ts
+++ b/interpreters/tests/javascript/runtimeErrors.test.ts
@@ -213,13 +213,14 @@ describe("Runtime Errors", () => {
       expect(frames[1].status).toBe("SUCCESS"); // inner scope, not a redeclaration
     });
 
-    test("declaring a let that shares a name with a built-in is allowed", () => {
-      const code = "let Math = 1; Math;";
+    test("redeclaring an injected built-in errors", () => {
+      // `let console = 1` is legal in real JS (it shadows the global), but in this
+      // educational interpreter it is virtually always a mistake, so we error.
+      const code = "let Math = 1;";
       const { frames } = interpret(code);
-      expect(frames).toBeArrayOfSize(2);
-      expect(frames[0].status).toBe("SUCCESS"); // shadowing a built-in is fine
-      expect(frames[1].status).toBe("SUCCESS");
-      expect((frames[1] as TestAugmentedFrame).variables.Math.value).toBe(1);
+      expect(frames).toBeArrayOfSize(1);
+      expectFrameToBeError(frames[0], "Math", "VariableAlreadyDeclared");
+      expect(frames[0].error!.message).toBe("VariableAlreadyDeclared: name: Math");
     });
   });
 

--- a/interpreters/tests/javascript/runtimeErrors.test.ts
+++ b/interpreters/tests/javascript/runtimeErrors.test.ts
@@ -182,6 +182,47 @@ describe("Runtime Errors", () => {
     });
   });
 
+  describe("VariableAlreadyDeclared", () => {
+    test("redeclaring a let in the same scope errors", () => {
+      const code = "let x = 1;\nlet x = 2;";
+      const { frames, error } = interpret(code);
+      expect(error).toBeNull();
+      expect(frames).toBeArrayOfSize(2); // Execution stops after error
+      expect(frames[0].status).toBe("SUCCESS"); // let x = 1
+      expectFrameToBeError(frames[1], "x", "VariableAlreadyDeclared");
+      expect(frames[1].error!.message).toBe("VariableAlreadyDeclared: name: x");
+
+      // Original binding is unchanged
+      expect((frames[0] as TestAugmentedFrame).variables.x.value).toBe(1);
+    });
+
+    test("redeclaring with const errors", () => {
+      const code = "let x = 1;\nconst x = 2;";
+      const { frames } = interpret(code);
+      expect(frames).toBeArrayOfSize(2);
+      expect(frames[0].status).toBe("SUCCESS");
+      expectFrameToBeError(frames[1], "x", "VariableAlreadyDeclared");
+      expect(frames[1].error!.message).toBe("VariableAlreadyDeclared: name: x");
+    });
+
+    test("redeclaring in different scopes is allowed (shadowing on)", () => {
+      const code = "let x = 1; { let x = 2; }";
+      const { frames } = interpret(code, { languageFeatures: { allowShadowing: true } });
+      expect(frames).toBeArrayOfSize(2);
+      expect(frames[0].status).toBe("SUCCESS");
+      expect(frames[1].status).toBe("SUCCESS"); // inner scope, not a redeclaration
+    });
+
+    test("declaring a let that shares a name with a built-in is allowed", () => {
+      const code = "let Math = 1; Math;";
+      const { frames } = interpret(code);
+      expect(frames).toBeArrayOfSize(2);
+      expect(frames[0].status).toBe("SUCCESS"); // shadowing a built-in is fine
+      expect(frames[1].status).toBe("SUCCESS");
+      expect((frames[1] as TestAugmentedFrame).variables.Math.value).toBe(1);
+    });
+  });
+
   describe("ShadowingDisabled", () => {
     describe("allowShadowing: false (default)", () => {
       test("simple variable shadowing in block", () => {


### PR DESCRIPTION
## What

`let x = 1; let x = 2;` in the JavaScript interpreter previously **overwrote** the binding silently (`error: null`, two `SUCCESS` frames). Real JavaScript raises a `SyntaxError: Identifier 'x' has already been declared` for this.

This PR makes the interpreter raise a new `VariableAlreadyDeclared` runtime error frame for same-scope `let`/`const` redeclaration (surfaced as a runtime error frame per the shared error-handling pattern, since it's detected at execution time).

## How

- `Environment.define()` takes a new `isDeclaration` flag. When a `let`/`const` declaration reuses a name **already present in the current scope**, it throws `VariableAlreadyDeclared`.
- Built-in injections (console, Math, Object, Number, String, custom functions/classes, secret constants) register with `isDeclaration: false`, so setting them up never trips the check; function-parameter binding is likewise unaffected.
- Cross-scope shadowing is untouched and still handled by the existing `ShadowingDisabled` path.

## Design decision: built-ins error too

Redeclaring an injected built-in (e.g. `let console = 1`, `let Math = 1`) **also errors**. In real JS that is legal shadowing of a global, but in this educational interpreter it's virtually always an unintentional student mistake, so erroring is more helpful than silently shadowing the built-in. (Secret constants keep their existing separate silently-ignored path.)

## Tests

New `VariableAlreadyDeclared` describe block in `tests/javascript/runtimeErrors.test.ts`:
- `let x; let x` → error
- `let x; const x` → error
- different scopes (shadowing on) → allowed
- `let Math = 1` (redeclaring a built-in) → error

Full interpreter suite (3430 passed) and curriculum suite (661 passed) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)