### PR TITLE
Fix misleading hints in Space Invaders: Repeat

### DIFF
--- a/curriculum/src/exercises/space-invaders-repeat/metadata.json
+++ b/curriculum/src/exercises/space-invaders-repeat/metadata.json
@@ -8,7 +8,7 @@
     },
     {
       "question": "What's the repeating pattern in the alien positions?",
-      "answer": "The aliens are in every other column, so the pattern is: `shoot`, `move`, `move`. That three-step group is what you want to repeat."
+      "answer": "Your laser cannon starts to the left of the aliens, and they sit in every other column with three aliens stacked in each. So the pattern for each column is: `move`, `move`, `shoot`, `shoot`, `shoot`. You move across the empty gap onto the alien column, then shoot down all three rows. That five-step group is what you want to repeat."
     },
     {
       "question": "How many times should I repeat the pattern?",
@@ -16,7 +16,7 @@
     },
     {
       "question": "Why does the target ask for only 7 lines?",
-      "answer": "One line for the `repeat` header, the repeating actions inside, the closing brace, and one or two actions outside is plenty. If you're writing more, you're probably not using the loop yet."
+      "answer": "One line for the `repeat` header, the five repeating actions inside, and one line for the closing brace makes seven. Everything you need fits inside the loop, with nothing outside it. If you're writing more, you're probably not using the loop yet."
     }
   ]
 }


### PR DESCRIPTION
## Problem

Forum report from Phil: two hints in the Space Invaders: Repeat exercise are misleading/wrong.

**Hint 2** ("What's the repeating pattern in the alien positions?") gave the pattern as `shoot, move, move`. That is incorrect:

- The laser cannon starts to the *left* of the aliens, at an empty column, so it must `move` before it can `shoot`.
- Each alien column has **three** stacked aliens (3 rows), so it needs three `shoot()` calls per column, not one.
- Following the hint literally shoots at the empty starting column, which triggers "you missed, wasting ammo" and loses the game, and the final iteration walks the cannon off the right edge.

The actual canonical solution is `move, move, shoot, shoot, shoot` repeated 5 times.

**Hint 4** ("Why does the target ask for only 7 lines?") implied that "one or two actions outside" the loop are expected. There is no valid solution with actions outside the loop. The 7-line solution is entirely inside the `repeat` block (header + 5 body lines + closing brace).

## Fix

Rewrote both hints to match the real mechanics and the canonical solution. No code, solution, or line-limit changes were needed. The `llm-metadata.ts` already described the correct pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)