### PR TITLE
Annalyn's Infiltration: exactly-once checks, reworked hints, fix typos

### DIFF
--- a/app/components/coding-exercise/CodingExercise.module.css
+++ b/app/components/coding-exercise/CodingExercise.module.css
@@ -616,6 +616,10 @@
     white-space: nowrap;
 }
 
+.testFeedback .message strong {
+    font-weight: 600;
+}
+
 .testDescription.stateFailed .testFeedback {
     background: var(--color-red-50);
 }

--- a/app/components/coding-exercise/ui/HintsPanel.tsx
+++ b/app/components/coding-exercise/ui/HintsPanel.tsx
@@ -210,7 +210,7 @@ function HintItem({ question, answer, isRevealed = false, onReveal, onHide, styl
           )}
         </div>
       </div>
-      <div className={style?.hintAnswer}>
+      <div className={style?.hintAnswer} onClick={(e) => e.stopPropagation()}>
         {showConfirmOverlay && (
           <div className={style?.hintConfirmOverlay} onClick={(e) => e.stopPropagation()}>
             <div className={style?.hintConfirmText}>Are you sure you want to reveal this hint?</div>

--- a/curriculum/src/exercises/annalyns-infiltration/Exercise.ts
+++ b/curriculum/src/exercises/annalyns-infiltration/Exercise.ts
@@ -13,11 +13,11 @@ export default class AnnalynsInfiltrationExercise extends VisualExercise {
   private prisonerAwake: boolean = false;
   private dogBehaving: boolean = false;
 
-  // Actions Annalyn has taken
-  didFastAttack: boolean = false;
-  didSpy: boolean = false;
-  didSignal: boolean = false;
-  didFree: boolean = false;
+  // Number of times Annalyn has taken each action
+  fastAttackCount: number = 0;
+  spyCount: number = 0;
+  signalCount: number = 0;
+  freeCount: number = 0;
 
   private backgroundImg!: HTMLImageElement;
 
@@ -89,22 +89,22 @@ export default class AnnalynsInfiltrationExercise extends VisualExercise {
 
   // Action functions
   fastAttack(executionCtx: ExecutionContext) {
-    this.didFastAttack = true;
+    this.fastAttackCount += 1;
     this.animateIntoView(executionCtx, `#${this.view.id} .action-fast-attack`);
   }
 
   spy(executionCtx: ExecutionContext) {
-    this.didSpy = true;
+    this.spyCount += 1;
     this.animateIntoView(executionCtx, `#${this.view.id} .action-spy`);
   }
 
   signalPrisoner(executionCtx: ExecutionContext) {
-    this.didSignal = true;
+    this.signalCount += 1;
     this.animateIntoView(executionCtx, `#${this.view.id} .action-signal`);
   }
 
   freePrisoner(executionCtx: ExecutionContext) {
-    this.didFree = true;
+    this.freeCount += 1;
     this.animateIntoView(executionCtx, `#${this.view.id} .action-free`);
   }
 
@@ -125,10 +125,10 @@ export default class AnnalynsInfiltrationExercise extends VisualExercise {
       archerAwake: this.archerAwake,
       prisonerAwake: this.prisonerAwake,
       dogBehaving: this.dogBehaving,
-      didFastAttack: this.didFastAttack,
-      didSpy: this.didSpy,
-      didSignal: this.didSignal,
-      didFree: this.didFree
+      fastAttackCount: this.fastAttackCount,
+      spyCount: this.spyCount,
+      signalCount: this.signalCount,
+      freeCount: this.freeCount
     };
   }
 

--- a/curriculum/src/exercises/annalyns-infiltration/instructions/en.md
+++ b/curriculum/src/exercises/annalyns-infiltration/instructions/en.md
@@ -3,17 +3,18 @@ title: "Annalyn's Infiltration"
 description: "Combine and, or, and not to decide which quest actions Annalyn can take."
 ---
 
+You're playing a programmatic RPG game, where you can use functions to solve puzzles.
+
 Annalyn's best friend has been kidnapped and is being held in a forest camp guarded by two kidnappers: a mighty **knight** and a cunning **archer**. Annalyn has tracked them down, and brought her (somewhat naughty) pet **dog** with her to help, though the dog only helps when it is behaving itself.
 
-Your job is to look at the camp and perform **every** action Annalyn can safely take. You can check whether each character is awake, and whether the dog is behaving.
+There are various things you can do that all increase the likelihood that the rescue succeeds. You must do all the tasks possible given a specific scenario.
 
-The rules for when each action is possible:
+Your job is to work out how best to rescue the prisoner depending on the circumstances.
 
-- **Fast attack**: possible only if the knight is **asleep** (it takes him time to get his armor on).
-- **Spy**: worthwhile only if **at least one** of the three is awake. If everyone is asleep, spying is a waste of time.
-- **Signal prisoner**: possible if the prisoner is **awake** AND the archer is **asleep** (archers are trained to intercept bird signals).
-- **Free prisoner**: risky, and only succeeds in one of two ways:
-  - If the **dog is behaving**, Annalyn can free the prisoner as long as the **archer is asleep**. The knight is scared of the dog, and the archer won't have time to react.
-  - If the **dog is not behaving**, it's no help, so Annalyn and the prisoner must be sneaky: Annalyn can free the prisoner only if the **prisoner is awake** AND **both** kidnappers are **asleep**. If the prisoner is asleep, they'd be startled awake and raise the alarm.
+1. Firstly, you want to **spy** on the camp. This is only worth doing if any of the knight, archer or prisoner is awake (there's no point spying if they're all asleep!).
+2. Next, you want to **signal the prisoner** using birdsounds. This is only worth doing if the prisoner is awake (else they can't hear you) and the archer is asleep (the archer is trained to intercept and understand bird sounds).
+3. If the knight is asleep, you should get in there and **attack fast**.
+4. Now, if your dog is behaving, it can sneak in and **free the prisoner**. The knight is terrified of dogs so won't fight back, but the archer will, so this only works if the archer is asleep.
+5. Or, if the prisoner is awake, and both the knight and the archer are asleep, Annalyn can sneak in and **free the prisoner** herself. If the prisoner is asleep, it's too risky that he'll make a noise when he wakes.
 
-For each camp, perform all of the actions that are possible.
+Perform each action you can in the order above. Don't perform any actions you shouldn't. The full list of functions you can use is below.

--- a/curriculum/src/exercises/annalyns-infiltration/metadata.json
+++ b/curriculum/src/exercises/annalyns-infiltration/metadata.json
@@ -3,24 +3,28 @@
   "levelId": "complex-conditionals",
   "hints": [
     {
-      "question": "How do I find out who is awake or asleep?",
-      "answer": "Each character has a function that returns `true` or `false`: `knightIsAwake()`, `archerIsAwake()`, and `prisonerIsAwake()`. Call the one you need inside an `if`, e.g. `if (knightIsAwake())`."
+      "question": "How do I check things about the camp?",
+      "answer": "You can check four things, each with a function that returns `true` or `false`:\n\n- Is the knight awake? `knightIsAwake()`\n- Is the archer awake? `archerIsAwake()`\n- Is the prisoner awake? `prisonerIsAwake()`\n- Is the dog behaving? `dogIsBehaving()`"
+    },
+    {
+      "question": "How do I make Annalyn do each of the actions?",
+      "answer": "There are four actions, each its own function:\n\n- Make a fast attack: `fastAttack()`\n- Spy on the camp: `spy()`\n- Signal the prisoner: `signalPrisoner()`\n- Free the prisoner: `freePrisoner()`"
     },
     {
       "question": "A fast attack needs the knight to be ASLEEP. How do I check that?",
-      "answer": "There's no `isAsleep()` function, but asleep is just the opposite of awake. Use `!` to flip a condition: `!isRaining()` is true when it is NOT raining. Apply the same idea to whichever character needs to be asleep."
+      "answer": "There's no `isAsleep()` function, but asleep is just the opposite of awake. Use `!` to flip a condition. Imagine we want to tell someone to stop eating when they're full, but we only have an `isHungry()` function. We can reverse it:\n\n```javascript\nif (!isHungry()) {\n  stopEating()\n}\n```\n\nApply the same idea to check the knight is asleep."
     },
     {
       "question": "Spying works if AT LEAST ONE of them is awake. How do I write that?",
-      "answer": "Use `||` (or) between checks so the whole condition is true if any single one is true. For example `if (isHungry() || isThirsty())` runs when either holds. Chain one check per character who needs to be awake."
+      "answer": "Use `||` (or) between checks so the whole condition is `true` if any single one is `true`. For example, this runs when someone is hungry, thirsty, or both:\n\n```javascript\nif (isHungry() || isThirsty()) {\n  rest()\n}\n```"
     },
     {
       "question": "Signalling needs TWO things to be true at once. How do I combine them?",
-      "answer": "Use `&&` (and) so both sides must be true. For example `if (isLoggedIn() && isAdmin())` needs both. Combine the two things signalling requires the same way, flipping any 'asleep' check with `!`."
+      "answer": "Use `&&` (and) so both sides must be `true`. For example, this only runs when someone is hungry AND thirsty:\n\n```javascript\nif (isHungry() && isThirsty()) {\n  drink()\n}\n```"
     },
     {
-      "question": "Freeing the prisoner has two completely separate ways to succeed. How do I handle that?",
-      "answer": "Work out each route on its own first, then join them with `||` so either one is enough. Wrap each route's requirements in its own brackets so the `&&` parts group together before the `||` splits them. Remember the dog route and the sneaky route care about different characters."
+      "question": "An action has two completely separate ways to succeed. How do I handle that?",
+      "answer": "Either way is enough on its own, so you have two options.\n\nThe first is to write a separate `if` for each way, both doing the same action:\n\n```javascript\nif (isHungry() && hasSnack()) {\n  eat()\n}\nif (isThirsty() && hasSnack()) {\n  eat()\n}\n```\n\nThe second is to combine both ways into a single `if` with `||`, wrapping each way's checks in brackets so the `&&` parts group together before the `||` splits them:\n\n```javascript\nif ((isHungry() && hasSnack()) || (isThirsty() && hasSnack())) {\n  eat()\n}\n```\n\nWork out each way's requirements on its own first, then use whichever style you find clearer."
     }
   ]
 }

--- a/curriculum/src/exercises/annalyns-infiltration/scenarios.ts
+++ b/curriculum/src/exercises/annalyns-infiltration/scenarios.ts
@@ -29,32 +29,61 @@ interface ExpectedActions {
   free: boolean;
 }
 
-function buildExpectations(exercise: AnnalynsInfiltrationExercise, expected: ExpectedActions, camp: string) {
-  return [
-    {
-      pass: exercise.didFastAttack === expected.fastAttack,
-      errorHtml: expected.fastAttack
-        ? `${camp} The knight is asleep, so Annalyn should make a <strong>fast attack</strong> — but she didn't.`
-        : `${camp} The knight is awake, so a <strong>fast attack</strong> would fail — Annalyn should NOT attack here.`
-    },
-    {
-      pass: exercise.didSpy === expected.spy,
-      errorHtml: expected.spy
-        ? `${camp} At least one of them is awake, so Annalyn should <strong>spy</strong> — but she didn't.`
-        : `${camp} Everyone is asleep, so spying is a waste of time — Annalyn should NOT <strong>spy</strong> here.`
-    },
-    {
-      pass: exercise.didSignal === expected.signal,
-      errorHtml: expected.signal
-        ? `${camp} The prisoner is awake and the archer asleep, so Annalyn should <strong>signal the prisoner</strong> — but she didn't.`
-        : `${camp} The conditions for signalling aren't met, so Annalyn should NOT <strong>signal the prisoner</strong> here.`
-    },
-    {
-      pass: exercise.didFree === expected.free,
-      errorHtml: expected.free
-        ? `${camp} Annalyn has a safe way to <strong>free the prisoner</strong> here — but she didn't take it.`
-        : `${camp} There's no safe way to <strong>free the prisoner</strong> here, so Annalyn should NOT try.`
+function actionExpectation(
+  count: number,
+  shouldDo: boolean,
+  actionLabel: string,
+  shouldMsg: string,
+  shouldNotMsg: string
+) {
+  if (shouldDo) {
+    if (count === 0) {
+      return { pass: false, errorHtml: shouldMsg };
     }
+    if (count > 1) {
+      return {
+        pass: false,
+        errorHtml: `Annalyn <strong>should</strong> only ${actionLabel} once here, but she did it ${count} times.`
+      };
+    }
+    return { pass: true, errorHtml: "" };
+  }
+  return {
+    pass: count === 0,
+    errorHtml: shouldNotMsg
+  };
+}
+
+function buildExpectations(exercise: AnnalynsInfiltrationExercise, expected: ExpectedActions) {
+  return [
+    actionExpectation(
+      exercise.fastAttackCount,
+      expected.fastAttack,
+      "fast attack",
+      "Annalyn <strong>should</strong> make a fast attack here, but she didn't. The knight is asleep, so she can strike before he wakes.",
+      "Annalyn <strong>should not</strong> make a fast attack here. The knight is awake, so attacking would get her caught."
+    ),
+    actionExpectation(
+      exercise.spyCount,
+      expected.spy,
+      "spy",
+      "Annalyn <strong>should</strong> spy here, but she didn't. At least one person in the camp is awake, so there's something to watch.",
+      "Annalyn <strong>should not</strong> spy here. Everyone is asleep, so there's nothing to learn."
+    ),
+    actionExpectation(
+      exercise.signalCount,
+      expected.signal,
+      "signal the prisoner",
+      "Annalyn <strong>should</strong> signal the prisoner here, but she didn't. The prisoner is awake and the archer is asleep, so the signal will get through.",
+      "Annalyn <strong>should not</strong> signal the prisoner here. Either the prisoner is asleep or the archer is awake, so signalling would fail."
+    ),
+    actionExpectation(
+      exercise.freeCount,
+      expected.free,
+      "free the prisoner",
+      "Annalyn <strong>should</strong> free the prisoner here, but she didn't. She can do it here without getting caught.",
+      "Annalyn <strong>should not</strong> try to free the prisoner here. She'd get caught."
+    )
   ];
 }
 
@@ -70,11 +99,12 @@ export const scenarios: VisualScenario[] = [
       ex.setupBackground(`${IMAGE_BASE}/all-asleep-naughty-dog.webp`);
     },
     expectations(exercise) {
-      return buildExpectations(
-        exercise as AnnalynsInfiltrationExercise,
-        { fastAttack: true, spy: false, signal: false, free: false },
-        "Everyone is asleep and the dog is misbehaving."
-      );
+      return buildExpectations(exercise as AnnalynsInfiltrationExercise, {
+        fastAttack: true,
+        spy: false,
+        signal: false,
+        free: false
+      });
     }
   },
   {
@@ -88,11 +118,12 @@ export const scenarios: VisualScenario[] = [
       ex.setupBackground(`${IMAGE_BASE}/all-asleep-behaving-dog.webp`);
     },
     expectations(exercise) {
-      return buildExpectations(
-        exercise as AnnalynsInfiltrationExercise,
-        { fastAttack: true, spy: false, signal: false, free: true },
-        "Everyone is asleep and the dog is behaving."
-      );
+      return buildExpectations(exercise as AnnalynsInfiltrationExercise, {
+        fastAttack: true,
+        spy: false,
+        signal: false,
+        free: true
+      });
     }
   },
   {
@@ -106,11 +137,12 @@ export const scenarios: VisualScenario[] = [
       ex.setupBackground(`${IMAGE_BASE}/knight-awake-naughty-dog.webp`);
     },
     expectations(exercise) {
-      return buildExpectations(
-        exercise as AnnalynsInfiltrationExercise,
-        { fastAttack: false, spy: true, signal: false, free: false },
-        "Only the knight is awake, and the dog is misbehaving."
-      );
+      return buildExpectations(exercise as AnnalynsInfiltrationExercise, {
+        fastAttack: false,
+        spy: true,
+        signal: false,
+        free: false
+      });
     }
   },
   {
@@ -125,11 +157,12 @@ export const scenarios: VisualScenario[] = [
       ex.setupBackground(`${IMAGE_BASE}/prisoner-awake-naughty-dog.webp`);
     },
     expectations(exercise) {
-      return buildExpectations(
-        exercise as AnnalynsInfiltrationExercise,
-        { fastAttack: true, spy: true, signal: true, free: true },
-        "Only the prisoner is awake, and the dog is misbehaving."
-      );
+      return buildExpectations(exercise as AnnalynsInfiltrationExercise, {
+        fastAttack: true,
+        spy: true,
+        signal: true,
+        free: true
+      });
     }
   },
   {
@@ -143,11 +176,12 @@ export const scenarios: VisualScenario[] = [
       ex.setupBackground(`${IMAGE_BASE}/archer-and-prisoner-awake-behaving-dog.webp`);
     },
     expectations(exercise) {
-      return buildExpectations(
-        exercise as AnnalynsInfiltrationExercise,
-        { fastAttack: true, spy: true, signal: false, free: false },
-        "The archer and prisoner are awake, and the dog is behaving."
-      );
+      return buildExpectations(exercise as AnnalynsInfiltrationExercise, {
+        fastAttack: true,
+        spy: true,
+        signal: false,
+        free: false
+      });
     }
   },
   {
@@ -161,11 +195,12 @@ export const scenarios: VisualScenario[] = [
       ex.setupBackground(`${IMAGE_BASE}/all-awake-behaving-dog.webp`);
     },
     expectations(exercise) {
-      return buildExpectations(
-        exercise as AnnalynsInfiltrationExercise,
-        { fastAttack: false, spy: true, signal: false, free: false },
-        "Everyone is awake, even though the dog is behaving."
-      );
+      return buildExpectations(exercise as AnnalynsInfiltrationExercise, {
+        fastAttack: false,
+        spy: true,
+        signal: false,
+        free: false
+      });
     }
   }
 ];


### PR DESCRIPTION
## What

Polishes the **Annalyn's Infiltration** exercise (complex-conditionals level) plus two small supporting app changes.

### Curriculum

- **Exactly-once grading.** `Exercise.ts` now tracks per-action call *counts* instead of `did*` booleans. Each scenario asserts every expected action is called **exactly once**, and unexpected actions **zero** times (a new "should only X once, but did it N times" message fires on repeats).
- **Rewritten scenario error messages.** Directive-first, two sentences, no em dashes, no duplicated camp prefix (the old prefix repeated the reason and dragged in irrelevant dog details). Free-prisoner messages use "get caught" language.
- **Reworked hints** into a progressive set of six: check functions, action functions (both bulleted), then `!`, `||`, `&&`, and the two-ways pattern. All worked examples use generic `isHungry()`/`isThirsty()` functions in ```` ```javascript ```` blocks so none map onto the real solution.
- **Fixed typos** throughout `instructions/en.md`.

### App

- Bold `<strong>` in test-feedback messages (so the new emphasis in error messages renders).
- Stop clicks inside a revealed hint answer from collapsing the panel (keeps code blocks readable/selectable).

## Test plan

- `pnpm test:curriculum` — 670 pass (solution validates against all 6 scenarios)
- `pnpm test:app` — 1735 pass
- Typecheck + lint clean (pre-commit)

## Open follow-ups (not in this PR)

- Instruction step order (spy → signal → attack → free) differs from the solution's order; grader ignores order.
- Earlier-discussed "only one action per camp" redesign and "spy" substitution were **not** done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)