### PR TITLE
Check checkerboard piece sizes and tidy instruction colours

### DIFF
--- a/curriculum/src/exercises/checkerboard/instructions/en.md
+++ b/curriculum/src/exercises/checkerboard/instructions/en.md
@@ -26,8 +26,8 @@ As normal, the canvas is always `100` wide and `100` tall. Follow these two rule
 - The pieces are ridged circles, with an outer border and an inner color:
   - The full piece is 80% as wide as the square.
   - The inner circle is 75% as wide as the full piece.
-- The rows at the **top** of the board get **"charcoal"** pieces (each with a **"black"** rim).
-- The rows at the **bottom** get **white** pieces (each with a **grey** rim).
+- The rows at the **top** of the board get `"charcoal"` pieces (each with a `"black"` rim).
+- The rows at the **bottom** get `"white"` pieces (each with a `"grey"` rim).
 - Pieces only ever sit on the **dark** squares.
 - The **middle two rows** are always left empty. All the other rows have pieces on.
 

--- a/curriculum/src/exercises/checkerboard/metadata.json
+++ b/curriculum/src/exercises/checkerboard/metadata.json
@@ -21,6 +21,10 @@
     {
       "question": "How do I draw a ridged piece?",
       "answer": "Draw two circles at the same centre: a larger one for the rim, then a slightly smaller one on top in the piece's colour. Base both radii on the cell size so the pieces scale with the board."
+    },
+    {
+      "question": "The size of the rim doesn't look like the sample diagram.",
+      "answer": "Check that the inner circle is 75% of the outer circle (not 75% of the square)."
     }
   ]
 }

--- a/curriculum/src/exercises/checkerboard/scenarios.ts
+++ b/curriculum/src/exercises/checkerboard/scenarios.ts
@@ -39,6 +39,12 @@ function boardExpectations(ex: CheckerboardExercise, n: number) {
   const cy = (row: number) => round5(margin + row * cell + mid);
   const c = round5(cell);
 
+  // Expected piece radii: the full piece is 80% as wide as the square (rim radius = 40% of
+  // the cell) and the inner face is 75% as wide as the full piece (inner radius = 30% of the
+  // cell). These scale with the board, so we round them the same way as every other value.
+  const rimRadius = round5(cell * 0.4);
+  const innerRadius = round5(cell * 0.3);
+
   // A dark square in one of the (empty) middle rows - the column that is dark there
   // depends on whether the middle row index is odd or even.
   const midRow = n / 2;
@@ -98,6 +104,26 @@ function boardExpectations(ex: CheckerboardExercise, n: number) {
     {
       pass: ex.hasCircleCenteredAtWithColor(cx(0), cy(last), "grey"),
       errorHtml: "The pieces in the bottom rows should have a rim around them."
+    },
+
+    // The pieces must be sized relationally: the rim (outer circle) is 40% of the cell and the
+    // inner face is 30% of the cell (75% of the piece). Check one piece of each colour - the
+    // sizing is uniform, so a single sample per colour catches a wrong ratio.
+    {
+      pass: ex.hasCircleAtWithColor(cx(1), cy(0), rimRadius, "black"),
+      errorHtml: "The rim of a piece should be 80% as wide as its square - check the outer circle's radius."
+    },
+    {
+      pass: ex.hasCircleAtWithColor(cx(1), cy(0), innerRadius, "charcoal"),
+      errorHtml: "The centre of a piece should be 75% as wide as the whole piece - check the inner circle's radius."
+    },
+    {
+      pass: ex.hasCircleAtWithColor(cx(0), cy(last), rimRadius, "grey"),
+      errorHtml: "The rim of a piece should be 80% as wide as its square - check the outer circle's radius."
+    },
+    {
+      pass: ex.hasCircleAtWithColor(cx(0), cy(last), innerRadius, "white"),
+      errorHtml: "The centre of a piece should be 75% as wide as the whole piece - check the inner circle's radius."
     },
 
     // Pieces only go on dark squares, and the middle rows stay empty.


### PR DESCRIPTION
## What & why

Three small fixes to the **checkerboard** exercise, all stemming from noticing the piece rim in the sample diagrams didn't line up with what the checks enforced.

### 1. Check the circle sizes (the real fix)
The scenarios only matched pieces by **centre + colour** (`hasCircleCenteredAt*`), never by radius — so a student drawing the rim at the wrong ratio (e.g. inner circle 75% of the *square* instead of 75% of the *piece*) passed silently.

Added exact-radius checks for both the rim (40% of the cell) and the inner face (30% of the cell), on a sample piece of each colour, with size-specific error messages. Expected radii are rounded to 5dp like every other value in the file.

### 2. Instruction colours
In "The pieces" the colours were bold and `white`/`grey` were unquoted, unlike "The Board" where colours are inline-code with quotes. Made them consistent: `` `"charcoal"` ``, `` `"black"` ``, `` `"white"` ``, `` `"grey"` ``.

### 3. Hint
Added a hint for the exact confusion above: "The size of the rim doesn't look like the sample diagram." → "Check that the inner circle is 75% of the outer circle (not 75% of the square)."

## Testing
- `all-exercises` solution validation passes (JS solution satisfies the new size checks)
- `checkerboard-border-routes` test passes
- Full curriculum suite: 674 passed
- Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)