### PR TITLE
Normalize off-scale Tailwind spacing to canonical scale tokens

### DIFF
--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -15,7 +15,7 @@ export function ResetPasswordForm() {
   const searchParams = useSearchParams();
   const { resetPassword, isLoading, error, clearError } = useAuthStore();
 
-  const [token] = useState(() => searchParams?.get("reset_password_token") || searchParams?.get("token") || "");
+  const [token] = useState(() => searchParams.get("reset_password_token") || searchParams.get("token") || "");
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
@@ -115,7 +115,7 @@ export function ResetPasswordForm() {
           <label htmlFor="password" className="block text-sm font-medium text-gray-700">
             {t("newPasswordLabel")}
           </label>
-          <div className="mt-1">
+          <div className="mt-4">
             <input
               id="password"
               name="password"
@@ -129,7 +129,7 @@ export function ResetPasswordForm() {
                   setValidationErrors({ ...validationErrors, password: "" });
                 }
               }}
-              className="block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+              className="block w-full appearance-none rounded-md border border-gray-300 px-12 py-2 placeholder-gray-400 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
               placeholder={t("newPasswordPlaceholder")}
             />
             {validationErrors.password && <p className="mt-2 text-sm text-red-600">{validationErrors.password}</p>}
@@ -140,7 +140,7 @@ export function ResetPasswordForm() {
           <label htmlFor="passwordConfirmation" className="block text-sm font-medium text-gray-700">
             {t("confirmPasswordLabel")}
           </label>
-          <div className="mt-1">
+          <div className="mt-4">
             <input
               id="passwordConfirmation"
               name="passwordConfirmation"
@@ -154,7 +154,7 @@ export function ResetPasswordForm() {
                   setValidationErrors({ ...validationErrors, passwordConfirmation: "" });
                 }
               }}
