### PR TITLE
Fix /fix skill choking on prose after the issue URL

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -13,10 +13,10 @@ You are fixing a GitHub issue for the jiki-education/front-end repository.
 ## Issue details
 
 ```json
-!`gh issue view $ARGUMENTS --json number,title,body,labels,comments`
+!`gh issue view "$(echo "$ARGUMENTS" | grep -oE 'issues/[0-9]+|[0-9]+' | grep -oE '[0-9]+' | head -1)" --json number,title,body,labels,comments`
 ```
 
-Issue number: !`echo "$ARGUMENTS" | grep -oE '[0-9]+$'`
+Issue number: !`echo "$ARGUMENTS" | grep -oE 'issues/[0-9]+|[0-9]+' | grep -oE '[0-9]+' | head -1`
 
 ## Critical: Two phase.
 


### PR DESCRIPTION
## Summary
- The `/fix` skill passed the whole `$ARGUMENTS` string straight to `gh issue view`. Any text appended after the issue number/URL was interpreted as extra positional args, so `/fix https://github.com/jiki-education/front-end/issues/646 - I believe this is an issue in outlook or something.` failed with `accepts 1 arg(s), received 12`.
- Now extract just the issue number (from an `issues/NNN` URL or a bare number) before calling `gh`, and reuse the same extractor for the displayed issue number (the old `[0-9]+$` only matched a number at the very end of the string).

## Test plan
- [x] `646` → `646`
- [x] `https://github.com/jiki-education/front-end/issues/646` → `646`
- [x] `https://github.com/jiki-education/front-end/issues/646 - I believe this is an issue in outlook or something.` → `646`
- [x] `fix 646 please` → `646`

🤖 Generated with [Claude Code](https://claude.com/claude-code)