### PR TITLE
JS: disallow assignment outside statement position

### DIFF
--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -1,5 +1,15 @@
 # JavaScript Interpreter Evolution
 
+## 2026-06-22: Assignment is statement-only (AssignmentInExpression)
+
+Assignment (`=`) is now only permitted as a complete expression statement (e.g. `x = 5;`) or in a for-loop's init/update clauses (e.g. `for (i = 0; i < 3; i = i + 1)`). Using assignment anywhere else - inside an `if`/`while` condition, a function argument, a variable initializer, an array/object literal, or nested in any other expression - raises a `AssignmentInExpression` syntax error.
+
+This blocks the classic beginner footgun `if (x = 5)` (which in real JS assigns and then tests truthiness, always entering the branch) by steering students toward `===`. Chained assignment (`x = y = 5`, `obj.a = obj.b = 42`) is also blocked, since the inner assignment is used as a value.
+
+### Mechanism
+
+Parser-level. `expression()`/`assignment()` take an `allowAssignment` flag (default `false`); only the three statement-position call sites (expression statement, for-init, for-update) pass `true`. When `assignment()` encounters `=` with the flag unset it throws `AssignmentInExpression` pointing at the `=` token. The RHS of a permitted assignment is parsed with the flag unset, which is what makes chained assignment an error. Because it is a parse error, it surfaces as `error` with empty `frames[]` per the shared error-handling pattern.
+
 ## 2026-06-22: Same-scope redeclaration error (VariableAlreadyDeclared)
 
 Redeclaring a `let`/`const` binding in the same scope (e.g. `let x = 1; let x = 2;`) now raises a `VariableAlreadyDeclared` runtime error instead of silently overwriting. This matches real JavaScript, which raises a SyntaxError for that code. (Detected at execution rather than parse time, so it surfaces as a runtime error frame following the shared error-handling pattern.)

--- a/interpreters/src/javascript/error.ts
+++ b/interpreters/src/javascript/error.ts
@@ -3,6 +3,7 @@ import type { Location } from "../shared/location";
 export type SyntaxErrorType =
   | "GenericSyntaxError"
   | "InvalidAssignmentTargetExpression"
+  | "AssignmentInExpression"
   | "MissingBacktickToTerminateTemplateLiteral"
   | "MissingDoubleQuoteToTerminateString"
   | "MissingExpression"

