### PR TITLE
Fix email preferences response key mismatch

### DIFF
--- a/app/lib/api/emailPreferences.ts
+++ b/app/lib/api/emailPreferences.ts
@@ -15,12 +15,12 @@ export interface EmailPreferences {
 }
 
 interface EmailPreferencesResponse {
-  preferences: EmailPreferences;
+  email_preferences: EmailPreferences;
 }
 
 export async function getEmailPreferences(token: string): Promise<EmailPreferences> {
   const response = await api.get<EmailPreferencesResponse>(`/external/email_preferences/${token}`, undefined, false);
-  return response.data.preferences;
+  return response.data.email_preferences;
 }
 
 export async function updateEmailPreference(token: string, key: string, value: boolean): Promise<EmailPreferences> {
@@ -30,7 +30,7 @@ export async function updateEmailPreference(token: string, key: string, value: b
     undefined,
     false
   );
-  return response.data.preferences;
+  return response.data.email_preferences;
 }
 
 export async function updateEmailPreferences(
@@ -43,7 +43,7 @@ export async function updateEmailPreferences(
     undefined,
     false
   );
-  return response.data.preferences;
+  return response.data.email_preferences;
 }
 
 export async function unsubscribeAll(token: string): Promise<EmailPreferences> {
@@ -53,7 +53,7 @@ export async function unsubscribeAll(token: string): Promise<EmailPreferences> {
     undefined,
     false
   );
-  return response.data.preferences;
+  return response.data.email_preferences;
 }
 
 export async function subscribeAll(token: string): Promise<EmailPreferences> {
@@ -63,5 +63,5 @@ export async function subscribeAll(token: string): Promise<EmailPreferences> {
     undefined,
     false
   );
-  return response.data.preferences;
+  return response.data.email_preferences;
 }


### PR DESCRIPTION
## Problem

On `/unsubscribe?token=...&key=newsletters`, the page only renders the "Unsubscribe from All Emails" card. The per-email "Unsubscribe from This Email" card (and the notifications section) never appear, even though the user is subscribed.

## Root cause

The external email preferences API returns the preferences object under the `email_preferences` key:

```json
{"email_preferences":{"email":"...","newsletters":true,...},"meta":{"events":[]}}
```

but the client read `response.data.preferences`, which was always `undefined`. That `undefined` slipped past the `notFound()` guard on the unsubscribe page (which only triggers on a thrown error), leaving `preferences == null`. Both the per-email card and the notifications section are gated on a truthy `preferences`, so neither rendered — only the unconditional "Unsubscribe from All Emails" card showed.

All five API functions (`getEmailPreferences`, `updateEmailPreference`, `updateEmailPreferences`, `unsubscribeAll`, `subscribeAll`) had the same latent bug and would have returned `undefined` after updates too.

## Fix

Read `email_preferences` from the response in all five functions and update the `EmailPreferencesResponse` interface. Verified the field name against the live production API.

## Testing

- `pnpm typecheck` passes
- Full app test suite passes (1735 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)