### PR TITLE
Fix broken layout on hybrid pages (de-Tailwind SidebarLayout)

### DIFF
--- a/app/app/styles/components/navigation.css
+++ b/app/app/styles/components/navigation.css
@@ -47,6 +47,12 @@
         padding-left: 12px;
     }
 
+    /* Vertical rhythm between nav items (replaces Tailwind space-y-2, which is
+       not available on hybrid routes like /concepts). --spacing-2 is 2px. */
+    .nav-list > * + * {
+        margin-top: var(--spacing-2);
+    }
+
     /* Navigation items */
     .nav-item {
         display: flex;

--- a/app/components/layout/SidebarLayout.module.css
+++ b/app/components/layout/SidebarLayout.module.css
@@ -1,0 +1,28 @@
+/*
+ * SidebarLayout is rendered on (hybrid) routes (e.g. /concepts) where the
+ * Tailwind utility bundle is not loaded, so its layout must be expressed as a
+ * CSS module rather than Tailwind classes.
+ */
+
+.appShell {
+    min-height: 100vh;
+    display: flex;
+    background-color: #fff;
+}
+
+.main {
+    flex: 1 1 0%;
+    min-width: 0;
+    overflow-x: hidden;
+}
+
+.externalShell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background-color: #fff;
+}
+
+.externalMain {
+    flex: 1 1 0%;
+}

--- a/app/components/layout/SidebarLayout.tsx
+++ b/app/components/layout/SidebarLayout.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from "../../lib/auth/authStore";
 import { ExternalFooter } from "./ExternalFooter";
 import Header from "./header/Header";
 import Sidebar from "./sidebar/Sidebar";
+import styles from "./SidebarLayout.module.css";
 
 interface SidebarLayoutProps {
   activeItem: string;
@@ -14,16 +15,16 @@ export default function SidebarLayout({ activeItem, children }: SidebarLayoutPro
   const { isAuthenticated } = useAuthStore();
   if (isAuthenticated) {
     return (
-      <div className="min-h-screen flex bg-white">
+      <div className={styles.appShell}>
         <Sidebar activeItem={activeItem} />
-        <main className="flex-1 min-w-0 overflow-x-hidden">{children}</main>
+        <main className={styles.main}>{children}</main>
       </div>
     );
   }
   return (
-    <div className="min-h-screen flex flex-col bg-white">
+    <div className={styles.externalShell}>
       <Header />
-      <main className="flex-1">{children}</main>
+      <main className={styles.externalMain}>{children}</main>
       <ExternalFooter />
     </div>
   );

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -51,7 +51,7 @@ export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
       <Logo />
 
       <nav>
-        <ul className="space-y-2">
+        <ul className="nav-list">
           {navigationItems.map((item) => (
             <NavigationItem
               key={item.id}
@@ -73,7 +73,7 @@ export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
           <p>
             {t("upsell.free")} <span className="upgrade-text">{t("upsell.upgrade")}</span> {t("upsell.accelerate")}
             &nbsp;
-            <span className={`inline-block align-middle ${rocket.rocketWrapper} ${launching ? rocket.launching : ""}`}>
+            <span className={`${rocket.rocketWrapper} ${launching ? rocket.launching : ""}`}>
               <RocketIcon width={16} height={16} className={rocket.rocket} />
             </span>
           </p>


### PR DESCRIPTION
## Problem

The Tailwind-isolation work (#783) scoped the Tailwind utility bundle to the `(app)` route group only. But `SidebarLayout` — rendered on `(hybrid)` routes like `/concepts` — was still written in Tailwind utilities. With Tailwind absent on those routes, `flex-1 min-w-0 overflow-x-hidden` (and the shell's `flex` / `min-h-screen` / `bg-white`) silently did nothing, breaking the page layout (the main content area no longer constrained/clipped horizontally).

## Fix

- **`SidebarLayout`** — move the shell + `<main>` classes into a CSS module (`SidebarLayout.module.css`). CSS modules load regardless of route group, so both the authenticated (`appShell` + `main`) and logged-out (`externalShell` + `externalMain`) branches now work on hybrid routes.
- **`Sidebar`** — the only other Tailwind in the rendered subtree:
  - Replace `space-y-2` with a global `.nav-list` rule using `var(--spacing-2)`. Note: this project's spacing scale defines `--spacing-2: 2px` (not Tailwind's default `0.5rem`), so the rule preserves the exact 2px rhythm.
  - Drop the redundant `inline-block align-middle` — the `rocketWrapper` module class already sets `display: inline-block; vertical-align: middle`.
- **`Header` / `ExternalFooter`** — already CSS-module based; no change needed.

## Verification

- `flex-1 min-w-0 overflow-x-hidden` combo now resolves via the module (confirmed `.main { flex:1; min-width:0; overflow-x:hidden }` in the served CSS on `/concepts`).
- No raw Tailwind class strings left in the rendered layout.
- Typecheck + full unit suite (1835 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)