--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -3,6 +3,7 @@
     "syntax": {
       "GenericSyntaxError": "A syntax error occurred in your code.",
       "InvalidAssignmentTargetExpression": "Invalid assignment target. You can only assign to variables.",
+      "AssignmentInExpression": "You probably meant to use ===, not = here in order to compare two values, not update the variable. Assigning variables inside a statement is not allowed in this editor.",
       "MissingBacktickToTerminateTemplateLiteral": "Missing closing backtick `` ` `` to terminate template literal.",
       "MissingDoubleQuoteToTerminateString": "Did you forget to add end quote? Maybe you meant to write:\n\n```\"{{string}}\"```",
       "MissingExpression": "Missing expression in code.",

--- a/interpreters/src/javascript/locales/system/translation.json
+++ b/interpreters/src/javascript/locales/system/translation.json
@@ -3,6 +3,7 @@
     "syntax": {
       "GenericSyntaxError": "GenericSyntaxError",
       "InvalidAssignmentTargetExpression": "InvalidAssignmentTargetExpression",
+      "AssignmentInExpression": "AssignmentInExpression",
       "MissingBacktickToTerminateTemplateLiteral": "MissingBacktickToTerminateTemplateLiteral",
       "MissingDoubleQuoteToTerminateString": "Did you forget to add end quote? Maybe you meant to write:\n\n```\"{{string}}\"```",
       "MissingExpression": "MissingExpression",

--- a/interpreters/src/javascript/parser.ts
+++ b/interpreters/src/javascript/parser.ts
@@ -226,7 +226,9 @@ export class Parser {
       // Check if ExpressionStatement is allowed
       this.checkNodeAllowed("ExpressionStatement", "ExpressionStatementNotAllowed", this.peek().location);
 
-      const expr = this.expression();
+      // Assignment is allowed here: a bare expression statement is the canonical
+      // place to assign to a variable (e.g. `x = 5;`).
+      const expr = this.expression(true);
       const semicolonToken = this.consumeSemicolon();
       // Create location that spans from expression start to semicolon end
       const statementLocation = new Location(
@@ -463,7 +465,8 @@ export class Parser {
         // would try to modify a constant variable
         throw this.error("ConstInForLoopInit", this.previous().location);
       } else {
-        init = this.expression();
+        // For-loop init is a statement position, so assignment is allowed (e.g. `i = 0`).
+        init = this.expression(true);
         this.consumeForLoopSemicolon();
       }
 
@@ -477,7 +480,8 @@ export class Parser {
       // Parse update
       let update: Expression | null = null;
       if (!this.check("RIGHT_PAREN")) {
-        update = this.expression();
+        // For-loop update is a statement position, so assignment is allowed (e.g. `i = i + 1`).
+        update = this.expression(true);
       }
 
       this.consume("RIGHT_PAREN", "MissingRightParenthesisAfterExpression");
@@ -563,17 +567,31 @@ export class Parser {
     return new ContinueStatement(continueToken, Location.between(continueToken, semicolonToken));
   }
 
-  private expression(): Expression {
-    return this.assignment();
+  private expression(allowAssignment = false): Expression {
+    return this.assignment(allowAssignment);
   }
 
-  private assignment(): Expression {
+  private assignment(allowAssignment = false): Expression {
     const expr = this.logicalOr();
 
-    if (this.match("EQUAL")) {
+    if (this.check("EQUAL")) {
+      const equalToken = this.peek();
+
+      // Assignment is only permitted as a complete statement (or in a for-loop
+      // init/update). Anywhere else - if/while conditions, function arguments,
+      // initializers, nested expressions - it is almost always a mistake for
+      // `===`, so we block it.
+      if (!allowAssignment) {
+        throw this.error("AssignmentInExpression", equalToken.location);
+      }
+
+      this.advance(); // consume the EQUAL token
+
       // Check if AssignmentExpression is allowed
       this.checkNodeAllowed("AssignmentExpression", "AssignmentExpressionNotAllowed", expr.location);
 
+      // The right-hand side is a value expression, so chained assignment
+      // (e.g. `x = y = 5`) is also disallowed - assignment stays statement-only.
       const value = this.assignment();
 
       if (expr instanceof IdentifierExpression) {

--- a/interpreters/tests/javascript/concepts/object-property-writing.test.ts
+++ b/interpreters/tests/javascript/concepts/object-property-writing.test.ts
@@ -1,4 +1,5 @@
 import { interpret } from "@javascript/interpreter";
+import { SyntaxError } from "@javascript/error";
 import type { TestAugmentedFrame } from "@shared/frames";
 
 describe("Object Property Writing", () => {
@@ -259,20 +260,18 @@ describe("Object Property Writing", () => {
   });
 
   describe("chained assignments", () => {
-    it("should handle chained property assignments", () => {
+    it("should block chained property assignments", () => {
+      // Chained assignment uses assignment as a value inside another expression,
+      // which is only allowed as a complete statement.
       const code = `
         let obj = {};
         let value = obj.a = obj.b = 42;
         value;
       `;
       const result = interpret(code);
-      expect(result.success).toBe(true);
-      expect(result.error).toBe(null);
-      expect(result.frames).toHaveLength(3);
-
-      const lastFrame = result.frames[2] as TestAugmentedFrame;
-      expect(lastFrame.status).toBe("SUCCESS");
-      expect(lastFrame.result?.jikiObject?.toString()).toBe("42");
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(SyntaxError);
+      expect(result.error?.type).toBe("AssignmentInExpression");
     });
   });
 

--- a/interpreters/tests/javascript/concepts/variables.test.ts
+++ b/interpreters/tests/javascript/concepts/variables.test.ts
@@ -1,4 +1,5 @@
 import { interpret } from "@javascript/interpreter";
+import { SyntaxError } from "@javascript/error";
 import type { TestAugmentedFrame } from "@shared/frames";
 describe("variables concept", () => {
   describe("parser", () => {
@@ -87,11 +88,12 @@ describe("variables concept", () => {
       expect((frames[2] as TestAugmentedFrame).variables.a.value).toBe(13);
     });
 
-    test("assignment in complex expressions (negation of assignment)", () => {
-      const { frames, error } = interpret("let x = 5; -(x = 3);");
-      expect(error).toBeNull();
-      expect(frames).toBeArrayOfSize(2);
-      expect((frames[1] as TestAugmentedFrame).variables.x.value).toBe(3); // Assignment happened inside negation
+    test("assignment nested in an expression is blocked", () => {
+      // Assignment is only allowed as a complete statement, so using it inside
+      // another expression (here, a negation) is a syntax error.
+      const { error } = interpret("let x = 5; -(x = 3);");
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error?.type).toBe("AssignmentInExpression");
     });
   });
 });

--- a/interpreters/tests/javascript/footguns/16-assignment-in-conditional.test.ts
+++ b/interpreters/tests/javascript/footguns/16-assignment-in-conditional.test.ts
@@ -1,18 +1,55 @@
 import { interpret } from "@javascript/interpreter";
+import { SyntaxError } from "@javascript/error";
 
 describe("Footgun #16: Assignment in conditional (if (x = 5))", () => {
   // In real JS: if (x = 5) assigns 5 to x, then checks truthiness (always true)
   // A beginner writing if (x = 5) almost certainly meant if (x === 5)
-  // This should be blocked or warned about
+  // Jiki blocks assignment anywhere other than a complete statement (or a
+  // for-loop init/update), so these are reported as syntax errors.
 
-  test.skip("assignment in if condition should be blocked", () => {
-    const { frames } = interpret("let x = 0; if (x = 5) { let y = 1 }");
-    // Should produce an error rather than silently assigning
-    expect(frames.find(f => f.status === "ERROR")).toBeDefined();
+  test("assignment in if condition is blocked", () => {
+    const { error, frames } = interpret("let x = 0; if (x = 5) { let y = 1 }");
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect(error?.type).toBe("AssignmentInExpression");
+    expect(frames).toHaveLength(0);
   });
 
-  test.skip("assignment in while condition should be blocked", () => {
-    const { frames } = interpret("let x = 0; while (x = 1) { break }");
-    expect(frames.find(f => f.status === "ERROR")).toBeDefined();
+  test("assignment in while condition is blocked", () => {
+    const { error } = interpret("let x = 0; while (x = 1) { break }");
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect(error?.type).toBe("AssignmentInExpression");
+  });
+
+  test("comparison in if condition is still allowed", () => {
+    const { error } = interpret("let x = 5; if (x === 5) { let y = 1 }");
+    expect(error).toBeNull();
+  });
+
+  test("assignment as a complete statement is still allowed", () => {
+    const { error } = interpret("let x = 0; x = 5;");
+    expect(error).toBeNull();
+  });
+
+  test("assignment in a function argument is blocked", () => {
+    const { error } = interpret("let x = 0; console.log(x = 5);");
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect(error?.type).toBe("AssignmentInExpression");
+  });
+
+  test("assignment in a variable initializer is blocked", () => {
+    const { error } = interpret("let x = 0; let y = (x = 5);");
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect(error?.type).toBe("AssignmentInExpression");
+  });
+
+  test("chained assignment is blocked", () => {
+    const { error } = interpret("let x = 0; let y = 0; x = y = 5;");
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect(error?.type).toBe("AssignmentInExpression");
+  });
+
+  test("assignment in for-loop init and update is still allowed", () => {
+    const { error } = interpret("let i = 0; for (i = 0; i < 3; i = i + 1) { let y = i }");
+    expect(error).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

A student could previously write `if (alien = true) {` in the JavaScript interpreter and it would silently assign and always enter the branch (the classic `=` vs `===` footgun). This PR blocks that.

Assignment (`=`) is now permitted **only** as a complete expression statement (`x = 5;`) or in a for-loop init/update clause (`for (i = 0; i < 3; i = i + 1)`). Using it anywhere else raises an `AssignmentInExpression` syntax error:

> You probably meant to use ===, not = here in order to compare two values, not update the variable. Assigning variables inside a statement is not allowed in this editor.

This catches `if (x = 5)`, `while (x = 1)`, `foo(x = 5)`, `let y = (x = 5)`, and chained `x = y = 5` / `obj.a = obj.b = 42`.

## Implementation

Parser-level. `expression()`/`assignment()` take an `allowAssignment` flag (default `false`); only the three statement-position call sites (expression statement, for-init, for-update) pass `true`. The RHS of a permitted assignment is parsed with the flag unset, which is what makes chained assignment an error. It surfaces as a parse error (`error` set, empty `frames[]`), per the shared error-handling pattern.

## Tests

- Un-skipped footgun #16 and expanded its coverage (conditions, args, initializers, chained assignment, for-loop init/update still allowed).
- Updated two concept tests that asserted the old footgun behavior.
- Full suites green: interpreters (1658), curriculum (661), app (1750); typecheck + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)