### PR TITLE
Focus LLM tutor on the student's current code

### DIFF
--- a/llm-chat-proxy/src/prompt-builder.ts
+++ b/llm-chat-proxy/src/prompt-builder.ts
@@ -474,6 +474,8 @@ function buildCurrentCodeSection(code: string, language: Language, wasCropped: b
 
 This is the student's current code.${croppedNote}
 
+Base every judgment ONLY on this Current Code block. The stub and solution are just artifacts to show you where the student came from and where they're going. All your discussion should focus on this current code.
+
 \`\`\`${language}
 ${code}
 \`\`\``;


### PR DESCRIPTION
## Problem

The "Talk to Jiki" chat falls out of sync with the student's code: Jiki asks for edits that have already been made, then congratulates the student when nothing changed.

The student's current code *is* sent fresh to the proxy each turn (and placed last in the prompt), so this isn't a stale-transport bug. The model is mis-tracking the code state because the prompt also contains the full **stub** and **solution** (`Target Code`), and the conversation history carries no per-turn code. With the whole solution in context, the model tends to reason about "distance from the solution" and its own prior advice rather than re-reading the current code each turn.

## Change

Add an explicit directive to the `## Current Code` section of the chat prompt:

> Base every judgment ONLY on this Current Code block. The stub and solution are just artifacts to show you where the student came from and where they're going. All your discussion should focus on this current code.

This is the cheapest of the available fixes and targets the most likely culprit. If the lag persists in practice, the next lever is giving the model a per-turn diff signal so it can see what actually changed between messages.

## Testing

- `pnpm test` (proxy): 86 passed
- Pre-commit typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)