### PR TITLE
Support onboarding-emails notification preference

### DIFF
--- a/app/app/dev/unsubscribe/page.tsx
+++ b/app/app/dev/unsubscribe/page.tsx
@@ -5,16 +5,15 @@ import UnsubscribeFromEmailSection from "@/components/unsubscribe/UnsubscribeFro
 import UnsubscribeFromAllSection from "@/components/unsubscribe/UnsubscribeFromAllSection";
 import ManageNotificationsSection from "@/components/unsubscribe/ManageNotificationsSection";
 import type { EmailPreferences } from "@/lib/api/emailPreferences";
+import { buildEmailPreferences } from "@/lib/notifications/config";
 import styles from "@/components/unsubscribe/UnsubscribePage.module.css";
 
 type ActionState = "idle" | "loading" | "success" | "error";
 
 export default function UnsubscribeDevPage() {
   const [preferences, setPreferences] = useState<EmailPreferences>({
-    newsletters: true,
-    event_emails: true,
-    milestone_emails: false,
-    activity_emails: true
+    ...buildEmailPreferences(true),
+    milestone_emails: false
   });
   const [emailKeyState, setEmailKeyState] = useState<ActionState>("idle");
   const [allState, setAllState] = useState<ActionState>("idle");
@@ -54,27 +53,13 @@ export default function UnsubscribeDevPage() {
             </button>
             <button
               className="ui-btn ui-btn-small ui-btn-secondary"
-              onClick={() =>
-                setPreferences({
-                  newsletters: true,
-                  event_emails: true,
-                  milestone_emails: true,
-                  activity_emails: true
-                })
-              }
+              onClick={() => setPreferences(buildEmailPreferences(true))}
             >
               Subscribe All
             </button>
             <button
               className="ui-btn ui-btn-small ui-btn-secondary"
-              onClick={() =>
-                setPreferences({
-                  newsletters: false,
-                  event_emails: false,
-                  milestone_emails: false,
-                  activity_emails: false
-                })
-              }
+              onClick={() => setPreferences(buildEmailPreferences(false))}
             >
               Unsubscribe All
             </button>
@@ -119,12 +104,7 @@ export default function UnsubscribeDevPage() {
                   error={allState === "error"}
                   onUnsubscribe={() => {
                     simulateAction(setAllState, () => {
-                      setPreferences({
-                        newsletters: false,
-                        event_emails: false,
-                        milestone_emails: false,
-                        activity_emails: false
-                      });
+                      setPreferences(buildEmailPreferences(false));
                     });
                   }}
                 />

--- a/app/components/settings/tabs/NotificationsTab.tsx
+++ b/app/components/settings/tabs/NotificationsTab.tsx
@@ -3,13 +3,13 @@
 import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { useSettingsStore } from "@/lib/settings/settingsStore";
-import type { NotificationSlug } from "@/lib/api/types/settings";
+import { NOTIFICATION_TYPES, notificationField, type NotificationSlug } from "@/lib/notifications/config";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import ActionField from "../ui/ActionField";
 import styles from "../Settings.module.css";
 
 interface NotificationSetting {
-  id: "essential" | "features" | "livestreams" | "milestones" | "activity";
+  id: string;
   titleKey: string;
   descriptionKey: string;
   apiSlug?: NotificationSlug;
@@ -23,30 +23,12 @@ const NOTIFICATION_CONFIGS: NotificationSetting[] = [
     descriptionKey: "essentialDescription",
     disabled: true // Cannot be toggled off
   },
-  {
-    id: "features",
-    titleKey: "featuresTitle",
-    descriptionKey: "featuresDescription",
-    apiSlug: "newsletters"
-  },
-  {
-    id: "livestreams",
-    titleKey: "livestreamsTitle",
-    descriptionKey: "livestreamsDescription",
-    apiSlug: "event_emails"
-  },
-  {
-    id: "milestones",
-    titleKey: "milestonesTitle",
-    descriptionKey: "milestonesDescription",
-    apiSlug: "milestone_emails"
-  },
-  {
-    id: "activity",
-    titleKey: "activityTitle",
-    descriptionKey: "activityDescription",
-    apiSlug: "activity_emails"
-  }
+  ...NOTIFICATION_TYPES.map((type) => ({
+    id: type.settingsI18nId,
+    titleKey: `${type.settingsI18nId}Title`,
+    descriptionKey: `${type.settingsI18nId}Description`,
+    apiSlug: type.slug
+  }))
 ];
 
 export default function NotificationsTab() {
@@ -64,16 +46,7 @@ export default function NotificationsTab() {
       return;
     }
 
-    // Get current value from settings
-    const fieldMap: Record<NotificationSlug, keyof typeof settings> = {
-      newsletters: "receive_newsletters",
-      event_emails: "receive_event_emails",
-      milestone_emails: "receive_milestone_emails",
-      activity_emails: "receive_activity_emails"
-    };
-
-    const field = fieldMap[notification.apiSlug];
-    const currentValue = settings[field] as boolean;
+    const currentValue = settings[notificationField(notification.apiSlug)];
 
     // Toggle the value
     await updateNotification({
@@ -96,15 +69,7 @@ export default function NotificationsTab() {
       return false;
     }
 
-    const fieldMap: Record<NotificationSlug, keyof typeof settings> = {
-      newsletters: "receive_newsletters",
-      event_emails: "receive_event_emails",
-      milestone_emails: "receive_milestone_emails",
-      activity_emails: "receive_activity_emails"
-    };
-
-    const field = fieldMap[notification.apiSlug];
-    return settings[field] as boolean;
+    return settings[notificationField(notification.apiSlug)];
   };
 
   if (loading || !settings) {

--- a/app/components/unsubscribe/ManageNotificationsSection.tsx
+++ b/app/components/unsubscribe/ManageNotificationsSection.tsx
@@ -2,32 +2,16 @@
 
 import { useEffect, useState } from "react";
 import type { EmailPreferences } from "@/lib/api/emailPreferences";
+import { NOTIFICATION_TYPES } from "@/lib/notifications/config";
 import NotificationItem, { type NotificationConfig } from "./NotificationItem";
 import CheckCircleIcon from "@/icons/check-circle.svg";
 import styles from "./UnsubscribePage.module.css";
 
-const NOTIFICATION_CONFIGS: NotificationConfig[] = [
-  {
-    id: "newsletters",
-    title: "Product Updates",
-    description: "Stay informed about new features and improvements."
-  },
-  {
-    id: "event_emails",
-    title: "Event Notifications",
-    description: "Get notified about upcoming livestreams and events."
-  },
-  {
-    id: "milestone_emails",
-    title: "Achievement Notifications",
-    description: "Receive notifications when you unlock new skills or achievements."
-  },
-  {
-    id: "activity_emails",
-    title: "Activity Emails",
-    description: "Activity-based notifications like unlocking badges and completing challenges."
-  }
-];
+const NOTIFICATION_CONFIGS: NotificationConfig[] = NOTIFICATION_TYPES.map((type) => ({
+  id: type.slug,
+  title: type.title,
+  description: type.description
+}));
 
 interface ManageNotificationsSectionProps {
   preferences: EmailPreferences;

--- a/app/components/unsubscribe/utils.ts
+++ b/app/components/unsubscribe/utils.ts
@@ -1,9 +1,5 @@
+import { NOTIFICATION_TYPES } from "@/lib/notifications/config";
+
 export function formatKeyName(key: string): string {
-  const names: Record<string, string> = {
-    newsletters: "product updates",
-    event_emails: "event notifications",
-    milestone_emails: "achievement notifications",
-    activity_emails: "activity emails"
-  };
-  return names[key] || "these";
+  return NOTIFICATION_TYPES.find((type) => type.slug === key)?.shortLabel ?? "these";
 }

--- a/app/lib/api/emailPreferences.ts
+++ b/app/lib/api/emailPreferences.ts
@@ -6,13 +6,9 @@
  */
 
 import { api } from "./client";
+import type { EmailPreferences } from "@/lib/notifications/config";
 
-export interface EmailPreferences {
-  newsletters: boolean;
-  event_emails: boolean;
-  milestone_emails: boolean;
-  activity_emails: boolean;
-}
+export type { EmailPreferences };
 
 interface EmailPreferencesResponse {
   email_preferences: EmailPreferences;

--- a/app/lib/api/types/settings.ts
+++ b/app/lib/api/types/settings.ts
@@ -3,19 +3,19 @@
  * Type definitions for user settings and related operations
  */
 
-export interface UserSettings {
+import type { NotificationField, NotificationSlug } from "@/lib/notifications/config";
+
+export type { NotificationSlug };
+
+export type UserSettings = {
   name: string;
   handle: string;
   email: string;
   unconfirmed_email: string | null;
   email_confirmed: boolean;
   locale: string;
-  receive_newsletters: boolean;
-  receive_event_emails: boolean;
-  receive_milestone_emails: boolean;
-  receive_activity_emails: boolean;
   streaks_enabled: boolean;
-}
+} & Record<NotificationField, boolean>;
 
 export interface SettingsResponse {
   settings: UserSettings;
@@ -28,8 +28,6 @@ export interface SettingsError {
     errors?: Record<string, string[]>;
   };
 }
-
-export type NotificationSlug = "newsletters" | "event_emails" | "milestone_emails" | "activity_emails";
 
 export type SettingField = "name" | "email" | "password" | "locale" | "handle";
 

--- a/app/lib/notifications/config.ts
+++ b/app/lib/notifications/config.ts
@@ -1,0 +1,79 @@
+/**
+ * Email notification preferences — single source of truth.
+ *
+ * Every preference is identified by its API slug. The two APIs name the same
+ * preference differently:
+ *   - `/internal/settings` stores it as `receive_<slug>` (see `notificationField`)
+ *   - `/external/email_preferences/:token` returns it as `<slug>`
+ *
+ * Adding a new preference type is a single entry in `NOTIFICATION_TYPES` (plus
+ * the settings copy under `settings.notifications` in the message catalogues).
+ */
+
+export interface NotificationType {
+  /** API slug, e.g. "newsletters". */
+  slug: string;
+  /** Key used to build the settings-tab i18n keys (`<id>Title` / `<id>Description`). */
+  settingsI18nId: string;
+  /** Title shown on the external (logged-out) unsubscribe page. */
+  title: string;
+  /** Description shown on the external unsubscribe page. */
+  description: string;
+  /** Human label used in the one-click unsubscribe confirmation copy. */
+  shortLabel: string;
+}
+
+export const NOTIFICATION_TYPES = [
+  {
+    slug: "newsletters",
+    settingsI18nId: "features",
+    title: "Product Updates",
+    description: "Stay informed about new features and improvements.",
+    shortLabel: "product updates"
+  },
+  {
+    slug: "event_emails",
+    settingsI18nId: "livestreams",
+    title: "Event Notifications",
+    description: "Get notified about upcoming livestreams and events.",
+    shortLabel: "event notifications"
+  },
+  {
+    slug: "milestone_emails",
+    settingsI18nId: "milestones",
+    title: "Achievement Notifications",
+    description: "Receive notifications when you unlock new skills or achievements.",
+    shortLabel: "achievement notifications"
+  },
+  {
+    slug: "activity_emails",
+    settingsI18nId: "activity",
+    title: "Activity Emails",
+    description: "Activity-based notifications like unlocking badges and completing challenges.",
+    shortLabel: "activity emails"
+  },
+  {
+    slug: "onboarding_emails",
+    settingsI18nId: "onboarding",
+    title: "Getting-Started Emails",
+    description: "Tips and guidance on how to get the most from Jiki.",
+    shortLabel: "getting-started emails"
+  }
+] as const satisfies readonly NotificationType[];
+
+export type NotificationSlug = (typeof NOTIFICATION_TYPES)[number]["slug"];
+
+/** The corresponding `/internal/settings` field, e.g. "receive_newsletters". */
+export type NotificationField = `receive_${NotificationSlug}`;
+
+export function notificationField(slug: NotificationSlug): NotificationField {
+  return `receive_${slug}`;
+}
+
+/** Email preferences as returned by the external email-preferences API. */
+export type EmailPreferences = Record<NotificationSlug, boolean>;
+
+/** Build a preferences object with every type set to `value` (used in dev/tests). */
+export function buildEmailPreferences(value: boolean): EmailPreferences {
+  return Object.fromEntries(NOTIFICATION_TYPES.map((type) => [type.slug, value])) as EmailPreferences;
+}

--- a/app/lib/settings/settingsStore.ts
+++ b/app/lib/settings/settingsStore.ts
@@ -8,12 +8,8 @@
 import { create } from "zustand";
 import { settingsApi } from "@/lib/api/settings";
 import { setLocaleCookie } from "@/lib/i18n/localeCookie";
-import type {
-  UserSettings,
-  UpdateSettingParams,
-  UpdateNotificationParams,
-  NotificationSlug
-} from "@/lib/api/types/settings";
+import type { UserSettings, UpdateSettingParams, UpdateNotificationParams } from "@/lib/api/types/settings";
+import { notificationField } from "@/lib/notifications/config";
 import toast from "react-hot-toast";
 
 interface SettingsState {
@@ -142,15 +138,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       return;
     }
 
-    // Map slug to field name for optimistic update
-    const fieldMap: Record<NotificationSlug, keyof UserSettings> = {
-      newsletters: "receive_newsletters",
-      event_emails: "receive_event_emails",
-      milestone_emails: "receive_milestone_emails",
-      activity_emails: "receive_activity_emails"
-    };
-
-    const field = fieldMap[slug];
+    const field = notificationField(slug);
 
     // Optimistic update
     const optimisticSettings = {

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -480,7 +480,9 @@
       "milestonesTitle": "Emails when you reach new milestones",
       "milestonesDescription": "Celebrate your achievements and progress on Jiki.",
       "activityTitle": "Other emails in response to things that you do on Jiki",
-      "activityDescription": "Activity-based notifications like unlocking badges and completing challenges."
+      "activityDescription": "Activity-based notifications like unlocking badges and completing challenges.",
+      "onboardingTitle": "Emails to help you get the most from Jiki",
+      "onboardingDescription": "Tips and guidance on how to get the most from Jiki."
     },
     "editableField": {
       "update": "Update",

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -480,7 +480,9 @@
       "milestonesTitle": "Emails when you reach new milestones",
       "milestonesDescription": "Celebrate your achievements and progress on Jiki.",
       "activityTitle": "Other emails in response to things that you do on Jiki",
-      "activityDescription": "Activity-based notifications like unlocking badges and completing challenges."
+      "activityDescription": "Activity-based notifications like unlocking badges and completing challenges.",
+      "onboardingTitle": "Emails to help you get the most from Jiki",
+      "onboardingDescription": "Tips and guidance on how to get the most from Jiki."
     },
     "editableField": {
       "update": "Update",


### PR DESCRIPTION
## What

The API added a new `receive_onboarding_emails` user preference (exposed as `onboarding_emails` on the external email-preferences endpoint). This surfaces it in the two places users manage email preferences:

- **Settings → Notifications tab** (`receive_onboarding_emails`)
- **External unsubscribe page** (`onboarding_emails`)

The API already handles the new slug in `updateNotification`, `unsubscribe_all`, and `subscribe_all`, so no other client wiring was needed.

## How

Introduces `lib/notifications/config.ts` as the **single source of truth** for email-preference types. It holds one entry per preference (slug + settings i18n id + unsubscribe copy + short label) and derives:

- `NotificationSlug` and the `receive_<slug>` `NotificationField` type
- the `notificationField()` helper (replaces the slug→field maps)
- the `EmailPreferences` type and a `buildEmailPreferences()` test/dev helper

The settings tab and unsubscribe page now drive their UI from this registry, removing the **three duplicated slug-to-field maps** and the parallel copy arrays. Adding a future preference type is now a single registry entry (plus its settings copy in the message catalogues).

Onboarding copy:
- Settings: "Emails to help you get the most from Jiki"
- Unsubscribe: "Getting-Started Emails" / "Tips and guidance on how to get the most from Jiki."

## Testing

- `pnpm typecheck` clean
- Full app suite passes (1835 tests); settings + unsubscribe unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)