### PR TITLE
Clarify gold-panning can be solved in 5 lines or less

### DIFF
--- a/curriculum/src/exercises/gold-panning/instructions/en.md
+++ b/curriculum/src/exercises/gold-panning/instructions/en.md
@@ -11,4 +11,4 @@ You have a `pan()` function that returns the amount of nuggets you find each tim
 
 Your robot follows the same pattern each time. It heads to the river, pans **5 times** and then sells the total number of nuggets it finds in these 5 pans at the end.
 
-Solve the puzzle in **5 lines of code!**
+Solve the puzzle in **5 lines of code** (or less)!


### PR DESCRIPTION
Updates the gold-panning exercise instructions to say the puzzle can be solved in **5 lines of code (or less)!** rather than exactly 5 lines, so students aren't misled into thinking a 5-line solution is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)