-              className="block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+              className="block w-full appearance-none rounded-md border border-gray-300 px-12 py-2 placeholder-gray-400 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
               placeholder={t("confirmPasswordPlaceholder")}
             />
             {validationErrors.passwordConfirmation && (

--- a/app/components/blog/BlogPostCard.tsx
+++ b/app/components/blog/BlogPostCard.tsx
@@ -13,11 +13,11 @@ export default function BlogPostCard({ post, locale }: BlogPostCardProps) {
   return (
     <article className="border-b border-border-primary pb-12 last:border-0">
       <Link href={postUrl} className="group">
-        <h2 className="mb-3 text-3xl font-bold text-text-primary transition-colors group-hover:text-link-primary">
+        <h2 className="mb-12 text-3xl font-bold text-text-primary transition-colors group-hover:text-link-primary">
           {post.title}
         </h2>
       </Link>
-      <div className="mb-4 flex items-center gap-3 text-sm text-text-secondary">
+      <div className="mb-4 flex items-center gap-12 text-sm text-text-secondary">
         <time dateTime={post.date}>
           {new Date(post.date).toLocaleDateString("en-US", {
             year: "numeric",
@@ -31,7 +31,7 @@ export default function BlogPostCard({ post, locale }: BlogPostCardProps) {
       <p className="mb-4 text-lg leading-relaxed text-text-primary">{post.excerpt}</p>
       <div className="flex flex-wrap gap-2">
         {post.tags.map((tag) => (
-          <span key={tag} className="rounded-full bg-info-bg px-3 py-1 text-sm text-info-text">
+          <span key={tag} className="rounded-full bg-info-bg px-12 py-4 text-sm text-info-text">
             {tag}
           </span>
         ))}

--- a/app/components/coding-exercise/ui/FunctionsView.tsx
+++ b/app/components/coding-exercise/ui/FunctionsView.tsx
@@ -18,18 +18,18 @@ export default function FunctionsView({ functions }: FunctionsViewProps) {
         <div key={index} className="border-b border-gray-200 last:border-0 pb-4 last:pb-0">
           <div className="flex items-center justify-between mb-2">
             <h3 className="font-mono font-semibold text-gray-900">{func.signature}</h3>
-            <span className="text-xs text-gray-500 px-2 py-1 bg-gray-100 rounded">{func.category}</span>
+            <span className="text-xs text-gray-500 px-2 py-4 bg-gray-100 rounded">{func.category}</span>
           </div>
 
           <div className="prose prose-sm max-w-none">
             <div
-              className="text-gray-700 mb-3"
+              className="text-gray-700 mb-12"
               dangerouslySetInnerHTML={{ __html: marked.parse(func.description, { async: false }) }}
             />
           </div>
 
           {func.examples && func.examples.length > 0 && (
-            <div className="mt-3">
+            <div className="mt-12">
               <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Examples</p>
               <div className="space-y-2">
                 {func.examples.map((example, idx) => (

--- a/app/components/coding-exercise/ui/HintsPanel.tsx
+++ b/app/components/coding-exercise/ui/HintsPanel.tsx
@@ -68,7 +68,7 @@ export default function HintsPanel({ hints, walkthroughVideoData, lessonSlug, cl
 
       <div className="py-24 px-32">
         {hasHints && (
-          <ul className="space-y-3">
+          <ul className="space-y-12">
             {hints.map((hint, index) => {
               const isRevealed = revealedHints.has(index);
 

--- a/app/components/coding-exercise/ui/LanguageToggle.tsx
+++ b/app/components/coding-exercise/ui/LanguageToggle.tsx
@@ -18,12 +18,12 @@ export default function LanguageToggle() {
   const { language } = useOrchestratorStore(orchestrator);
 
   return (
-    <div className="flex gap-1 bg-bg-secondary rounded-md p-1">
+    <div className="flex gap-4 bg-bg-secondary rounded-md p-4">
       {LANGUAGES.map((lang) => (
         <button
           key={lang.value}
           onClick={() => orchestrator.getStore().getState().setLanguage(lang.value)}
-          className={`px-3 py-1 text-sm rounded transition-colors ${
+          className={`px-12 py-4 text-sm rounded transition-colors ${
             language === lang.value
               ? "bg-surface-elevated text-text-primary font-medium shadow-sm"
               : "text-text-secondary hover:text-text-primary"

--- a/app/components/coding-exercise/ui/TasksView.tsx
+++ b/app/components/coding-exercise/ui/TasksView.tsx
@@ -26,7 +26,7 @@ export default function TasksView({ tasks, orchestrator, className = "" }: Tasks
 
   return (
     <div className={`p-4 ${className}`}>
-      <ul className="space-y-3">
+      <ul className="space-y-12">
         {tasks.map((task, index) => {
           const progress = taskProgress.get(task.id);
           const isCompleted = completedTasks.has(task.id);
@@ -34,7 +34,7 @@ export default function TasksView({ tasks, orchestrator, className = "" }: Tasks
           const status = progress?.status || "not-started";
 
           return (
-            <li key={task.id} className="flex items-start gap-3">
+            <li key={task.id} className="flex items-start gap-12">
               <TaskStatusIndicator
                 index={index}
                 status={status}
@@ -69,12 +69,12 @@ export default function TasksView({ tasks, orchestrator, className = "" }: Tasks
                     </span>
                   )}
                 </div>
-                {task.description && <p className="text-xs text-gray-500 mt-1">{task.description}</p>}
+                {task.description && <p className="text-xs text-gray-500 mt-4">{task.description}</p>}
                 {progress && status === "in-progress" && (
                   <div className="mt-2">
-                    <div className="w-full bg-gray-200 rounded-full h-1">
+                    <div className="w-full bg-gray-200 rounded-full h-4">
                       <div
-                        className="bg-blue-500 h-1 rounded-full transition-all duration-300"
+                        className="bg-blue-500 h-4 rounded-full transition-all duration-300"
                         style={{
                           width: `${progress.totalScenarios > 0 ? (progress.passedScenarios.length / progress.totalScenarios) * 100 : 0}%`
                         }}

--- a/app/components/coding-exercise/ui/TypingTestPanel.tsx
+++ b/app/components/coding-exercise/ui/TypingTestPanel.tsx
@@ -45,9 +45,9 @@ export default function TypingTestPanel() {
   return (
     <div className="max-w-2xl mx-auto p-8 space-y-6">
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
-        <div className="border-b border-gray-200 px-4 py-3">
+        <div className="border-b border-gray-200 px-4 py-12">
           <h2 className="text-lg font-semibold text-gray-900">Typing Effect Test Panel</h2>
-          <p className="text-sm text-gray-600 mt-1">Test the typing mechanism without expensive API calls</p>
+          <p className="text-sm text-gray-600 mt-4">Test the typing mechanism without expensive API calls</p>
         </div>
 
         {/* Controls */}
@@ -56,7 +56,7 @@ export default function TypingTestPanel() {
             <button
               onClick={simulateThinking}
               disabled={status !== "idle"}
-              className="px-3 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-12 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               1. Start Thinking
             </button>
@@ -64,7 +64,7 @@ export default function TypingTestPanel() {
             <button
               onClick={simulateTyping}
               disabled={status !== "thinking"}
-              className="px-3 py-2 bg-green-600 text-white text-sm rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-12 py-2 bg-green-600 text-white text-sm rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               2. Start Typing
             </button>
@@ -72,12 +72,12 @@ export default function TypingTestPanel() {
             <button
               onClick={simulateInstantText}
               disabled={status !== "idle"}
-              className="px-3 py-2 bg-purple-600 text-white text-sm rounded-md hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-12 py-2 bg-purple-600 text-white text-sm rounded-md hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Test Instant
             </button>
 
-            <button onClick={reset} className="px-3 py-2 bg-gray-600 text-white text-sm rounded-md hover:bg-gray-700">
+            <button onClick={reset} className="px-12 py-2 bg-gray-600 text-white text-sm rounded-md hover:bg-gray-700">
               Reset
             </button>
           </div>
@@ -102,7 +102,7 @@ export default function TypingTestPanel() {
           <div className="flex items-center gap-4 text-sm">
             <span className="font-medium">Status:</span>
             <span
-              className={`px-2 py-1 rounded text-xs font-medium ${
+              className={`px-2 py-4 rounded text-xs font-medium ${
                 status === "idle"
                   ? "bg-gray-100 text-gray-800"
                   : status === "thinking"
@@ -142,7 +142,7 @@ export default function TypingTestPanel() {
       {/* Debug Info */}
       <div className="bg-gray-50 rounded-lg border border-gray-200 p-4">
         <h3 className="text-md font-medium text-gray-900 mb-2">Debug Info:</h3>
-        <div className="text-xs font-mono text-gray-600 space-y-1">
+        <div className="text-xs font-mono text-gray-600 space-y-4">
           <div>Status: {status}</div>
           <div>Content: &quot;{currentResponse}&quot;</div>
           <div>Content Length: {currentResponse.length} chars</div>

--- a/app/components/common/NavigationLoadingOverlay.tsx
+++ b/app/components/common/NavigationLoadingOverlay.tsx
@@ -24,7 +24,7 @@ export default function NavigationLoadingOverlay({
         </div>
         <p className="mt-4 text-lg text-gray-700 font-medium">{message}</p>
         {/* Simple loading dots using Tailwind animations */}
-        <div className="mt-2 flex justify-center gap-1">
+        <div className="mt-2 flex justify-center gap-4">
           <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
           <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse [animation-delay:150ms]" />
           <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse [animation-delay:300ms]" />

--- a/app/components/concepts/LoadingStates.tsx
+++ b/app/components/concepts/LoadingStates.tsx
@@ -19,7 +19,7 @@ export function LoadingSkeleton({ withSidebar }: LoadingSkeletonProps) {
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="rounded-xl border border-gray-200 bg-white p-6">
-              <div className="mb-3 h-6 w-3/4 bg-gray-200 rounded"></div>
+              <div className="mb-12 h-6 w-3/4 bg-gray-200 rounded"></div>
               <div className="mb-4 space-y-2">
                 <div className="h-4 w-full bg-gray-200 rounded"></div>
                 <div className="h-4 w-5/6 bg-gray-200 rounded"></div>
@@ -36,7 +36,7 @@ export function InlineLoading() {
   return (
     <div className="mb-4 text-center">
       <div className="inline-flex items-center px-4 py-2 text-sm text-blue-600 bg-blue-50 rounded-lg">
-        <svg className="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
+        <svg className="animate-spin -ml-4 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path
             className="opacity-75"

--- a/app/components/landing-page/BootcampSection.tsx
+++ b/app/components/landing-page/BootcampSection.tsx
@@ -279,7 +279,7 @@ export function BootcampSection() {
               />
               <div className={`${styles.certificate} flex-shrink-0 mt-24 lg:mt-0`}>
                 <Image
-                  className="lg:w-[350px] w-100 rounded-[5px]"
+                  className="lg:w-[350px] rounded-[5px]"
                   style={{ boxShadow: "0 0 20px rgba(0,0,0,0.4)" }}
                   src={certificate}
                   alt={t("certificateAlt")}

--- a/app/components/quiz-card/InfoBox.tsx
+++ b/app/components/quiz-card/InfoBox.tsx
@@ -20,21 +20,21 @@ export function InfoBox({ type, title, message }: InfoBoxProps) {
           bg: "bg-green-50",
           border: "border-green-200",
           text: "text-green-900",
-          icon: <CheckCircle className="w-5 h-5 text-green-600" />
+          icon: <CheckCircle className="w-20 h-20 text-green-600" />
         };
       case "error":
         return {
           bg: "bg-red-50",
           border: "border-red-200",
           text: "text-red-900",
-          icon: <XCircle className="w-5 h-5 text-red-600" />
+          icon: <XCircle className="w-20 h-20 text-red-600" />
         };
       case "info":
         return {
           bg: "bg-blue-50",
           border: "border-blue-200",
           text: "text-blue-900",
-          icon: <Info className="w-5 h-5 text-blue-600" />
+          icon: <Info className="w-20 h-20 text-blue-600" />
         };
       default:
         return {
@@ -50,10 +50,10 @@ export function InfoBox({ type, title, message }: InfoBoxProps) {
 
   return (
     <div className={`mt-4 p-4 ${styles.bg} border ${styles.border} rounded-lg`}>
-      <div className="flex items-start gap-3">
+      <div className="flex items-start gap-12">
         {styles.icon && <div className="mt-0.5 flex-shrink-0">{styles.icon}</div>}
         <div className={`text-sm ${styles.text}`}>
-          {title && <p className="font-semibold mb-1">{title}</p>}
+          {title && <p className="font-semibold mb-4">{title}</p>}
           {message && <p>{message}</p>}
         </div>
       </div>

--- a/app/components/quiz-card/QuizCard.tsx
+++ b/app/components/quiz-card/QuizCard.tsx
@@ -82,7 +82,7 @@ export function QuizCard({ question, onNext }: QuizCardProps) {
         <QuizContent markdown={question.content} />
       </div>
 
-      <div className="space-y-3 mb-6">
+      <div className="space-y-12 mb-6">
         {question.options.map((option, index) => (
           <QuizOption
             key={index}
@@ -103,7 +103,7 @@ export function QuizCard({ question, onNext }: QuizCardProps) {
       <button
         onClick={submitted ? handleNext : handleSubmit}
         disabled={!submitted && selectedIndex === null}
-        className="w-full mt-6 px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors duration-200"
+        className="w-full mt-6 px-6 py-12 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors duration-200"
       >
         {submitted ? "Next Question" : "Submit"}
       </button>

--- a/app/components/quiz-card/QuizFeedback.tsx
+++ b/app/components/quiz-card/QuizFeedback.tsx
@@ -18,10 +18,10 @@ export function QuizFeedback({ type, explanation }: QuizFeedbackProps) {
 
   return (
     <div className="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-lg">
-      <div className="flex items-start gap-3">
-        <AlertCircle className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" />
+      <div className="flex items-start gap-12">
+        <AlertCircle className="w-20 h-20 text-amber-600 mt-0.5 flex-shrink-0" />
         <div className="text-sm text-amber-900">
-          <p className="font-semibold mb-1">Not quite right!</p>
+          <p className="font-semibold mb-4">Not quite right!</p>
           {explanation && <p>{explanation}</p>}
         </div>
       </div>

--- a/app/components/quiz-card/QuizOption.tsx
+++ b/app/components/quiz-card/QuizOption.tsx
@@ -25,7 +25,7 @@ export function QuizOption({ text, index, state, onSelect, disabled }: QuizOptio
 
   const getButtonStyles = () => {
     const base =
-      "w-full px-4 py-3 text-left rounded-lg transition-all duration-200 flex items-center justify-between group";
+      "w-full px-4 py-12 text-left rounded-lg transition-all duration-200 flex items-center justify-between group";
 
     switch (state) {
       case "default":
@@ -57,15 +57,15 @@ export function QuizOption({ text, index, state, onSelect, disabled }: QuizOptio
       onMouseDown={() => !disabled && state === "default"}
       onMouseUp={() => !disabled && state === "default"}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-12">
         <span className="font-semibold text-gray-600">{letter}.</span>
         <span className="text-gray-800">{text}</span>
       </div>
       {showIcon && (
         <div className="ml-2">
-          {state === "correct" && <Check className="w-5 h-5 text-green-600" />}
-          {state === "incorrect" && <X className="w-5 h-5 text-red-600" />}
-          {state === "correct-reveal" && <Check className="w-5 h-5 text-green-600" />}
+          {state === "correct" && <Check className="w-20 h-20 text-green-600" />}
+          {state === "incorrect" && <X className="w-20 h-20 text-red-600" />}
+          {state === "correct-reveal" && <Check className="w-20 h-20 text-green-600" />}
         </div>
       )}
     </button>

--- a/app/components/settings/modals/ChangeEmailModal.tsx
+++ b/app/components/settings/modals/ChangeEmailModal.tsx
@@ -70,12 +70,12 @@ export function ChangeEmailModal({ currentEmail, onSave }: ChangeEmailModalProps
 
       <form onSubmit={handleSubmit} className="space-y-16 ">
         <div className="ui-form-field-large">
-          <label className="block text-sm font-semibold mb-1">{t("currentEmailLabel")}</label>
+          <label className="block text-sm font-semibold mb-4">{t("currentEmailLabel")}</label>
           <input type="email" value={currentEmail} disabled />
         </div>
 
         <div className="ui-form-field-large">
-          <label htmlFor="new-email" className="block text-sm font-semibold mb-1">
+          <label htmlFor="new-email" className="block text-sm font-semibold mb-4">
             {t("newEmailLabel")}
           </label>
           <input
@@ -90,7 +90,7 @@ export function ChangeEmailModal({ currentEmail, onSave }: ChangeEmailModalProps
         </div>
 
         <div className="ui-form-field-large">
-          <label htmlFor="current-password" className="block text-sm font-semibold mb-1">
+          <label htmlFor="current-password" className="block text-sm font-semibold mb-4">
             {t("passwordLabel")}
           </label>
           <input
@@ -101,12 +101,12 @@ export function ChangeEmailModal({ currentEmail, onSave }: ChangeEmailModalProps
             placeholder={t("passwordPlaceholder")}
             disabled={isSaving}
           />
-          <p className="text-xs text-text-secondary mt-1">{t("passwordHint")}</p>
+          <p className="text-xs text-text-secondary mt-4">{t("passwordHint")}</p>
         </div>
 
-        {error && <div className="bg-red-50 text-red-600 p-3 rounded-md text-sm">{error}</div>}
+        {error && <div className="bg-red-50 text-red-600 p-12 rounded-md text-sm">{error}</div>}
 
-        <div className="flex gap-3 pt-4">
+        <div className="flex gap-12 pt-4">
           <button type="submit" disabled={isSaving} className="ui-btn ui-btn-small ui-btn-primary flex-1">
             {isSaving ? <LoadingSpinner size="sm" /> : t("submit")}
           </button>

--- a/app/components/settings/modals/ChangePasswordModal.tsx
+++ b/app/components/settings/modals/ChangePasswordModal.tsx
@@ -65,7 +65,7 @@ export function ChangePasswordModal({ onSave }: ChangePasswordModalProps) {
 
       <form onSubmit={handleSubmit} className="space-y-16">
         <div className="ui-form-field-large">
-          <label htmlFor="current-password" className="block text-sm font-medium mb-1">
+          <label htmlFor="current-password" className="block text-sm font-medium mb-4">
             {t("currentLabel")}
           </label>
           <input
@@ -80,7 +80,7 @@ export function ChangePasswordModal({ onSave }: ChangePasswordModalProps) {
         </div>
 
         <div className="ui-form-field-large">
-          <label htmlFor="new-password" className="block text-sm font-medium mb-1">
+          <label htmlFor="new-password" className="block text-sm font-medium mb-4">
             {t("newLabel")}
           </label>
           <input
@@ -91,11 +91,11 @@ export function ChangePasswordModal({ onSave }: ChangePasswordModalProps) {
             placeholder={t("newPlaceholder")}
             disabled={isSaving}
           />
-          <p className="text-xs text-text-secondary mt-1">{t("newHint")}</p>
+          <p className="text-xs text-text-secondary mt-4">{t("newHint")}</p>
         </div>
 
         <div className="ui-form-field-large">
-          <label htmlFor="confirm-password" className="block text-sm font-medium mb-1">
+          <label htmlFor="confirm-password" className="block text-sm font-medium mb-4">
             {t("confirmLabel")}
           </label>
           <input
@@ -108,9 +108,9 @@ export function ChangePasswordModal({ onSave }: ChangePasswordModalProps) {
           />
         </div>
 
-        {error && <div className="bg-red-50 text-red-600 p-3 rounded-md text-sm">{error}</div>}
+        {error && <div className="bg-red-50 text-red-600 p-12 rounded-md text-sm">{error}</div>}
 
-        <div className="flex gap-3 pt-4">
+        <div className="flex gap-12 pt-4">
           <button type="submit" disabled={isSaving} className="ui-btn ui-btn-primary ui-btn-small flex-1">
             {isSaving ? <LoadingSpinner size="sm" /> : t("submit")}
           </button>

--- a/app/components/settings/sections/ProfileSection.tsx
+++ b/app/components/settings/sections/ProfileSection.tsx
@@ -93,7 +93,7 @@ export default function ProfileSection({ settings, updateName, updateHandle, upd
               {t("confirmationPendingPrefix")}
               <strong>{settings.unconfirmed_email}</strong>
             </p>
-            <p className="text-xs mt-1">{t("confirmationPendingHint")}</p>
+            <p className="text-xs mt-4">{t("confirmationPendingHint")}</p>
           </StatusNotification>
         )}
         {!settings.email_confirmed && !settings.unconfirmed_email && (

--- a/app/components/settings/subscription/SubscriptionErrorBoundary.tsx
+++ b/app/components/settings/subscription/SubscriptionErrorBoundary.tsx
@@ -38,7 +38,7 @@ export default class SubscriptionErrorBoundary extends Component<
       return (
         <div className="bg-red-50 border border-red-200 rounded-lg p-6">
           <div className="flex items-center mb-4">
-            <div className="w-3 h-3 bg-red-500 rounded-full mr-3"></div>
+            <div className="w-12 h-12 bg-red-500 rounded-full mr-12"></div>
             <h3 className="font-medium text-red-900">Subscription System Error</h3>
           </div>
 
@@ -50,7 +50,7 @@ export default class SubscriptionErrorBoundary extends Component<
             <p>Please try refreshing the page, or contact support if the issue persists.</p>
           </div>
 
-          <div className="flex gap-3">
+          <div className="flex gap-12">
             <button
               onClick={() => window.location.reload()}
               className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition-colors focus-ring"
@@ -66,7 +66,7 @@ export default class SubscriptionErrorBoundary extends Component<
           </div>
 
           {process.env.NODE_ENV === "development" && this.state.error && (
-            <details className="mt-4 p-3 bg-red-100 border border-red-300 rounded text-xs">
+            <details className="mt-4 p-12 bg-red-100 border border-red-300 rounded text-xs">
               <summary className="cursor-pointer font-medium text-red-900 mb-2">Error Details (Development)</summary>
               <pre className="text-red-800 whitespace-pre-wrap break-words">
                 {this.state.error.message}

--- a/app/components/settings/subscription/SubscriptionSection.tsx
+++ b/app/components/settings/subscription/SubscriptionSection.tsx
@@ -36,7 +36,7 @@ export default function SubscriptionSection({ user, refreshUser, className = "" 
       <SettingsCard title={t("loadingCardTitle")} description={t("loadingCardDescription")} className={className}>
         <div className="flex items-center justify-center py-8">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-link-primary"></div>
-          <span className="ml-3 text-text-secondary">{t("loadingData")}</span>
+          <span className="ml-12 text-text-secondary">{t("loadingData")}</span>
         </div>
       </SettingsCard>
     );

--- a/app/components/settings/subscription/states/NeverSubscribedState.tsx
+++ b/app/components/settings/subscription/states/NeverSubscribedState.tsx
@@ -17,7 +17,7 @@ export default function NeverSubscribedState({ onUpgradeToPremium, isLoading = f
       className="bg-bg-primary p-4 rounded border border-border-secondary"
       aria-labelledby="upgrade-plans-heading"
     >
-      <h3 id="upgrade-plans-heading" className="font-medium text-text-primary mb-3">
+      <h3 id="upgrade-plans-heading" className="font-medium text-text-primary mb-12">
         {t("heading")}
       </h3>
       <p className="text-text-secondary text-sm mb-4">{t("subtitle")}</p>
@@ -27,11 +27,11 @@ export default function NeverSubscribedState({ onUpgradeToPremium, isLoading = f
           <h4 id="premium-plan-title" className="font-medium text-text-primary mb-2">
             {premiumTier.name}
           </h4>
-          <p className="text-2xl font-bold text-text-primary mb-1">
+          <p className="text-2xl font-bold text-text-primary mb-4">
             <PremiumPrice interval="monthly" />
             <span className="text-sm font-normal">{t("perMonth")}</span>
           </p>
-          <ul className="text-sm text-text-secondary space-y-1 mb-4" aria-label={t("featuresLabel")}>
+          <ul className="text-sm text-text-secondary space-y-4 mb-4" aria-label={t("featuresLabel")}>
             {premiumTier.features.map((feature: string, index: number) => (
               <li key={index}>• {feature}</li>
             ))}

--- a/app/components/settings/tabs/LearningTab.tsx
+++ b/app/components/settings/tabs/LearningTab.tsx
@@ -53,7 +53,7 @@ export default function LearningTab() {
         </ActionField>
         <Link
           href={routes.article("streaks")}
-          className="text-sm text-gray-500 underline hover:text-gray-700 mt-1 inline-block"
+          className="text-sm text-gray-500 underline hover:text-gray-700 mt-4 inline-block"
         >
           {t("learnMore")}
         </Link>

--- a/app/components/settings/ui/SubscriptionStatus.tsx
+++ b/app/components/settings/ui/SubscriptionStatus.tsx
@@ -139,9 +139,9 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
       aria-label={t("statusAriaLabel", { status: statusInfo.text })}
     >
       <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-12">
           <div
-            className="px-3 py-1 rounded-full text-sm font-medium bg-blue-50 text-blue-700"
+            className="px-12 py-4 rounded-full text-sm font-medium bg-blue-50 text-blue-700"
             role="status"
             aria-label={t("currentPlanAriaLabel", { plan: tierDetails.name })}
           >
@@ -149,7 +149,7 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
             {t("planSuffix")}
           </div>
           <div
-            className={`px-2 py-1 rounded text-xs font-medium ${statusInfo.bgColor} ${statusInfo.color}`}
+            className={`px-2 py-4 rounded text-xs font-medium ${statusInfo.bgColor} ${statusInfo.color}`}
             role="status"
             aria-label={t("statusAriaLabel", { status: statusInfo.text })}
           >
@@ -165,11 +165,11 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
         </p>
 
         {/* Status-specific messages */}
-        {status === "canceled" && <p className="mt-1">{t("messageCanceled")}</p>}
-        {status === "payment_failed" && <p className="mt-1 text-red-600">{t("messagePaymentFailed")}</p>}
-        {status === "cancelling" && <p className="mt-1">{t("messageCancelling")}</p>}
-        {status === "incomplete" && <p className="mt-1 text-yellow-600">{t("messageIncomplete")}</p>}
-        {status === "incomplete_expired" && <p className="mt-1 text-red-600">{t("messageIncompleteExpired")}</p>}
+        {status === "canceled" && <p className="mt-4">{t("messageCanceled")}</p>}
+        {status === "payment_failed" && <p className="mt-4 text-red-600">{t("messagePaymentFailed")}</p>}
+        {status === "cancelling" && <p className="mt-4">{t("messageCancelling")}</p>}
+        {status === "incomplete" && <p className="mt-4 text-yellow-600">{t("messageIncomplete")}</p>}
+        {status === "incomplete_expired" && <p className="mt-4 text-red-600">{t("messageIncompleteExpired")}</p>}
       </div>
     </div>
   );

--- a/app/components/ui/SoundToggle.tsx
+++ b/app/components/ui/SoundToggle.tsx
@@ -13,9 +13,9 @@ export function SoundToggle() {
       aria-label={muted ? "Unmute sounds" : "Mute sounds"}
     >
       {muted ? (
-        <VolumeX className="w-5 h-5 text-text-secondary" />
+        <VolumeX className="w-20 h-20 text-text-secondary" />
       ) : (
-        <Volume2 className="w-5 h-5 text-text-secondary" />
+        <Volume2 className="w-20 h-20 text-text-secondary" />
       )}
     </button>
   );

--- a/app/components/ui/ThemeToggle.tsx
+++ b/app/components/ui/ThemeToggle.tsx
@@ -17,13 +17,13 @@ export function ThemeToggle() {
   const getIcon = () => {
     switch (theme) {
       case "light":
-        return <Sun className="w-5 h-5" />;
+        return <Sun className="w-20 h-20" />;
       case "dark":
-        return <Moon className="w-5 h-5" />;
+        return <Moon className="w-20 h-20" />;
       case "system":
-        return <Monitor className="w-5 h-5" />;
+        return <Monitor className="w-20 h-20" />;
       default:
-        return <Sun className="w-5 h-5" />;
+        return <Sun className="w-20 h-20" />;
     }
   };
 

--- a/app/lib/keyboard/KeyboardHelpModal.tsx
+++ b/app/lib/keyboard/KeyboardHelpModal.tsx
@@ -41,11 +41,11 @@ export function KeyboardHelpModal({ shortcuts }: KeyboardHelpModalProps) {
           <h3 className="font-semibold text-sm uppercase tracking-wide text-gray-500 mb-2">
             {scope === "global" ? "Global" : scope}
           </h3>
-          <div className="space-y-1">
+          <div className="space-y-4">
             {items.map((item, index) => (
-              <div key={`${scope}-${index}`} className="flex justify-between items-center py-1">
+              <div key={`${scope}-${index}`} className="flex justify-between items-center py-4">
                 <span className="text-sm">{item.options.description}</span>
-                <kbd className="ml-4 px-2 py-1 text-xs font-semibold text-gray-800 bg-gray-100 rounded">
+                <kbd className="ml-4 px-2 py-4 text-xs font-semibold text-gray-800 bg-gray-100 rounded">
                   {formatShortcutForDisplay(item.keys)}
                 </kbd>
               </div>

--- a/app/lib/modal/modals/SubscriptionModal.tsx
+++ b/app/lib/modal/modals/SubscriptionModal.tsx
@@ -122,13 +122,13 @@ export function SubscriptionModal({
       {/* Feature Context Benefits */}
       {featuresContext && (
         <div className="bg-bg-secondary p-4 rounded-lg border border-border-secondary">
-          <h3 className="font-medium text-text-primary mb-3">
+          <h3 className="font-medium text-text-primary mb-12">
             {t("unlockWith", { feature: featuresContext.feature })}
           </h3>
           <ul className="space-y-2">
             {featuresContext.benefits.map((benefit, index) => (
               <li key={index} className="flex items-center text-sm text-text-secondary">
-                <span className="text-green-500 mr-3 flex-shrink-0" aria-hidden="true">
+                <span className="text-green-500 mr-12 flex-shrink-0" aria-hidden="true">
                   ✓
                 </span>
                 {benefit}
@@ -149,8 +149,8 @@ export function SubscriptionModal({
           }`}
         >
           {suggestedTier === "premium" && (
-            <div className="absolute -top-3 left-4">
-              <span className="bg-blue-600 text-white text-xs px-3 py-1 rounded-full">{t("recommended")}</span>
+            <div className="absolute -top-12 left-4">
+              <span className="bg-blue-600 text-white text-xs px-12 py-4 rounded-full">{t("recommended")}</span>
             </div>
           )}
 
@@ -168,7 +168,7 @@ export function SubscriptionModal({
           <ul className="space-y-2 mb-6">
             {premiumTier.features.map((feature: string, index: number) => (
               <li key={index} className="flex items-start text-sm text-text-secondary">
-                <span className="text-green-500 mr-3 mt-0.5 flex-shrink-0" aria-hidden="true">
+                <span className="text-green-500 mr-12 mt-0.5 flex-shrink-0" aria-hidden="true">
                   ✓
                 </span>
                 {feature}
@@ -190,7 +190,7 @@ export function SubscriptionModal({
 
       {/* Footer */}
       <div className="text-center pt-4 border-t border-border-secondary">
-        <p className="text-xs text-text-tertiary mb-3">{t("renewNotice")}</p>
+        <p className="text-xs text-text-tertiary mb-12">{t("renewNotice")}</p>
 
         <button onClick={handleClose} className="text-text-secondary hover:text-text-primary text-sm underline">
           {t("notNow")}

--- a/app/lib/modal/modals/SubscriptionSuccessModal.tsx
+++ b/app/lib/modal/modals/SubscriptionSuccessModal.tsx
@@ -90,7 +90,7 @@ export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onCl
 
       {/* Subscription Details */}
       <div className="bg-bg-secondary p-4 rounded-lg border border-border-secondary">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center justify-between mb-12">
           <span className="font-medium text-text-primary">{t("planLabel", { tier: tierInfo.name })}</span>
           <span className="text-2xl font-bold text-text-primary">
             <PremiumPrice interval="monthly" />
@@ -101,7 +101,7 @@ export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onCl
         {content.features.length > 0 && (
           <div>
             <h4 className="font-medium text-text-primary mb-2 text-sm">{t("whatYouCanDo")}</h4>
-            <ul className="space-y-1 text-left">
+            <ul className="space-y-4 text-left">
               {content.features.map((feature, index) => (
                 <li key={index} className="flex items-start text-sm text-text-secondary">
                   <span className="text-green-500 mr-2 mt-0.5 flex-shrink-0" aria-hidden="true">
@@ -119,7 +119,7 @@ export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onCl
       {nextSteps && (
         <div className="bg-blue-50 p-4 rounded-lg border border-blue-200">
           <h3 className="font-medium text-blue-900 mb-2">{nextSteps.title}</h3>
-          <p className="text-blue-800 text-sm mb-3">{nextSteps.description}</p>
+          <p className="text-blue-800 text-sm mb-12">{nextSteps.description}</p>
           <button
             onClick={handleNextSteps}
             className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
@@ -130,11 +130,11 @@ export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onCl
       )}
 
       {/* Action Buttons */}
-      <div className="space-y-3">
+      <div className="space-y-12">
         {!nextSteps && (
           <button
             onClick={handleClose}
-            className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+            className="w-full px-6 py-12 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
           >
             {t("continueLearning")}
           </button>


### PR DESCRIPTION
## What

Our theme (`app/styles/theme/spacing.css`) defines an explicit **pixel-based** spacing scale (`--spacing-8: 8px`, `--spacing-12: 12px`, ...). A number of production components were using **off-scale, default-Tailwind** spacing values (`mt-1`, `mb-3`, `h-5`, `gap-3`, ...) that only resolved via Tailwind's default `0.25rem` multiplier fallback rather than our canonical tokens, plus one stray `w-100` that fell back to **400px**.

This normalizes every off-scale spacing utility in production components to the equivalent canonical scale token, **preserving rendered pixels**:

| off-scale | → canonical | px |
|---|---|---|
| `*-1` | `*-4` | 4px |
| `*-3` | `*-12` | 12px |
| `*-5` | `*-20` | 20px |

- Removes the stray `w-100` on the bootcamp certificate image (it was rendering 400px via the fallback; the `lg:w-[350px]` beside it is the intended sizing).
- Fractions (`w-1/2`, `w-3/4`, ...) are valid Tailwind and **left untouched**.
- `app/dev` and `app/test` pages are intentionally **excluded** (not user-facing).

## Why

Purely mechanical cleanup. It gives a saner, self-consistent starting point (every spacing value now maps to a real theme token) ahead of the CSS-module work planned for the external pages.

## Note

Also drops two now-flagged unnecessary optional chains on the non-nullish `useSearchParams()` result in `ResetPasswordForm` — surfaced by `lint-staged` because the file was touched. No behaviour change.

## Testing

- All 1846 unit tests pass, typecheck + lint clean (pre-commit hook).
- Pixel values are preserved by construction, so no visual change is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)