### PR TITLE
Audit sprouting-flower: fix stub, comments, and LLM metadata

### DIFF
--- a/curriculum/.claude/commands/audit-exercise.md
+++ b/curriculum/.claude/commands/audit-exercise.md
@@ -239,6 +239,24 @@ Note: It is ok for the LLM instructions to have the answers! The LLM knows not t
 
 ---
 
+### Check 10: Stubs Are Level-Appropriate and Consistent
+
+**Rule**: Each stub (`stub.javascript`, `stub.jiki`, `stub.py`) is the student's starting point. It must only contain language constructs that have already been introduced **at or before this exercise's level**, must follow the target language's conventions, and must structurally align with the solution.
+
+**Check each of these**:
+
+1. **Level-appropriate constructs**: The stub must NOT use syntax or AST nodes that the exercise's level (and earlier levels) hasn't introduced yet. Cross-reference the exercise's `levelId` against the level definitions in `src/levels/` (and `.context/levels.md`) to see which features are allowed. For example, do NOT use a `for` loop in the stub if `for` loops are introduced much later — use the construct the curriculum teaches at this point (e.g. `repeat(N) { ... }`). The stub should model the expected approach, not foreshadow later syntax.
+
+2. **JavaScript-first conventions**: `stub.javascript` must use JavaScript syntax (`repeat(60) { ... }`, `let`, `//` comments, camelCase). No Jikiscript (`repeat N times do ... end`, `set ... to`) or Python (`for i in range`, `:` blocks, `#` comments) syntax in the `.javascript` stub.
+
+3. **Stub ↔ solution structure**: The fixed/pre-written parts of the stub (scaffolding, comments, pre-drawn elements, constant values) must match the corresponding parts of the solution. Flag drift such as a stub drawing a shape at one size while the solution uses another, or a `// TODO` that doesn't correspond to what the solution actually does there.
+
+4. **Cross-language parity**: All three stubs should present the same scaffold and the same TODOs, differing only in language syntax. Flag a stub that is missing a section another language's stub has, or that hardcodes a different value.
+
+**How to check**: Read all three stub files and the matching solution files. Identify the exercise's level, list the constructs the stub uses, and confirm each is allowed at that level. Then diff the stub's fixed portions against the solution.
+
+---
+
 ## Step 3: Report Audit Results and Exercise Context
 
 Present the audit results, then the full exercise context:

--- a/curriculum/src/exercises/sprouting-flower/llm-metadata.ts
+++ b/curriculum/src/exercises/sprouting-flower/llm-metadata.ts
@@ -9,22 +9,28 @@ interface LLMMetadata {
 
 export const llmMetadata: LLMMetadata = {
   description: `
-    This exercise lets a student practise building a complex graphic from variable
-    relationships, deriving every element from a single moving point (the flower center).
+    Objective: derive every element of a scene from one moving anchor (the flower center)
+    and animate it via per-iteration variable updates.
   `,
 
   tasks: {
     "draw-scene": {
       description: `
-        Common mistakes:
-        - Using absolute positions instead of deriving everything from flowerCenter
-        - Forgetting to update variables at the start of each iteration (before drawing)
-        - Confusing the coordinate system (y=0 is top, y=100 is bottom)
-        - Hardcoding values instead of using the relationships in the spec
-        - Drawing in the wrong order (sky/ground must come first, or they cover the flower)
+        There is a single task that spans the entire solution (no sub-progression). The
+        student is expected to build it incrementally: flower head -> pistil -> stem ->
+        leaves, getting each working before adding the next.
 
-        Encourage building one element at a time (flower, then pistil, stem, leaves) and
-        using the scrubber to inspect variable values and compare first/last frames.
+        Two traps survive even with the solution in front of you, so steer towards them:
+        - Update order: variables must be reassigned at the TOP of the loop body, before any
+          draw call. Updating after drawing produces a frame-off result that still "looks"
+          almost right and is hard to spot without the scrubber. If the student is stuck
+          here, try to help them reason about why this needs to happen, rather than just
+          enforce it as a rule for them.
+        - Draw order: shapes paint over each other, so the back-to-front sequence (sky,
+          ground, stem, flower head, pistil, leaves) matters. A wrong order hides elements.
+
+        Point the student at the scrubber's info toggle to compare their first/last-frame
+        values against the ones given in the instructions.
       `
     }
   }

--- a/curriculum/src/exercises/sprouting-flower/solution.jiki
+++ b/curriculum/src/exercises/sprouting-flower/solution.jiki
@@ -43,7 +43,7 @@ repeat 60 times do
   // Ground
   rectangle(0, ground_top, 100, 10, "green")
 
-  // Ground
+  // Stem
   rectangle(stem_left, stem_top, stem_width, stem_height, "green")
 
   // Flower head
@@ -52,7 +52,7 @@ repeat 60 times do
   // Pistil
   circle(flower_center_x, flower_center_y, pistil_radius, "yellow")
 
-  // Stem
+  // Leaves
   ellipse(left_leaf_left, leaf_top, leaf_x_radius, leaf_y_radius, "green")
   ellipse(right_leaf_left, leaf_top, leaf_x_radius, leaf_y_radius, "green")
 

--- a/curriculum/src/exercises/sprouting-flower/stub.javascript
+++ b/curriculum/src/exercises/sprouting-flower/stub.javascript
@@ -1,6 +1,6 @@
 // TODO: Set your initial variables here
 
-for (let i = 0; i < 60; i = i + 1) {
+repeat(60) {
   // TODO: Update your variables here
 
   // Sky


### PR DESCRIPTION
Audit pass over the `sprouting-flower` exercise, plus a new stub check in the audit skill.

## Changes

- **`stub.javascript`** — use `repeat(60) { }` instead of a `for` loop. `for` loops aren't introduced until much later; `basic-state` only adds `AssignmentExpression`/`UnaryExpression`, so the stub now models the level-appropriate construct (and matches `solution.javascript`).
- **`solution.jiki`** — fix mislabeled comments (`// Ground` → `// Stem` over the stem rect, `// Stem` → `// Leaves` over the ellipses). Now consistent with the JS/Py solutions.
- **`llm-metadata.ts`** — trim content derivable from the instructions/solution (audit Check 7b). Keeps the single-task framing, the incremental build order, and the two traps that survive even with the solution visible (update-order, draw-order). Nudges the LLM to help students reason about *why* updates must precede draws rather than enforce it as a rule.
- **`audit-exercise.md`** — add **Check 10**: stubs must use only level-appropriate constructs, follow JS-first conventions, align structurally with the solution, and stay in cross-language parity.

## Testing

- `pnpm typecheck` clean
- `pnpm test` — 661 tests pass (sprouting-flower: 18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)