### PR TITLE
Tighten spacing for lists nested directly inside paragraphs

### DIFF
--- a/app/app/styles/components/textual-content.css
+++ b/app/app/styles/components/textual-content.css
@@ -37,6 +37,11 @@
         &:last-child {
             margin-bottom: 0;
         }
+
+        & > ol,
+        & > ul {
+            margin-top: -12px;
+        }
     }
 
     strong {


### PR DESCRIPTION
## Summary

- Pull `ol`/`ul` that render inline within a `<p>` in `.ui-textual-content` up by 12px so nested lists sit closer to their introducing text.

## Details

Added a nested `& > ol, & > ul { margin-top: -12px; }` rule inside the existing `p` block in `app/app/styles/components/textual-content.css`, matching the file's CSS-nesting idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)