### PR TITLE
Fix more Tailwind-on-hybrid breakage (spinner, CTA, <strong>)

### DIFF
--- a/app/app/styles/base.css
+++ b/app/app/styles/base.css
@@ -43,6 +43,14 @@
         font-weight: inherit;
     }
 
+    /* Emphasis renders semibold (not the browser-default bold) everywhere,
+       including hybrid/external routes where Tailwind utilities aren't loaded.
+       In @layer base, so Tailwind utilities and CSS modules still override it. */
+    strong,
+    b {
+        font-weight: 600;
+    }
+
     p,
     figure,
     blockquote,

--- a/app/components/premium/CtaSection.tsx
+++ b/app/components/premium/CtaSection.tsx
@@ -46,7 +46,7 @@ export default function CtaSection() {
         <h2 className={styles["cta-title"]}>{t("freeTitle")}</h2>
         <p className={styles["cta-desc"]}>{t("freeDesc")}</p>
         <button
-          className="ui-btn ui-btn-large ui-btn-white w-[260px] font-semibold"
+          className={`ui-btn ui-btn-large ui-btn-white ${styles.upgradeButton}`}
           onClick={() => (window.location.href = routes.authSignup())}
         >
           {t("freeButton")}

--- a/app/components/ui/LoadingSpinner.module.css
+++ b/app/components/ui/LoadingSpinner.module.css
@@ -1,0 +1,40 @@
+/*
+ * LoadingSpinner renders on (hybrid) routes (e.g. /unsubscribe) where the
+ * Tailwind utility bundle is not loaded, so its styles live here rather than in
+ * Tailwind classes. Values mirror the previous utilities exactly, referencing
+ * the same design tokens Tailwind generated them from.
+ */
+
+.wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.spinner {
+    border: 2px solid var(--color-gray-300);
+    border-top-color: var(--color-blue-500);
+    border-radius: 9999px;
+    animation: spin 1s linear infinite;
+}
+
+.sm {
+    width: var(--spacing-4);
+    height: var(--spacing-4);
+}
+
+.md {
+    width: var(--spacing-6);
+    height: var(--spacing-6);
+}
+
+.lg {
+    width: var(--spacing-8);
+    height: var(--spacing-8);
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/app/components/ui/LoadingSpinner.tsx
+++ b/app/components/ui/LoadingSpinner.tsx
@@ -1,18 +1,14 @@
+import styles from "./LoadingSpinner.module.css";
+
 interface LoadingSpinnerProps {
   size?: "sm" | "md" | "lg";
   className?: string;
 }
 
 export default function LoadingSpinner({ size = "md", className = "" }: LoadingSpinnerProps) {
-  const sizeClasses = {
-    sm: "w-4 h-4",
-    md: "w-6 h-6",
-    lg: "w-8 h-8"
-  };
-
   return (
-    <div className={`inline-flex items-center justify-center ${className}`}>
-      <div className={`${sizeClasses[size]} border-2 border-gray-300 rounded-full animate-spin border-t-blue-500`} />
+    <div className={`${styles.wrapper} ${className}`}>
+      <div className={`${styles.spinner} ${styles[size]}`} />
     </div>
   );
 }

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -919,7 +919,7 @@
       "nextItem3Title": "Add Deep Dive Videos",
       "nextItem3Description": "Long-form videos that go beyond the core lessons to explore concepts in real depth. Perfect for learners who want to understand the why behind the how, and to see how ideas connect to the wider world of programming.",
       "nextItem4Title": "Add first translations to other languages",
-      "nextItem4Description": "Bringing Jiki to learners in their own language, starting with <strong class=\"font-semibold\">European Portuguese</strong>, <strong class=\"font-semibold\">Spanish</strong>, <strong class=\"font-semibold\">Japanese</strong>, and <strong class=\"font-semibold\">Brazilian Portuguese</strong>. The whole interface and curriculum will be translated, not just the marketing pages.",
+      "nextItem4Description": "Bringing Jiki to learners in their own language, starting with <strong>European Portuguese</strong>, <strong>Spanish</strong>, <strong>Japanese</strong>, and <strong>Brazilian Portuguese</strong>. The whole interface and curriculum will be translated, not just the marketing pages.",
       "futureLabel": "Future",
       "futureTimeframe": "Q4 2026",
       "futureSummary": "On the horizon. Subject to change as we learn.",

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -919,7 +919,7 @@
       "nextItem3Title": "Add Deep Dive Videos",
       "nextItem3Description": "Long-form videos that go beyond the core lessons to explore concepts in real depth. Perfect for learners who want to understand the why behind the how, and to see how ideas connect to the wider world of programming.",
       "nextItem4Title": "Add first translations to other languages",
-      "nextItem4Description": "Bringing Jiki to learners in their own language, starting with <strong class=\"font-semibold\">European Portuguese</strong>, <strong class=\"font-semibold\">Spanish</strong>, <strong class=\"font-semibold\">Japanese</strong>, and <strong class=\"font-semibold\">Brazilian Portuguese</strong>. The whole interface and curriculum will be translated, not just the marketing pages.",
+      "nextItem4Description": "Bringing Jiki to learners in their own language, starting with <strong>European Portuguese</strong>, <strong>Spanish</strong>, <strong>Japanese</strong>, and <strong>Brazilian Portuguese</strong>. The whole interface and curriculum will be translated, not just the marketing pages.",
       "futureLabel": "Future",
       "futureTimeframe": "Q4 2026",
       "futureSummary": "On the horizon. Subject to change as we learn.",


### PR DESCRIPTION
Follow-up to #791 (SidebarLayout). I audited every `(hybrid)` and `(external)` route for shared components still written in Tailwind utilities — which have no effect off the `(app)` route group since Tailwind was isolated there in #783. Found and fixed three more:

## Fixes

- **`components/ui/LoadingSpinner.tsx`** — was *entirely* Tailwind (size, border, color, `animate-spin`), so it rendered invisible on `/unsubscribe` (hybrid). Moved to a CSS module that mirrors the exact values via the **same design tokens** Tailwind used (`--spacing-4/6/8`, `--color-gray-300`, `--color-blue-500`), so its `(app)` usages in settings look identical.
- **`components/premium/CtaSection.tsx`** — the free-tier CTA button used `w-[260px] font-semibold` on the hybrid `/premium` page. Reuse the existing `styles.upgradeButton` (same `width: 260px; font-weight: 600`) that its sibling button already uses.
- **`<strong>` emphasis** — the `en`/`hu` messages embedded `<strong class="font-semibold">`, which did nothing on hybrid (and the browser-default `<strong>` is 700, not the intended 600). Make `<strong>`/`<b>` render **semibold (600) globally** via `@layer base` — so Tailwind utilities and CSS modules still override on `(app)` — and drop the now-redundant class from both message files.

## Audit result (everything else clean)

- **External auth** (8 pages) — already CSS-module based.
- **Hybrid** blog / articles / concepts / delete-account — clean (concepts fixed by #791).
- **Global chrome** — the 7 always-available core modals, the `BaseModal` shell, and the toaster are all CSS-module/global; the Tailwind-heavy modals (subscription, exercise-success, …) are registered `(app)`-only, so they can't open off-`(app)`.

## Verification

- `/premium`: no `font-semibold` left in the HTML; `<strong>` renders 600 via the served `strong, b { font-weight: 600 }` base rule.
- `LoadingSpinner` module CSS matches the prior tokens exactly.
- Typecheck + full unit suite (1835 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)