### PR TITLE
Fix false success in owners-bouquets checks

### DIFF
--- a/curriculum/src/exercises/owners-bouquets/scenarios.ts
+++ b/curriculum/src/exercises/owners-bouquets/scenarios.ts
@@ -15,6 +15,7 @@ export const tasks = [
 
 function flowerExpectations(exercise: PlantTheFlowersScenariosExercise, count: number) {
   const gap = 100 / (count + 1);
+  const expectedPositions = Array.from({ length: count }, (_, i) => gap * (i + 1));
   const expects = [];
 
   expects.push({
@@ -22,26 +23,23 @@ function flowerExpectations(exercise: PlantTheFlowersScenariosExercise, count: n
     errorHtml: `The owner expected to see ${count} flower${count === 1 ? "" : "s"} planted. But you planted ${exercise.flowers.length}.`
   });
 
+  // Every expected position must have a flower.
+  for (const position of expectedPositions) {
+    expects.push({
+      pass: exercise.hasFlowerAt(position),
+      errorHtml: `Expected a flower at position ${position}, but didn't find one.`
+    });
+  }
+
+  // No flowers should be planted at unexpected positions.
+  const strayFlower = exercise.flowers.find((position) => !expectedPositions.includes(position));
   expects.push({
-    pass: exercise.hasFlowerAt(gap),
-    errorHtml: `Expected a flower at position ${gap}, but didn't find one.`
+    pass: strayFlower === undefined,
+    errorHtml:
+      strayFlower === undefined
+        ? ""
+        : `Found a flower at position ${strayFlower}, which isn't where the owner wanted one. The flowers should be evenly spaced.`
   });
-
-  if (count > 1) {
-    expects.push({
-      pass: exercise.hasFlowerAt(gap * count),
-      errorHtml: `Expected a flower at position ${gap * count}, but didn't find one.`
-    });
-  }
-
-  if (count >= 3) {
-    const midIndex = Math.ceil(count / 2);
-    const midPosition = gap * midIndex;
-    expects.push({
-      pass: exercise.hasFlowerAt(midPosition),
-      errorHtml: `Expected a flower at position ${midPosition}, but didn't find one.`
-    });
-  }
 
   return expects;
 }


### PR DESCRIPTION
## Problem

A forum bug report ("Owner's Bouquets: This code gives a false success on scenario 3") flagged that a wrong solution passed. The student's code doubled the position each iteration instead of adding a fixed gap:

```js
let fl = askNumberOfFlowers()
let position = 100/(fl+1)
repeat(fl){
  plant(position)
  position = position + position   // doubles, should be position + gap
}
```

For the 4-flower scenario (the 3rd scenario in the list), this plants flowers at `[20, 40, 80, 160]` instead of the correct `[20, 40, 60, 80]`.

## Root cause

`flowerExpectations` only spot-checked **three** positions for presence: the first gap, `gap * count` (last), and a midpoint. For count=4 those sampled points are 20, 40, and 80, all of which the doubling solution coincidentally hits, so all checks passed. Position 60 was never checked, and the stray flower at 160 was never flagged.

## Fix

Replace the spot-checks with a full check:
- Every expected evenly-spaced position (`gap*1 … gap*count`) must have a flower.
- No flower may sit at an unexpected position (catches strays like 160).

Gaps stay exact integers (50, 25, 20, 10), so no float tolerance is introduced.

## Verification

- Reference solution passes all four scenarios (1, 3, 4, 9 flowers).
- The doubling bug now correctly fails on 3, 4, and 9 flowers (reporting the missing/stray positions); 1-flower still passes as it is genuinely correct.
- Curriculum typecheck, lint, and full test suite (670 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)