### PR TITLE
Fix immutable Cache-Control being capped at 1 day by the /static/* catch-all

### DIFF
--- a/app/public/_headers
+++ b/app/public/_headers
@@ -1,20 +1,34 @@
+# Cloudflare Workers Static Assets COMBINES the headers of every matching rule
+# below (duplicate header values are comma-joined) — there is no "most specific
+# wins". Each content-hashed path here also matches the /static/* catch-all at the
+# bottom, so without intervention it would get
+#   Cache-Control: public, max-age=86400, public, max-age=31536000, immutable
+# and browsers honour the FIRST max-age (86400 → 1 day), defeating the immutable
+# intent. So each immutable rule first drops the inherited value with
+# `! Cache-Control`, then sets its own. (/_next/static/* needs no `!` — nothing
+# else matches it.)
+
 /_next/static/*
   Cache-Control: public, max-age=31536000, immutable
 
 /static/content/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable
 
 # Concept + exercise caches: every file is content-hashed (index JSON, per-slug
 # HTML/JSON, and concept icons under concepts/icons/), so the whole prefix is
 # safe to serve immutably.
 /static/concepts/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable
 
 /static/exercises/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable
 
 # Lesson/badge/project icons copied to content-hashed filenames by generate-icon-cache.js.
 /static/icons-hashed/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable
 
 # Landing-page media (videos + background svgs) carries a content hash in its
@@ -23,6 +37,7 @@
 # get captured by the SVGR rule), so the hash is applied by hand — bump the hash
 # in the filename to bust the cache when the file changes.
 /static/images/landing-page/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable
 
 /static/*


### PR DESCRIPTION
## Problem

After #793 deployed, every content-hashed asset came back with a **doubled** `Cache-Control`:

```
cache-control: public, max-age=86400, public, max-age=31536000, immutable
```

Cloudflare Workers Static Assets **combines the headers of every matching `_headers` rule** (duplicate values are comma-joined) — there is **no "most-specific-wins"** ([docs](https://developers.cloudflare.com/workers/static-assets/headers/)). Every immutable prefix also matches the `/static/*` catch-all, so both rules' `Cache-Control` were concatenated. Per [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html), a cache uses the **first** `max-age` (or treats the response as stale) — so the effective TTL was **1 day, not 1 year**, defeating the immutable intent. (This also silently affected the pre-existing `/static/content/*`.)

## Fix

Prepend `! Cache-Control` to each immutable rule. The `!` operator drops a header inherited from a broader rule, so the catch-all's `max-age=86400` is removed before the immutable value is set — leaving a single clean `Cache-Control: public, max-age=31536000, immutable`.

Applied to the five content-hashed prefixes: `/static/content/*`, `/static/concepts/*`, `/static/exercises/*`, `/static/icons-hashed/*`, `/static/images/landing-page/*`. `/_next/static/*` is untouched (nothing else matches it), and the `/static/*` catch-all still covers every non-fingerprinted asset — **no coverage risk**.

Verified before applying: all files under each of these prefixes are content-hashed (60 content, 86 concepts, 310 exercises, 151 icons, 12 landing) — so `immutable` is safe.

## Verification note

`_headers` is deploy-time Cloudflare config and can't be verified by the local dev server (local `wrangler` also wouldn't surface a discrepancy). **After merge+deploy, curl a hashed asset and confirm the header is now a single `max-age=31536000, immutable`.** The one historical concern about the `!` operator ([workers-sdk #2776](https://github.com/cloudflare/workers-sdk/issues/2776)) was a **Cloudflare Pages** bug, **closed as completed in 2023** and reported resolved — not applicable to Workers Static Assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)