### PR TITLE
Restyle concepts pages, header nav, and signup CTAs

### DIFF
--- a/app/app/styles/modules/concepts.module.css
+++ b/app/app/styles/modules/concepts.module.css
@@ -2,6 +2,24 @@
 .mainContent {
     flex: 1;
     min-height: 100vh;
+    position: relative;
+    isolation: isolate;
+
+    &::before {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        z-index: -1;
+        height: 520px;
+        opacity: 0.7;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cg opacity='0.4'%3E%3Cline x1='14' y1='0' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3Cline x1='0' y1='14' x2='14' y2='14' stroke='%23cbd5e1' stroke-width='1'/%3E%3C/g%3E%3C/svg%3E");
+        -webkit-mask-image: linear-gradient(to bottom, black 0%, black 65%, transparent 100%);
+        mask-image: linear-gradient(to bottom, black 0%, black 65%, transparent 100%);
+        pointer-events: none;
+        content: "";
+    }
 
     @media (max-width: 1200px) {
         padding: 24px 20px;
@@ -31,7 +49,6 @@
     font-weight: 400;
     position: sticky;
     top: 0;
-    background: white;
     z-index: var(--z-index-sticky);
     border-bottom: 1px solid var(--color-gray-200);
 

--- a/app/components/articles/ArticleDetailPage.tsx
+++ b/app/components/articles/ArticleDetailPage.tsx
@@ -63,7 +63,7 @@ export default async function ArticleDetailPage({ slug, authenticated, locale }:
         variant="gradient"
         title="Ready to Start Your Coding Journey?"
         subtitle="Join thousands of learners on Jiki. Practice coding exercises, get feedback from mentors, and level up your skills — it's free!"
-        buttonText="Sign Up to Jiki"
+        buttonText="Sign Up For Free"
         buttonHref="/signup"
       />
     </>

--- a/app/components/blog/BlogPostPage.tsx
+++ b/app/components/blog/BlogPostPage.tsx
@@ -68,7 +68,7 @@ export default async function BlogPostPage({ slug, authenticated, locale }: Blog
         variant="gradient"
         title="Ready to Start Your Coding Journey?"
         subtitle="Join thousands of learners on Jiki. Practice coding exercises, get feedback from mentors, and level up your skills — it's free!"
-        buttonText="Sign Up to Jiki"
+        buttonText="Sign Up For Free"
         buttonHref="/signup"
       />
     </>

--- a/app/components/concepts/Breadcrumb.tsx
+++ b/app/components/concepts/Breadcrumb.tsx
@@ -18,11 +18,11 @@ interface BreadcrumbProps {
 export default function Breadcrumb({ conceptTitle, ancestors = [] }: BreadcrumbProps) {
   const breadcrumbItems: BreadcrumbItem[] = [];
 
-  // If no concept title, we're on the "All Concepts" page
+  // If no concept title, we're on the "Coding Concepts" page
   if (!conceptTitle) {
-    breadcrumbItems.push({ label: "All Concepts", isCurrent: true });
+    breadcrumbItems.push({ label: "Coding Concepts", isCurrent: true });
   } else {
-    breadcrumbItems.push({ label: "All Concepts", href: "/concepts" });
+    breadcrumbItems.push({ label: "Coding Concepts", href: "/concepts" });
 
     // Add ancestors to breadcrumb path
     for (const ancestor of ancestors) {

--- a/app/components/concepts/ConceptGroupView.tsx
+++ b/app/components/concepts/ConceptGroupView.tsx
@@ -19,18 +19,20 @@ export function ConceptGroupView({ concept, ancestors, initialSubconcepts }: Con
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   return (
-    <ConceptsLayout>
-      <Breadcrumb conceptTitle={concept.title} ancestors={ancestors} />
+    <>
+      <ConceptsLayout>
+        <Breadcrumb conceptTitle={concept.title} ancestors={ancestors} />
 
-      <header>
-        <h1 className={styles.pageHeading}>
-          <FolderIcon className={`${styles.headingIcon} w-8 h-8`} />
-          {concept.title}
-        </h1>
-      </header>
+        <header>
+          <h1 className={styles.pageHeading}>
+            <FolderIcon className={`${styles.headingIcon} w-8 h-8`} />
+            {concept.title}
+          </h1>
+        </header>
 
-      <SubconceptsGrid parentSlug={concept.slug} initialSubconcepts={initialSubconcepts} />
+        <SubconceptsGrid parentSlug={concept.slug} initialSubconcepts={initialSubconcepts} />
+      </ConceptsLayout>
       {!isAuthenticated && <SignupCta />}
-    </ConceptsLayout>
+    </>
   );
 }

--- a/app/components/concepts/ConceptHero.module.css
+++ b/app/components/concepts/ConceptHero.module.css
@@ -3,7 +3,7 @@
     margin-bottom: 32px;
     border-radius: 24px;
     text-align: center;
-    background: linear-gradient(135deg, var(--color-blue-500-5) 0%, var(--color-purple-500-6) 100%);
+    background: var(--color-purple-100);
 
     @media (max-width: 1200px) {
         padding: 40px 24px;
@@ -17,7 +17,7 @@
 }
 
 .title {
-    font-size: 56px;
+    font-size: 48px;
     font-weight: 700;
     line-height: 1.2;
     color: var(--color-gray-800);

--- a/app/components/concepts/ConceptLayout.module.css
+++ b/app/components/concepts/ConceptLayout.module.css
@@ -16,10 +16,6 @@
     min-width: 0;
 }
 
-.footer {
-    grid-column: 1 / -1;
-}
-
 @media (max-width: 1200px) {
     .grid {
         grid-template-columns: 1fr;

--- a/app/components/concepts/ConceptLayout.tsx
+++ b/app/components/concepts/ConceptLayout.tsx
@@ -5,10 +5,9 @@ interface ConceptLayoutProps {
   children: React.ReactNode;
   breadcrumb?: React.ReactNode;
   rightPanel?: React.ReactNode;
-  footer?: React.ReactNode;
 }
 
-export default function ConceptLayout({ children, breadcrumb, rightPanel, footer }: ConceptLayoutProps) {
+export default function ConceptLayout({ children, breadcrumb, rightPanel }: ConceptLayoutProps) {
   return (
     <div className={styles.grid}>
       <main className={styles.main}>
@@ -16,7 +15,6 @@ export default function ConceptLayout({ children, breadcrumb, rightPanel, footer
         {children}
       </main>
       <aside className={styles.aside}>{rightPanel || <div />}</aside>
-      {footer && <div className={styles.footer}>{footer}</div>}
     </div>
   );
 }

--- a/app/components/concepts/ConceptLeafView.tsx
+++ b/app/components/concepts/ConceptLeafView.tsx
@@ -46,28 +46,30 @@ export function ConceptLeafView({ slug, initialData }: ConceptLeafViewProps) {
   }
 
   return (
-    <ConceptsLayout>
-      <ConceptLayout
-        breadcrumb={<Breadcrumb conceptTitle={concept.title} ancestors={ancestors} />}
-        rightPanel={
-          <ConceptSidebar
-            conceptSlug={concept.slug}
-            relatedConcepts={relatedConcepts}
-            relatedExercises={relatedExercises}
-            relatedProjects={relatedProjects}
-            videoData={videoData}
-            isConceptUnlocked={isConceptUnlocked}
-            getExerciseStatus={getExerciseStatus}
-            getProjectStatus={getProjectStatus}
-            isAuthenticated={isAuthenticated}
-          />
-        }
-        footer={!isAuthenticated && content ? <SignupCta /> : undefined}
-      >
-        <ConceptHero title={concept.title} intro={concept.description} />
-        {isContentLoading && <ConceptArticleSkeleton />}
-        {content && <MarkdownContent content={content} variant="base" />}
-      </ConceptLayout>
-    </ConceptsLayout>
+    <>
+      <ConceptsLayout>
+        <ConceptLayout
+          breadcrumb={<Breadcrumb conceptTitle={concept.title} ancestors={ancestors} />}
+          rightPanel={
+            <ConceptSidebar
+              conceptSlug={concept.slug}
+              relatedConcepts={relatedConcepts}
+              relatedExercises={relatedExercises}
+              relatedProjects={relatedProjects}
+              videoData={videoData}
+              isConceptUnlocked={isConceptUnlocked}
+              getExerciseStatus={getExerciseStatus}
+              getProjectStatus={getProjectStatus}
+              isAuthenticated={isAuthenticated}
+            />
+          }
+        >
+          <ConceptHero title={concept.title} intro={concept.description} />
+          {isContentLoading && <ConceptArticleSkeleton />}
+          {content && <MarkdownContent content={content} variant="base" />}
+        </ConceptLayout>
+      </ConceptsLayout>
+      {!isAuthenticated && content && <SignupCta />}
+    </>
   );
 }

--- a/app/components/concepts/ConceptsListPage.tsx
+++ b/app/components/concepts/ConceptsListPage.tsx
@@ -31,28 +31,32 @@ export default function ConceptsListPage({ initialConcepts }: ConceptsListPagePr
   const showEmptyState = unlockedCount === 0 && concepts.length > 0;
 
   return (
-    <ConceptsLayout>
-      <ConceptsHeader />
+    <>
+      <ConceptsLayout>
+        <ConceptsHeader />
 
-      {showEmptyState || isLoading ? (
-        <p className={styles.conceptsDescription}>Here you can review and revisit the concepts you&apos;ve learned.</p>
-      ) : (
-        <ConceptsSearch
-          searchQuery={searchQuery}
-          onSearchChange={handleSearchChange}
-          onClearSearch={clearSearch}
-          totalCount={totalCount}
-        />
-      )}
+        {showEmptyState || isLoading ? (
+          <p className={styles.conceptsDescription}>
+            Here you can review and revisit the concepts you&apos;ve learned.
+          </p>
+        ) : (
+          <ConceptsSearch
+            searchQuery={searchQuery}
+            onSearchChange={handleSearchChange}
+            onClearSearch={clearSearch}
+            totalCount={totalCount}
+          />
+        )}
 
-      {showSkeleton ? (
-        <ConceptCardsLoadingSkeleton />
-      ) : error && concepts.length === 0 ? (
-        <ErrorState error={error} onRetry={() => window.location.reload()} />
-      ) : (
-        <ConceptsGrid concepts={concepts} showEmptyState={showEmptyState} />
-      )}
+        {showSkeleton ? (
+          <ConceptCardsLoadingSkeleton />
+        ) : error && concepts.length === 0 ? (
+          <ErrorState error={error} onRetry={() => window.location.reload()} />
+        ) : (
+          <ConceptsGrid concepts={concepts} showEmptyState={showEmptyState} />
+        )}
+      </ConceptsLayout>
       {!isAuthenticated && !isLoading && <SignupCta />}
-    </ConceptsLayout>
+    </>
   );
 }

--- a/app/components/concepts/SignupCta.module.css
+++ b/app/components/concepts/SignupCta.module.css
@@ -4,32 +4,32 @@
 
 .cta {
     padding: 40px 60px;
-    background: linear-gradient(135deg, var(--color-purple-600) 0%, var(--color-purple-500) 100%);
-    border-radius: 16px;
+    background: linear-gradient(135deg, var(--color-blue-600) 0%, var(--color-blue-500) 100%);
     text-align: center;
 }
 
 .title {
-    font-size: 25px;
+    font-size: 32px;
     font-weight: 700;
     color: white;
-    margin-bottom: 16px;
+    margin-bottom: 8px;
     line-height: 1.2;
 }
 
 .subtitle {
     font-size: 18px;
-    color: var(--color-purple-200);
-    margin-bottom: 24px;
+    color: var(--color-blue-100);
+    max-width: 600px;
+    margin: 0 auto 20px;
     line-height: 1.6;
 }
 
 .button {
     display: inline-block;
     background: white;
-    color: var(--color-purple-600);
+    color: var(--color-blue-600);
     padding: 16px 40px;
-    border-radius: 8px;
+    border-radius: 12px;
     font-size: 18px;
     font-weight: 600;
     text-decoration: none;

--- a/app/components/concepts/SignupCta.tsx
+++ b/app/components/concepts/SignupCta.tsx
@@ -7,12 +7,11 @@ export function SignupCta() {
       <div className={styles.cta}>
         <h2 className={styles.title}>Ready to Start Your Coding Journey?</h2>
         <p className={styles.subtitle}>
-          Join thousands of learners on Jiki.
-          <br />
-          Practice coding exercises, get feedback from mentors, and level up your skills — it&apos;s free!
+          Join thousands of learners on Jiki. Practice coding exercises, get feedback from mentors, and level up your
+          skills — it&apos;s free!
         </p>
         <Link href="/auth/signup" className={styles.button}>
-          Sign Up to Jiki
+          Sign Up For Free
         </Link>
       </div>
     </div>

--- a/app/components/concepts/UpgradeCard.tsx
+++ b/app/components/concepts/UpgradeCard.tsx
@@ -16,7 +16,7 @@ export function UpgradeCard() {
         all, <span className={styles.free}>it&apos;s free!</span>
       </p>
       <Link href="/auth/signup" className="ui-btn ui-btn-small ui-btn-primary" style={{ width: "100%" }}>
-        Sign Up
+        Sign Up For Free
       </Link>
     </div>
   );

--- a/app/components/concepts/VideoRecapCard.module.css
+++ b/app/components/concepts/VideoRecapCard.module.css
@@ -66,7 +66,7 @@
     justify-content: center;
     transition: all 0.3s ease;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
-    opacity: 0;
+    opacity: 1;
 
     svg {
         width: 22px;

--- a/app/components/layout/AuthHeader.tsx
+++ b/app/components/layout/AuthHeader.tsx
@@ -79,7 +79,7 @@ export function AuthHeader({ title }: AuthHeaderProps) {
                   href="/auth/signup"
                   className="px-3 py-1.5 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
                 >
-                  Sign Up
+                  Sign Up For Free
                 </Link>
               </div>
             )}

--- a/app/components/layout/header/external.module.css
+++ b/app/components/layout/header/external.module.css
@@ -1,0 +1,17 @@
+.navLink {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 8px 14px;
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--color-gray-700);
+    border-radius: 6px;
+    white-space: nowrap;
+    transition: all 0.15s ease;
+
+    &:hover {
+        color: var(--color-blue-600);
+        background: var(--color-gray-100);
+    }
+}

--- a/app/components/layout/header/external.tsx
+++ b/app/components/layout/header/external.tsx
@@ -1,8 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import shared from "@/components/landing-page/shared.module.css";
-
-const navLinkStyle = { borderBottom: "1px solid var(--color-gray-400)", lineHeight: 1.2 };
+import styles from "./external.module.css";
 
 export default function ExternalHeader() {
   return (
@@ -19,14 +18,17 @@ export default function ExternalHeader() {
           />
         </Link>
 
-        <div className="flex items-center gap-12 font-medium text-gray-700 max-[719px]:hidden">
-          <Link href="https://jiki.io/blog/the-backstory-of-jiki" style={navLinkStyle}>
-            About
+        <div className="flex items-center gap-4 text-gray-700 max-[719px]:hidden">
+          <Link href="https://jiki.io/blog/the-backstory-of-jiki" className={styles.navLink}>
+            About Jiki
           </Link>
-          <Link href="/premium" style={navLinkStyle}>
+          <Link href="/concepts" className={styles.navLink}>
+            Coding Concepts
+          </Link>
+          <Link href="/premium" className={styles.navLink}>
             Premium
           </Link>
-          <Link href="/testimonials" style={navLinkStyle}>
+          <Link href="/testimonials" className={styles.navLink}>
             Testimonials
           </Link>
         </div>
@@ -36,7 +38,7 @@ export default function ExternalHeader() {
             Login
           </Link>
           <Link href="/auth/signup" className="ui-btn ui-btn-small ui-btn-primary">
-            Sign Up
+            Sign Up For Free
           </Link>
         </div>
       </div>

--- a/app/components/testimonials/TestimonialsPage.module.css
+++ b/app/components/testimonials/TestimonialsPage.module.css
@@ -1,5 +1,5 @@
 .page {
-    padding-top: 60px;
+    padding-top: 56px;
     padding-bottom: 80px;
     background-repeat: repeat;
     background-color: var(--light-blue);
@@ -13,24 +13,19 @@
     margin-bottom: 48px;
 
     h1 {
-        font-size: 32px;
+        color: var(--color-gray-900);
+        margin-bottom: 16px;
+        font-size: max(34px, min(7vw, 52px));
         font-weight: 700;
-        margin-bottom: 12px;
-
-        @media (min-width: 768px) {
-            font-size: 48px;
-        }
+        line-height: 1.15;
     }
 
     .subtitle {
-        font-size: 18px;
-        font-weight: 400;
-        max-width: 640px;
+        max-width: 650px;
         margin: 0 auto;
-
-        @media (min-width: 768px) {
-            font-size: 22px;
-        }
+        font-size: clamp(16px, 2.2vw, 20px);
+        line-height: 1.6;
+        color: var(--color-gray-500);
     }
 }
 

--- a/app/tests/unit/components/concepts-page/Breadcrumb.test.tsx
+++ b/app/tests/unit/components/concepts-page/Breadcrumb.test.tsx
@@ -4,18 +4,18 @@ import { render, screen } from "@testing-library/react";
 describe("Breadcrumb", () => {
   it("renders without crashing", () => {
     render(<Breadcrumb />);
-    expect(screen.getByText("All Concepts")).toBeInTheDocument();
+    expect(screen.getByText("Coding Concepts")).toBeInTheDocument();
   });
 
-  it("renders All Concepts as current when no conceptTitle provided", () => {
+  it("renders Coding Concepts as current when no conceptTitle provided", () => {
     render(<Breadcrumb />);
-    expect(screen.getByText("All Concepts")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "All Concepts" })).not.toBeInTheDocument();
+    expect(screen.getByText("Coding Concepts")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Coding Concepts" })).not.toBeInTheDocument();
   });
 
-  it("renders concept title with link to All Concepts when conceptTitle provided", () => {
+  it("renders concept title with link to Coding Concepts when conceptTitle provided", () => {
     render(<Breadcrumb conceptTitle="Test Concept" />);
-    expect(screen.getByRole("link", { name: "All Concepts" })).toHaveAttribute("href", "/concepts");
+    expect(screen.getByRole("link", { name: "Coding Concepts" })).toHaveAttribute("href", "/concepts");
     expect(screen.getByText("Test Concept")).toBeInTheDocument();
   });
 

--- a/app/tests/unit/components/concepts-page/ConceptsHeader.test.tsx
+++ b/app/tests/unit/components/concepts-page/ConceptsHeader.test.tsx
@@ -14,6 +14,6 @@ describe("ConceptsHeader", () => {
 
   it("renders breadcrumb component", () => {
     render(<ConceptsHeader />);
-    expect(screen.getByText("All Concepts")).toBeInTheDocument();
+    expect(screen.getByText("Coding Concepts")).toBeInTheDocument();
   });
 });

--- a/app/tests/unit/components/layout/AuthHeader.test.tsx
+++ b/app/tests/unit/components/layout/AuthHeader.test.tsx
@@ -89,7 +89,7 @@ describe("AuthHeader Hydration", () => {
     // Wait for component to mount (hydration simulation)
     await waitFor(() => {
       expect(screen.getByText("Sign In")).toBeInTheDocument();
-      expect(screen.getByText("Sign Up")).toBeInTheDocument();
+      expect(screen.getByText("Sign Up For Free")).toBeInTheDocument();
     });
 
     // Should still show static content
@@ -126,7 +126,7 @@ describe("AuthHeader Hydration", () => {
 
     // Should NOT show anonymous content
     expect(screen.queryByText("Sign In")).not.toBeInTheDocument();
-    expect(screen.queryByText("Sign Up")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign Up For Free")).not.toBeInTheDocument();
   });
 
   it("shows navigation links consistently", () => {


### PR DESCRIPTION
## Summary

Visual restyle of the concepts pages, the external header nav, and the signup CTAs across the site.

### Header (external)
- Nav links restyled to match the design (pill hover, blue-600 hover text) via a new `external.module.css`
- Added a **Coding Concepts** nav link (`/concepts`)
- "About" → "About Jiki"
- Signup button → "Sign Up For Free"

### Concepts pages
- Breadcrumb "All Concepts" → "Coding Concepts"
- Added the faint grid `::before` backdrop (lifted from the Premium page) at `0.7` opacity; removed the breadcrumb white background
- `ConceptHero`: `purple-100` background, 48px title
- `SignupCta` restyled blue (gradient, `blue-100` subtitle, `blue-600` button text), now full-width (lifted out of the layout container on list/group/leaf views), squared card, 12px button radius, tightened title/subtitle spacing
- Removed the now-unused `ConceptLayout` `footer` prop/slot

### CTAs
- `UpgradeCard`, `AuthHeader`, and the article/blog CTA buttons → "Sign Up For Free"

### Testimonials
- Heading/subtitle restyled to match the Premium page

## Testing
- `tsc --noEmit` clean
- Full app suite: 1735 tests passing (incl. updated Breadcrumb / ConceptsHeader / AuthHeader assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)