### PR TITLE
Consolidate llm-chat-proxy logging to one structured summary per request

### DIFF
--- a/llm-chat-proxy/src/auth.ts
+++ b/llm-chat-proxy/src/auth.ts
@@ -1,4 +1,5 @@
 import { jwtVerify } from "jose";
+import { debugLog } from "./log";
 
 export interface JWTResult {
   userId: string | null;
@@ -23,29 +24,28 @@ export async function verifyJWT(token: string, secret: string): Promise<JWTResul
 
     // User ID is in the 'sub' claim (accept string or number)
     if (typeof payload.sub !== "string" && typeof payload.sub !== "number") {
-      console.log("Invalid token: missing or invalid sub claim");
+      debugLog("Invalid token: missing or invalid sub claim");
       return { userId: null, error: "missing_claim" };
     }
     const userId = String(payload.sub);
 
     // Exercise slug is required for chat tokens
     if (typeof payload.exercise_slug !== "string") {
-      console.log("Invalid token: missing or invalid exercise_slug claim");
+      debugLog("Invalid token: missing or invalid exercise_slug claim");
       return { userId: null, error: "missing_claim" };
     }
 
     return { userId, exerciseSlug: payload.exercise_slug };
   } catch (error) {
-    console.error("JWT verification failed:", error);
-
-    // Check if error is specifically due to expiration
-    if (error && typeof error === "object" && "code" in error) {
-      if (error.code === "ERR_JWT_EXPIRED") {
-        console.log("Token is expired");
-        return { userId: null, error: "expired" };
-      }
+    // Expired tokens are a routine client condition (the frontend auto-retries),
+    // so they are dev-only noise. Genuinely invalid tokens (bad signature,
+    // malformed) are unexpected and logged as errors even in production.
+    if (error && typeof error === "object" && "code" in error && error.code === "ERR_JWT_EXPIRED") {
+      debugLog("Token is expired");
+      return { userId: null, error: "expired" };
     }
 
+    console.error("JWT verification failed:", error);
     // All other errors (invalid signature, malformed token, etc.)
     return { userId: null, error: "invalid" };
   }

--- a/llm-chat-proxy/src/gemini.ts
+++ b/llm-chat-proxy/src/gemini.ts
@@ -1,4 +1,27 @@
 import { GoogleGenAI } from "@google/genai";
+import { debugLog } from "./log";
+
+/**
+ * Token usage for a completed request. Output is split into thinking vs visible
+ * (both billed as output); cachedTokens is the prefix-cached portion of the input.
+ */
+export interface GeminiUsage {
+  inputTokens: number;
+  cachedTokens: number;
+  outputTokens: number;
+  thinkingTokens: number;
+  visibleTokens: number;
+  totalTokens: number;
+}
+
+/** Result of opening a Gemini stream: the text stream, the model that served it,
+ *  and a promise resolving to token usage once streaming completes (null if the
+ *  final chunk carried no usageMetadata). */
+export interface GeminiStreamResult {
+  stream: ReadableStream;
+  model: string;
+  usage: Promise<GeminiUsage | null>;
+}
 
 const MODEL_CHAIN = [
   {
@@ -72,18 +95,18 @@ async function tryModel(
         contents: prompt,
         config: { ...config, systemInstruction }
       });
-      console.log(`[Gemini] Using model: ${model}`);
+      debugLog(`[Gemini] Using model: ${model}`);
       return result;
     } catch (error) {
       if (isRateLimitError(error)) {
-        console.log(`[Gemini] Rate limited on ${model}, trying next model`);
+        debugLog(`[Gemini] Rate limited on ${model}, trying next model`);
         return "rate-limited";
       }
       if (!isRetryableError(error) || attempt === MAX_RETRIES) {
         throw error;
       }
       const backoff = RETRY_BASE_DELAY_MS * 2 ** attempt;
-      console.log(
+      debugLog(
         `[Gemini] Retryable error on ${model} (attempt ${attempt + 1}/${MAX_RETRIES}), retrying in ${backoff}ms`
       );
       await delay(backoff);
@@ -112,39 +135,43 @@ async function openModelStream(
 }
 
 /**
- * Logs token usage for a completed request. Breaks output into thinking vs
- * visible tokens (thinking is billed as output) and surfaces cached prefix
- * tokens, so we can measure the impact of the thinking budget and prefix caching.
+ * Extracts token usage from the final stream chunk. Breaks output into thinking
+ * vs visible tokens (thinking is billed as output) and surfaces cached prefix
+ * tokens, so callers can measure the thinking budget and prefix-caching impact.
+ * Returns null if the chunk carried no usageMetadata.
  */
-function logUsage(model: string, usage: GeminiChunk): void {
-  const meta = (usage as { usageMetadata?: Record<string, number> }).usageMetadata;
+function extractUsage(chunk: GeminiChunk): GeminiUsage | null {
+  const meta = (chunk as { usageMetadata?: Record<string, number> }).usageMetadata;
   if (!meta) {
-    return;
+    return null;
   }
 
-  const promptTokens = meta.promptTokenCount ?? 0;
-  const cachedTokens = meta.cachedContentTokenCount ?? 0;
   // thoughtsTokenCount is billed as output but reported SEPARATELY from
   // candidatesTokenCount (the visible answer). Billed output = candidates + thoughts.
   const visibleTokens = meta.candidatesTokenCount ?? 0;
   const thinkingTokens = meta.thoughtsTokenCount ?? 0;
-  const outputTokens = visibleTokens + thinkingTokens;
-  const totalTokens = meta.totalTokenCount ?? 0;
-  const cachedPct = promptTokens > 0 ? Math.round((cachedTokens / promptTokens) * 100) : 0;
 
-  console.log(
-    `[Gemini Usage] model=${model} input=${promptTokens} (cached=${cachedTokens}, ${cachedPct}%) ` +
-      `output=${outputTokens} (thinking=${thinkingTokens}, visible=${visibleTokens}) ` +
-      `total=${totalTokens}`
-  );
+  return {
+    inputTokens: meta.promptTokenCount ?? 0,
+    cachedTokens: meta.cachedContentTokenCount ?? 0,
+    outputTokens: visibleTokens + thinkingTokens,
+    thinkingTokens,
+    visibleTokens,
+    totalTokens: meta.totalTokenCount ?? 0
+  };
 }
 
 /**
  * Wraps a Gemini stream as a ReadableStream of text chunks, invoking onChunk
  * for each non-empty chunk. Captures usage metadata (which arrives on the final
- * chunk, often with empty text) and logs it once streaming completes.
+ * chunk, often with empty text) and resolves `onUsage` with it once streaming
+ * completes, so the caller can attribute cost in its own summary log.
  */
-function toTextStream(result: GeminiStream, model: string, onChunk?: (chunk: string) => void): ReadableStream {
+function toTextStream(
+  result: GeminiStream,
+  onChunk: ((chunk: string) => void) | undefined,
+  onUsage: (usage: GeminiUsage | null) => void
+): ReadableStream {
   const encoder = new TextEncoder();
 
   return new ReadableStream({
@@ -162,12 +189,11 @@ function toTextStream(result: GeminiStream, model: string, onChunk?: (chunk: str
           onChunk?.(text);
           controller.enqueue(encoder.encode(text));
         }
-        if (lastChunk !== undefined) {
-          logUsage(model, lastChunk);
-        }
+        onUsage(lastChunk !== undefined ? extractUsage(lastChunk) : null);
         controller.close();
       } catch (error) {
         console.error("Gemini streaming error:", error);
+        onUsage(null);
         controller.error(error);
       }
     }
@@ -182,15 +208,23 @@ function toTextStream(result: GeminiStream, model: string, onChunk?: (chunk: str
  * @param apiKey - Google Gemini API key
  * @param systemInstruction - The persona + tutor rules, sent as systemInstruction
  * @param onChunk - Optional callback for each chunk (for collecting full response)
- * @returns A ReadableStream of text chunks
+ * @returns The text stream, the model that served it, and a promise resolving to
+ *          token usage once streaming completes.
  */
 export async function streamGeminiResponse(
   prompt: string,
   apiKey: string,
   systemInstruction: string,
   onChunk?: (chunk: string) => void
-): Promise<ReadableStream> {
+): Promise<GeminiStreamResult> {
   const ai = new GoogleGenAI({ apiKey });
   const { result, model } = await openModelStream(ai, prompt, systemInstruction);
-  return toTextStream(result, model, onChunk);
+
+  let resolveUsage: (usage: GeminiUsage | null) => void;
+  const usage = new Promise<GeminiUsage | null>((resolve) => {
+    resolveUsage = resolve;
+  });
+
+  const stream = toTextStream(result, onChunk, (u) => resolveUsage(u));
+  return { stream, model, usage };
 }

--- a/llm-chat-proxy/src/index.ts
+++ b/llm-chat-proxy/src/index.ts
@@ -2,9 +2,10 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { verifyJWT } from "./auth";
 import { streamGeminiResponse } from "./gemini";
-import { buildPrompt } from "./prompt-builder";
+import { buildPrompt, INPUT_LIMITS } from "./prompt-builder";
 import { createSignaturePayload, generateSignature } from "./crypto";
 import { checkUsage, recordUsage, buildUsageMeta } from "./usage";
+import { debugLog, isDev } from "./log";
 import type { Bindings, ChatRequest } from "./types";
 
 const app = new Hono<{ Bindings: Bindings }>();
@@ -42,22 +43,22 @@ app.get("/health", (c) => {
 // Main chat endpoint
 app.post("/chat", async (c) => {
   try {
-    console.log("[Chat] Incoming request");
+    debugLog("[Chat] Incoming request");
 
     // 1. Extract and verify JWT from Authorization header
     const authHeader = c.req.header("Authorization");
     if (!authHeader) {
-      console.log("[Chat] ❌ No Authorization header");
+      debugLog("[Chat] ❌ No Authorization header");
       return c.json({ error: "Missing authorization token" }, 401);
     }
 
     const token = authHeader.replace("Bearer ", "");
 
-    console.log("[Chat] Token (first 20 chars):", token.substring(0, 20) + "...");
+    debugLog("[Chat] Token (first 20 chars):", token.substring(0, 20) + "...");
 
     const jwtResult = await verifyJWT(token, c.env.DEVISE_JWT_SECRET_KEY);
     if (!jwtResult.userId) {
-      console.log(`[Chat] ❌ JWT verification failed - ${jwtResult.error}`);
+      debugLog(`[Chat] ❌ JWT verification failed - ${jwtResult.error}`);
 
       if (jwtResult.error === "expired") {
         return c.json(
@@ -78,14 +79,14 @@ app.post("/chat", async (c) => {
       );
     }
 
-    console.log("[Chat] ✅ JWT verified, user ID:", jwtResult.userId);
+    debugLog("[Chat] ✅ JWT verified, user ID:", jwtResult.userId);
     const userId = jwtResult.userId;
 
     // 1b. Per-user burst limit: 10 requests/minute, keyed on JWT sub.
     // Checked before building the prompt so throttled requests never reach Gemini.
     const { success } = await c.env.RATE_LIMITER.limit({ key: userId });
     if (!success) {
-      console.log(`[Chat] ⛔ Rate limited user ${userId}`);
+      debugLog(`[Chat] ⛔ Rate limited user ${userId}`);
       return c.json(
         {
           error: "rate_limited",
@@ -100,7 +101,7 @@ app.post("/chat", async (c) => {
     const now = new Date();
     const usage = await checkUsage(c.env.USAGE_KV, userId, now);
     if (!usage.allowed) {
-      console.log(
+      debugLog(
         `[Chat] ⛔ ${usage.scope} cap reached for user ${userId} (day=${usage.counts.day}, month=${usage.counts.month})`
       );
       return c.json(
@@ -127,7 +128,7 @@ app.post("/chat", async (c) => {
 
     // 2b. Validate exerciseSlug in request matches JWT claim
     if (jwtResult.exerciseSlug !== exerciseSlug) {
-      console.log(`[Chat] ❌ Exercise mismatch: JWT=${jwtResult.exerciseSlug}, body=${exerciseSlug}`);
+      debugLog(`[Chat] ❌ Exercise mismatch: JWT=${jwtResult.exerciseSlug}, body=${exerciseSlug}`);
       return c.json(
         {
           error: "exercise_mismatch",
@@ -144,7 +145,6 @@ app.post("/chat", async (c) => {
     // so trusting it in production would let a direct API caller point us at
     // arbitrary/oversized JSON. The header is only honoured in development so
     // local testing can hit localhost.
-    const isDev = process.env.NODE_ENV === "development";
     const origin = isDev ? c.req.header("Origin") || "https://jiki.io" : "https://jiki.io";
     const contentUrl = `${origin}/static/exercises/${exerciseSlug}/en-${language}-${contentHash}.json`;
 
@@ -163,7 +163,11 @@ app.post("/chat", async (c) => {
     // an API error) does NOT consume the user's quota - we only count requests
     // Gemini actually accepted.
     let fullResponse = "";
-    const geminiStream = await streamGeminiResponse(prompt, c.env.GOOGLE_GEMINI_API_KEY, systemInstruction, (chunk) => {
+    const {
+      stream: geminiStream,
+      model,
+      usage: usagePromise
+    } = await streamGeminiResponse(prompt, c.env.GOOGLE_GEMINI_API_KEY, systemInstruction, (chunk) => {
       fullResponse += chunk;
     });
 
@@ -186,6 +190,33 @@ app.post("/chat", async (c) => {
             if (done) break;
             controller.enqueue(value);
           }
+
+          // One structured summary per successful request. Logged as an object
+          // (not a string) so Workers Logs indexes each field for querying. This
+          // is the ONLY log event a healthy request emits in production; all the
+          // per-step tracing above goes through debugLog (dev only). `model`
+          // doubles as the fallback signal (flash-lite => cascaded off flash).
+          const u = await usagePromise;
+          const cachedPct = u && u.inputTokens > 0 ? Math.round((u.cachedTokens / u.inputTokens) * 100) : 0;
+          console.log({
+            event: "chat",
+            outcome: "ok",
+            userId,
+            exerciseSlug,
+            language,
+            model,
+            inputTokens: u?.inputTokens ?? null,
+            cachedTokens: u?.cachedTokens ?? null,
+            cachedPct,
+            outputTokens: u?.outputTokens ?? null,
+            durationMs: Date.now() - now.getTime(),
+            dayCount: usageCounts.day,
+            monthCount: usageCounts.month,
+            questionLen: question.length,
+            codeLen: code.length,
+            historyCount: history.length,
+            codeCropped: code.length > INPUT_LIMITS.CODE_MAX_LENGTH
+          });
 
           // Generate signature after streaming completes
           try {

--- a/llm-chat-proxy/src/log.ts
+++ b/llm-chat-proxy/src/log.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether we're running in local development. In production (deployed Worker)
+ * NODE_ENV is unset, so this is false.
+ */
+export const isDev = process.env.NODE_ENV === "development";
+
+/**
+ * Logs only in development. Use for tracing/debug output that must not add to
+ * production log volume - Cloudflare Workers Logs bills per log EVENT (not size),
+ * so every stray console.log is a billable event retained for 7 days. In prod we
+ * emit a single structured summary per request instead (see index.ts); genuine
+ * failures use console.error directly so they are always visible.
+ */
+export function debugLog(...args: unknown[]): void {
+  if (isDev) {
+    console.log(...args);
+  }
+}

--- a/llm-chat-proxy/src/prompt-builder.ts
+++ b/llm-chat-proxy/src/prompt-builder.ts
@@ -1,5 +1,6 @@
 import { getExercise, getLanguageFeatures, getLLMMetadata, getTaughtConcepts } from "@jiki/curriculum";
 import type { ExerciseCore, LLMMetadata, Language } from "@jiki/curriculum";
+import { isDev } from "./log";
 import type { ChatMessage } from "./types";
 
 interface ExerciseContent {
@@ -144,13 +145,16 @@ export async function buildPrompt(options: PromptOptions): Promise<{ systemInstr
   // Filter out null/empty sections and join with double newlines
   const prompt = sections.filter((section) => section !== null && section !== "").join("\n\n");
 
-  // Log prompt for debugging in development
-  console.log("[Prompt Builder] Generated prompt:");
-  console.log("=".repeat(80));
-  console.log(systemInstruction);
-  console.log("-".repeat(80));
-  console.log(prompt);
-  console.log("=".repeat(80));
+  // Log prompt for debugging in development only. This dumps student code and
+  // questions, so it must never run in production (privacy + log volume).
+  if (isDev) {
+    console.log("[Prompt Builder] Generated prompt:");
+    console.log("=".repeat(80));
+    console.log(systemInstruction);
+    console.log("-".repeat(80));
+    console.log(prompt);
+    console.log("=".repeat(80));
+  }
 
   return { systemInstruction, prompt };
 }
@@ -482,8 +486,6 @@ ${code}
 }
 
 function buildTutorGuidelines(): string {
-  const isDev = process.env.NODE_ENV === "development";
-
   const rules = [
     "- Your aim is to UNBLOCK students. As soon as you can, encourage them to try things out themselves. Once they've made a step forward, push them back into code. Don't keep talking UNLESS the student needs it.",
     "- IMPORTANT: Do NOT give away the answer. Your job is to GUIDE the student to DISCOVER the answer THEMSELVES, not tell them the answer.",

--- a/llm-chat-proxy/tests/auth.test.ts
+++ b/llm-chat-proxy/tests/auth.test.ts
@@ -6,12 +6,13 @@ vi.mock("../src/gemini", () => ({
   streamGeminiResponse: vi.fn(
     async (_prompt: string, _apiKey: string, _systemInstruction: string, onChunk?: (chunk: string) => void) => {
       onChunk?.("mocked response");
-      return new ReadableStream({
+      const stream = new ReadableStream({
         start(controller) {
           controller.enqueue(new TextEncoder().encode("mocked response"));
           controller.close();
         }
       });
+      return { stream, model: "gemini-2.5-flash", usage: Promise.resolve(null) };
     }
   )
 }));

--- a/llm-chat-proxy/tests/log.test.ts
+++ b/llm-chat-proxy/tests/log.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// isDev is resolved from process.env.NODE_ENV at module load, so each variant is
+// exercised by setting the env and re-importing the module in isolation.
+async function loadLog(nodeEnv: string | undefined) {
+  vi.resetModules();
+  const prev = process.env.NODE_ENV;
+  if (nodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = nodeEnv;
+  }
+  const mod = await import("../src/log");
+  process.env.NODE_ENV = prev;
+  return mod;
+}
+
+describe("debugLog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs in development", async () => {
+    const { debugLog, isDev } = await loadLog("development");
+    expect(isDev).toBe(true);
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    debugLog("hello", 123);
+    expect(spy).toHaveBeenCalledWith("hello", 123);
+  });
+
+  it("is silent in production", async () => {
+    const { debugLog, isDev } = await loadLog(undefined);
+    expect(isDev).toBe(false);
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    debugLog("should not appear");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("is silent under other envs (e.g. test)", async () => {
+    const { debugLog, isDev } = await loadLog("test");
+    expect(isDev).toBe(false);
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    debugLog("should not appear");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/llm-chat-proxy/wrangler.toml
+++ b/llm-chat-proxy/wrangler.toml
@@ -3,6 +3,13 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Retain Workers Logs (queryable by status/time in the dashboard for 7 days on the
+# paid plan) so failures are diagnosable after the fact without catching them live.
+# Billed per log EVENT, not size; a healthy request emits one structured summary
+# line (see src/index.ts), so volume stays well within the included allotment.
+[observability]
+enabled = true
+
 [[rules]]
 type = "Text"
 globs = ["**/*.css", "**/*.javascript", "**/*.py", "**/*.jiki", "**/*.md"]


### PR DESCRIPTION
## Context

Diagnosing a student's "Server error. Please try again in a few moments." meant catching the failure live with `wrangler tail`, because the worker retains no logs. While in there, the `/chat` path was emitting ~11 `console.log` events per successful request: request chatter, a 6-line prompt dump that included student code/questions, plus model + usage lines. Cloudflare Workers Logs bills per log **event** (not size) and retains 7 days, so this was pure noise and put student content into retained logs.

## What this does

- **`src/log.ts`** (new): a dev-only `debugLog(...)` wrapper plus a shared `isDev` (previously recomputed in two files). All per-step tracing routes through it, so the detail stays in local dev but production stays quiet.
- **One structured summary per successful request** (`index.ts`), logged as an **object** so Workers Logs indexes each field for querying: `outcome, userId, exerciseSlug, language, model, inputTokens, cachedTokens, cachedPct, outputTokens, durationMs, dayCount, monthCount, questionLen, codeLen, historyCount, codeCropped`. `model` doubles as the fallback signal (`gemini-2.5-flash-lite` => cascaded off flash).
- **`gemini.ts`**: `streamGeminiResponse` now returns `{ stream, model, usage }` so index attributes cost in its own summary instead of gemini logging it. `logUsage` became a pure `extractUsage`. No change to streaming or model-fallback behaviour.
- **`auth.ts`**: expired JWTs (a routine, auto-retried client condition) are demoted from `console.error` to `debugLog`; only genuinely invalid tokens log as errors. Genuine server failures everywhere else keep `console.error`.
- **`prompt-builder.ts`**: the prompt dump is gated behind `isDev` (no student content in prod logs).
- **`wrangler.toml`**: `[observability] enabled = true` so summaries are retained and queryable after the fact, instead of needing a live tail.

Net: prod goes from ~11 log events per request to 1 (plus errors on failure), and no student content in retained logs.

## Not included

This does **not** change Gemini retry/fallback behaviour. The specific 503 `UNAVAILABLE` that triggered the investigation was caused by a lapsed billing card (dropping the key to free-tier capacity), already resolved out-of-band.

## Test plan

- `pnpm test` (proxy): 89 pass, including new `tests/log.test.ts` (debugLog on in dev, silent in prod/test).
- `pnpm typecheck` (proxy): clean.
- `pnpm lint` (proxy): clean.
- Requires `pnpm deploy` (Jiki account) for observability + logging to take effect in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)