### PR TITLE
Quote strings in JS interpreter descriptions

### DIFF
--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -1,5 +1,13 @@
 # JavaScript Interpreter Evolution
 
+## 2026-07-05: Quote strings in descriptions via `toDisplayString()`
+
+A student reported that variable declaration descriptions showed string values unquoted, e.g. `let border_color = "black"` described as "set it to `black`" instead of "set it to `"black"`". The root cause was `JSString.toString()` returning the raw value, which describers inherited through `formatJSObject()`.
+
+JikiScript avoids this by baking `JSON.stringify` into its primitive `toString()`, but the JS interpreter cannot: unlike JikiScript, JS `toString()` is the value/coercion representation and is relied on by real program-behaviour paths that must stay unquoted (`console.log` output, `array.join`/`toString`/`sort`, object property keys). Conflating value and display into `toString()` would break those. The code already hinted at this by ad-hoc quoting `JSString` inside `JSArray.toString()`/`JSDictionary.toString()`.
+
+The fix introduces a dedicated display representation, `toDisplayString()`, as a concrete default on the shared `JikiObject` base (returns `this.toString()`), overridden only in `JSString` to return `JSON.stringify(this._value)`. The display bottlenecks `formatJSObject()` and `codeTag()` (both in `src/javascript/helpers.ts`) now call `toDisplayString()`, and the describers that bypassed those helpers by calling `.toString()` directly (return, array expression, member access, for-in key, for-of element) were switched to `.toDisplayString()`. Value paths were left untouched. Arrays/dicts inherit the default and keep their existing (already-quoting) `toString()` for display, so nested strings still render correctly. Python inherits the default no-op and is unaffected.
+
 ## 2026-06-27: No-arg `repeat()` raises MaxIterationsReached at the cap
 
 A no-argument `repeat() { ... }` is meant to run until the exercise signals completion (`_exerciseFinished`), bounded only by the infinite-loop guard. Previously `executeRepeatStatement` passed `maxTotalLoopIterations` as the loop's literal `count`, so `while (iteration < count)` stopped the loop at exactly the cap, one iteration before `guardInfiniteLoop` (which throws only when `totalLoopIterations > max`) could fire. The result: a never-finishing loop like `repeat() { turnLeft() }` ran exactly `max` times and then exited cleanly with `status: SUCCESS` and no error frame, so the student got no feedback that they were stuck in an unproductive loop. (Before the per-exercise caps landed, the default cap of 10,000 meant this silently generated 10,000 frames and froze the browser.)

--- a/interpreters/src/javascript/describers/describeArrayExpression.ts
+++ b/interpreters/src/javascript/describers/describeArrayExpression.ts
@@ -8,7 +8,7 @@ export function describeArrayExpression(expression: ArrayExpression, result: Eva
   if (count === 0) {
     return "Created an empty list";
   } else if (count === 1) {
-    return `Created a list with 1 element: ${jikiObject.toString()}`;
+    return `Created a list with 1 element: ${jikiObject.toDisplayString()}`;
   }
-  return `Created a list with ${count} elements: ${jikiObject.toString()}`;
+  return `Created a list with ${count} elements: ${jikiObject.toDisplayString()}`;
 }

--- a/interpreters/src/javascript/describers/describeForInStatement.ts
+++ b/interpreters/src/javascript/describers/describeForInStatement.ts
@@ -27,7 +27,7 @@ function describeFinalStep(result: EvaluationResultForInStatement, statement: Fo
     }
 
     if (result.currentKey) {
-      const keyValue = result.currentKey.toString();
+      const keyValue = result.currentKey.toDisplayString();
       return `<li>Set <code>${variableName}</code> to <code>${keyValue}</code> (iteration ${result.iteration}).</li>`;
     }
   }
@@ -45,7 +45,7 @@ function describeResult(result: EvaluationResultForInStatement, statement: ForIn
     }
 
     if (result.currentKey) {
-      const keyValue = result.currentKey.toString();
+      const keyValue = result.currentKey.toDisplayString();
       return `<p>Set <code>${variableName}</code> to <code>${keyValue}</code> for iteration ${result.iteration}.</p>`;
     }
   }

--- a/interpreters/src/javascript/describers/describeForOfStatement.ts
+++ b/interpreters/src/javascript/describers/describeForOfStatement.ts
@@ -28,7 +28,7 @@ function describeFinalStep(result: EvaluationResultForOfStatement, statement: Fo
     }
 
     if (result.currentElement) {
-      const elementValue = result.currentElement.toString();
+      const elementValue = result.currentElement.toDisplayString();
       return `<li>Set <code>${variableName}</code> to <code>${elementValue}</code> (iteration ${result.iteration}).</li>`;
     }
   }
@@ -47,7 +47,7 @@ function describeResult(result: EvaluationResultForOfStatement, statement: ForOf
     }
 
     if (result.currentElement) {
-      const elementValue = result.currentElement.toString();
+      const elementValue = result.currentElement.toDisplayString();
       return `<p>Set <code>${variableName}</code> to <code>${elementValue}</code> for iteration ${result.iteration}.</p>`;
     }
   }

--- a/interpreters/src/javascript/describers/describeMemberExpression.ts
+++ b/interpreters/src/javascript/describers/describeMemberExpression.ts
@@ -10,8 +10,8 @@ export function describeMemberExpression(
   const indexValue = result.property.immutableJikiObject;
 
   if (objectValue.type === "string") {
-    return `Accessed character at index ${indexValue.toString()} of the string, got ${jikiObject.toString()}`;
+    return `Accessed character at index ${indexValue.toString()} of the string, got ${jikiObject.toDisplayString()}`;
   }
 
-  return `Accessed element at index ${indexValue.toString()} of the list, got ${jikiObject.toString()}`;
+  return `Accessed element at index ${indexValue.toString()} of the list, got ${jikiObject.toDisplayString()}`;
 }

