### PR TITLE
Enable strict CSS chunking

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -13,7 +13,8 @@ const nextConfig: NextConfig = {
   // sends a real Chrome UA so neither would see metadata in <head> without this.
   htmlLimitedBots: /.*/,
   experimental: {
-    reactCompiler: true
+    reactCompiler: true,
+    cssChunking: "strict"
   },
   images: {
     unoptimized: true,


### PR DESCRIPTION
## What

Sets `experimental.cssChunking: 'strict'` in `next.config.ts`.

## Why

Next defaults to `'loose'`, which merges CSS-module chunks across routes via a "commonly loaded together" heuristic. On the external/marketing surface this leaked app-only module CSS (`Badges`, `BenefitSection`) into the chunk the landing page loads.

`'strict'` splits CSS more granularly per component cluster, dropping that app-only leak from the home path and shipping less dead CSS on external routes.

## Notes / limits

- Genuinely shared components still group together (e.g. `BlogPostCard` is shared by the landing page and the blog index, so its cluster travels with blog/article-detail CSS). That's expected and not addressable at the source level — there's no barrel or stray import to cut.
- Verified: `pnpm build` passes clean; type check, lint, and all 1835 app tests green via pre-commit.
- Net effect is modest polish on an already-fast page; the larger render-blocking lever (`inlineCss`) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)