### PR TITLE
Filter Outlook SafeLinks crawler noise from Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -10,6 +10,13 @@ if (process.env.NODE_ENV === "production") {
     tracesSampleRate: 0.1,
     enableLogs: true,
     sendDefaultPii: true,
+    ignoreErrors: [
+      // Microsoft Outlook SafeLinks / email-scanner crawlers inject a script that fires a
+      // non-Error promise rejection with this value. It has no stack trace and is not a real
+      // error, so it slips past the frame-based beforeSend filter below.
+      // https://github.com/getsentry/sentry-javascript/issues/3440
+      "Object Not Found Matching Id"
+    ],
     beforeSend(event) {
       // Drop aborted-request errors - these happen when the user navigates away
       // while a fetch is still in flight, which is expected, not a bug.


### PR DESCRIPTION
Closes #646

## Summary
- The Sentry error `Non-Error promise rejection captured with value: Object Not Found Matching Id:N, MethodName:update, ParamCount:N` is a well-known false positive. It's injected by Microsoft Outlook SafeLinks / email-scanner crawlers when they render our pages, not by real users.
- Because it's a *non-Error* promise rejection it has no stack trace, so it slipped past the existing frame-based `beforeSend` filter (which returns the event when there are no frames).
- Added `"Object Not Found Matching Id"` to `ignoreErrors` in the client Sentry init (`instrumentation-client.ts`). Substring match covers all `Id:N` / `ParamCount:N` variants, and `ignoreErrors` is evaluated before `beforeSend`.
- Client-only change; the edge config never sees this browser crawler artifact.

## Test plan
- [x] `pnpm typecheck` (monorepo root) passes
- [x] `pnpm run lint` — no new errors (only pre-existing warnings in unrelated files)
- [x] `pnpm test` — 1835 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)