--- a/interpreters/src/javascript/describers/describeReturnStatement.ts
+++ b/interpreters/src/javascript/describers/describeReturnStatement.ts
@@ -16,7 +16,7 @@ export function describeReturnStatement(frame: FrameWithResult, _context: Descri
     };
   }
 
-  const value = result.jikiObject.toString();
+  const value = result.jikiObject.toDisplayString();
   return {
     result: `<p>Jiki returned the value <code>${value}</code> from the function.</p>`,
     steps: [

--- a/interpreters/src/javascript/helpers.ts
+++ b/interpreters/src/javascript/helpers.ts
@@ -8,7 +8,7 @@ export function formatJSObject(value?: any): string {
   }
 
   if (value instanceof JikiObject) {
-    return value.toString();
+    return value.toDisplayString();
   }
 
   return JSON.stringify(value);
@@ -17,7 +17,7 @@ export function formatJSObject(value?: any): string {
 export function codeTag(code: string | JikiObject, location: Location): string {
   let parsedCode: string;
   if (code instanceof JikiObject) {
-    parsedCode = code.toString();
+    parsedCode = code.toDisplayString();
   } else {
     parsedCode = code;
   }

--- a/interpreters/src/javascript/jsObjects/JSString.ts
+++ b/interpreters/src/javascript/jsObjects/JSString.ts
@@ -13,6 +13,10 @@ export class JSString extends JikiObject {
     return this._value;
   }
 
+  public toDisplayString(): string {
+    return JSON.stringify(this._value);
+  }
+
   public clone(): JSString {
     // Strings are immutable, so return self
     return this;

--- a/interpreters/src/shared/jikiObject.ts
+++ b/interpreters/src/shared/jikiObject.ts
@@ -7,4 +7,12 @@ export abstract class JikiObject {
   public abstract toString(): string;
   public abstract get value(): any;
   public abstract clone(): JikiObject;
+
+  // Display representation used in educational descriptions ("What happened").
+  // Defaults to toString(); override where the display form differs from the
+  // value/coercion form (e.g. strings are quoted for display but not when
+  // coerced to an actual program value).
+  public toDisplayString(): string {
+    return this.toString();
+  }
 }

--- a/interpreters/tests/javascript/describers.test.ts
+++ b/interpreters/tests/javascript/describers.test.ts
@@ -37,6 +37,21 @@ describe("describers", () => {
       expect(description).toContain("hello world");
     });
 
+    test("string variable declaration quotes the assigned value", () => {
+      // Regression: a string initializer should be shown quoted in the
+      // description, e.g. `set it to "black"`, not `set it to black`.
+      const code = 'let border_color = "black";';
+      const result = interpret(code);
+
+      expect(result.success).toBe(true);
+
+      const frame = result.frames[0];
+      const description = describeFrame(frame);
+
+      expect(description).toContain('set it to <code>"black"</code>');
+      expect(description).toContain('assigned it the value <code>"black"</code>');
+    });
+
     test("boolean expression", () => {
       const code = "true && false;";
       const result = interpret(code);

--- a/interpreters/tests/javascript/string-indexing.test.ts
+++ b/interpreters/tests/javascript/string-indexing.test.ts
@@ -208,7 +208,7 @@ describe("JavaScript String Indexing", () => {
 
       const frame = result.frames[1] as TestFrame;
       expect(frame.description).toContain("Accessed character at index 0");
-      expect(frame.description).toContain("got h");
+      expect(frame.description).toContain('got "h"');
     });
 
     test("description does not say list", () => {


### PR DESCRIPTION
## Problem

A student (Isaac) reported that in the JavaScript interpreter's "What happened" panel, `let border_color = "black"` was described as *"Declared variable `border_color` and set it to `black`"* — the string value shown **unquoted**. It should read `"black"`.

## Root cause

`JSString.toString()` returns the raw value. Describers format values through `formatJSObject()` → `value.toString()`, so they inherit the unquoted string.

JikiScript avoids this by baking `JSON.stringify` into its primitive `toString()`, but the JS interpreter **can't**: unlike JikiScript, JS `toString()` is the *value/coercion* representation and is relied on by real program-behaviour paths that must stay unquoted — `console.log` output, `array.join`/`toString`/`sort`, and object property keys. (The codebase already hinted at the value-vs-display split by ad-hoc quoting `JSString` inside `JSArray.toString()`/`JSDictionary.toString()`.)

## Fix

Introduce a dedicated **display** representation, `toDisplayString()`:

- Concrete default on the shared `JikiObject` base (returns `this.toString()`), so all JS objects and Python inherit it for free.
- Overridden only in `JSString` to return `JSON.stringify(value)`.
- The display bottlenecks `formatJSObject()` and `codeTag()` (in `src/javascript/helpers.ts`) now route through it.
- The five describers that bypassed those helpers with direct `.toString()` calls (return, array expression, member access, for-in key, for-of element) switched to `.toDisplayString()`.

`describeCallExpression`'s actual-printed-output line and all value paths (`console/log`, `array/{join,toString,sort}`, property keys) are deliberately left calling `.toString()`.

## Tests

- Added a regression test reproducing the exact reported bug (`let border_color = "black"` → description contains `"black"`).
- Updated the string-indexing assertion (`got "h"`).
- Value-path suites (`console`, `array-methods-cross-validation`) confirm coercion output stays unquoted.

Full interpreter suite (3505 tests), typecheck, lint, and curriculum suite (674 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)