### PR TITLE
rainbow-splodges: enforce circles stay inside the box

### DIFF
--- a/curriculum/src/exercises/rainbow-splodges/Exercise.ts
+++ b/curriculum/src/exercises/rainbow-splodges/Exercise.ts
@@ -20,6 +20,15 @@ export class RainbowSplodgesExercise extends DrawExercise {
     return this.circles.length > 0 && this.circles.every((c) => c.radius >= min && c.radius < max);
   }
 
+  public checkAllCirclesInsideBox(): boolean {
+    return (
+      this.circles.length > 0 &&
+      this.circles.every(
+        (c) => c.cx - c.radius >= 0 && c.cx + c.radius <= 100 && c.cy - c.radius >= 0 && c.cy + c.radius <= 100
+      )
+    );
+  }
+
   public checkCirclesTouchEdges(): boolean {
     return (
       this.circles.some((c) => c.cx - c.radius <= 0 || c.cx + c.radius >= 100) &&

--- a/curriculum/src/exercises/rainbow-splodges/instructions/en.md
+++ b/curriculum/src/exercises/rainbow-splodges/instructions/en.md
@@ -5,7 +5,7 @@ description: "Splatter hundreds of colourful splodges across the canvas."
 
 Your task in this exercise is to create a canvas full of colorful rainbow splodges!
 
-You need to draw **200 circles** at random positions with random colors. The result should look something like this:
+You need to draw **200 circles** with random radii, at random positions, with random colors. The result should look something like this:
 
 <img src="/static/images/exercise-assets/rainbow-splodges/example.webp" alt="Rainbow Splodges" style="width: 100%; max-width: 300px; border: 1px solid rgba(0, 0, 0, 0.1); border-radius: 5px; box-shadow: 0 0 3px rgba(0, 0, 0, 0.1); margin-bottom: 8px;" />
 

--- a/curriculum/src/exercises/rainbow-splodges/metadata.json
+++ b/curriculum/src/exercises/rainbow-splodges/metadata.json
@@ -5,6 +5,10 @@
     {
       "question": "How do I keep the circles inside the box?",
       "answer": "The order is important. You need to decide on the radius of the circle, then make sure it's left and top positions never allow it to be pushed outside the box."
+    },
+    {
+      "question": "I can't keep my circles in the box",
+      "answer": "Remember that a circle's position is its center, so you'll need to account for its radius to keep the whole circle inside. If you currently let a position be as low as 0, the circle's edge will stick out past the box by its radius. So what does that minimum need to change to so the circle never sits outside the box? Then apply the same logic to the maximum."
     }
   ]
 }

--- a/curriculum/src/exercises/rainbow-splodges/scenarios.ts
+++ b/curriculum/src/exercises/rainbow-splodges/scenarios.ts
@@ -41,7 +41,8 @@ export const scenarios: VisualScenario[] = [
         },
         {
           pass: ex.checkCirclesTouchEdges(),
-          errorHtml: "Some circles should touch the edges of the canvas. Make sure your positions cover the full range."
+          errorHtml:
+            "None of your circles touched the edges of the canvas. If you're confident your code is correct, it might be that the random numbers didn't happen to land a circle exactly on an edge. Try running it again!"
         },
         {
           pass: ex.checkSaturationAndLuminosityInRange(20, 80),

--- a/curriculum/src/exercises/rainbow-splodges/scenarios.ts
+++ b/curriculum/src/exercises/rainbow-splodges/scenarios.ts
@@ -36,6 +36,10 @@ export const scenarios: VisualScenario[] = [
           errorHtml: "All circle radii must be at least 1 and less than 30."
         },
         {
+          pass: ex.checkAllCirclesInsideBox(),
+          errorHtml: "Circles must not go outside the box. Account for each circle's radius when choosing its position."
+        },
+        {
           pass: ex.checkCirclesTouchEdges(),
           errorHtml: "Some circles should touch the edges of the canvas. Make sure your positions cover the full range."
         },

--- a/curriculum/src/exercises/rainbow-splodges/solution.javascript
+++ b/curriculum/src/exercises/rainbow-splodges/solution.javascript
@@ -1,10 +1,12 @@
 let x = 0
 let y = 0
+let radius = 0
 let hue = 0
 
 repeat(200) {
-  x = Math.randomInt(0, 100)
-  y = Math.randomInt(0, 100)
+  radius = Math.randomInt(2, 12)
+  x = Math.randomInt(radius, 100 - radius)
+  y = Math.randomInt(radius, 100 - radius)
   hue = Math.randomInt(0, 360)
-  circle(x, y, 3, hsl(hue, 80, 50))
+  circle(x, y, radius, hsl(hue, 80, 50))
 }

--- a/curriculum/src/exercises/rainbow-splodges/solution.jiki
+++ b/curriculum/src/exercises/rainbow-splodges/solution.jiki
@@ -1,10 +1,12 @@
 set x to 0
 set y to 0
+set radius to 0
 set hue to 0
 
 repeat 200 times do
-  change x to random_number(0, 100)
-  change y to random_number(0, 100)
+  change radius to random_number(2, 12)
+  change x to random_number(radius, 100 - radius)
+  change y to random_number(radius, 100 - radius)
   change hue to random_number(0, 360)
-  circle(x, y, 3, hsl(hue, 80, 50))
+  circle(x, y, radius, hsl(hue, 80, 50))
 end

--- a/curriculum/src/exercises/rainbow-splodges/solution.py
+++ b/curriculum/src/exercises/rainbow-splodges/solution.py
@@ -1,9 +1,11 @@
 x = 0
 y = 0
+radius = 0
 hue = 0
 
 repeat(200):
-    x = random.randint(0, 100)
-    y = random.randint(0, 100)
+    radius = random.randint(2, 12)
+    x = random.randint(radius, 100 - radius)
+    y = random.randint(radius, 100 - radius)
     hue = random.randint(0, 360)
-    circle(x, y, 3, hsl(hue, 80, 50))
+    circle(x, y, radius, hsl(hue, 80, 50))


### PR DESCRIPTION
## Problem

A student reported ([forum post](https://jiki.io/r/forum)) that Rainbow Splodges never checks rule 3 ("The circles cannot go outside of the box"). Their code with `radius = randomInt(1, 15)` and `x = randomInt(0, 99)` produced circles spilling well past the edges, yet passed.

The scenario only enforced the *second* half of rule 3 (`checkCirclesTouchEdges`); nothing enforced "cannot go outside the box". The reference solution also bled off the edges (centers `0..100` with radius `3`), so a strict check couldn't have been added without breaking it.

## Changes

- Add `checkAllCirclesInsideBox()` (asserts `cx ± radius` / `cy ± radius` within `0..100`) and wire it into the scenario.
- Randomise the radius in all three solutions and derive positions from it (`randomInt(radius, 100 - radius)`), so circles stay fully inside while still touching edges.
- Add an "I can't keep my circles in the box" hint explaining that position is the circle's center, so you must account for the radius.

## Verification

`all-exercises.test.ts` runs the JS solution (with `randomSeed`) against every scenario and passes, confirming the seeded solution stays inside the box *and* still touches edges. Full curriculum test suite (670 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)