### PR TITLE
Add missing conceptSlugs to relational drawing exercises

### DIFF
--- a/curriculum/src/exercises/relational-snowman/index.ts
+++ b/curriculum/src/exercises/relational-snowman/index.ts
@@ -20,6 +20,7 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
+  conceptSlugs: ["variables", "arithmetic", "using-functions-with-inputs"],
   readonlyRanges: {
     javascript: [
       { fromLine: 1, toLine: 2, toChar: 11 },

--- a/curriculum/src/exercises/relational-sun/index.ts
+++ b/curriculum/src/exercises/relational-sun/index.ts
@@ -20,6 +20,7 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
+  conceptSlugs: ["variables", "arithmetic", "using-functions-with-inputs"],
   readonlyRanges: {
     javascript: [
       { fromLine: 1, toLine: 6 },

--- a/curriculum/src/exercises/relational-traffic-lights/index.ts
+++ b/curriculum/src/exercises/relational-traffic-lights/index.ts
@@ -27,6 +27,7 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
+  conceptSlugs: ["variables", "arithmetic", "using-functions-with-inputs"],
   readonlyRanges: {
     javascript: [
       { fromLine: 1, toLine: 5 },


### PR DESCRIPTION
## Summary

Reported on the forum by Phil: Relational Sun, Relational Snowman, and Relational Traffic Lights had no related concepts.

Root cause: all three exercises were missing the `conceptSlugs` array in their `index.ts`, so they mapped to no concepts at build time.

## Fix

Added `conceptSlugs: ["variables", "arithmetic", "using-functions-with-inputs"]` to each of the three exercises. These are fundamentally variable + arithmetic exercises (all at `levelId: variables`) that derive drawing dimensions via arithmetic and pass them into draw calls — matching the placement and values already used by the sibling `structured-house` exercise. This is broader than the forum suggestion of just Arithmetic, reflecting what the exercises actually teach.

## Notes

An audit surfaced two secondary, Python/Jikiscript-only inconsistencies (no launch impact, left for later): snowman's `size` default differs between the JS and Py/Jiki solutions, and traffic-lights' Py/Jiki assets use a divergent `center_x = radius * 5` model vs. the JS-canonical fixed `center = 50`.

## Test plan

- [x] `pnpm typecheck`
- [x] Pre-commit checks (lint, format, 674 tests) pass
- [x] `generate-exercise-map` regenerates cleanly (35 concepts, 89 exercises)

🤖 Generated with [Claude Code](https://claude.com/claude-code)