### PR TITLE
Align exercise titles with API syllabus

### DIFF
--- a/curriculum/src/exercises/golf-rolling-ball-loop/instructions/en.md
+++ b/curriculum/src/exercises/golf-rolling-ball-loop/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Golf: Rolling Ball"
+title: "Rolling Ball"
 description: "Roll a golf ball into the hole using a loop."
 ---
 

--- a/curriculum/src/exercises/golf-rolling-ball-state/instructions/en.md
+++ b/curriculum/src/exercises/golf-rolling-ball-state/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Golf: Rolling Ball"
+title: "Stateful Ball"
 description: "Roll a golf ball into the hole by tracking its position."
 ---
 

--- a/curriculum/src/exercises/golf-scenarios/instructions/en.md
+++ b/curriculum/src/exercises/golf-scenarios/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Golf: Scenarios"
+title: "Golf Shot Scenarios"
 description: "Roll a ball to the correct spot in different scenarios."
 ---
 

--- a/curriculum/src/exercises/golf-shot-checker/instructions/en.md
+++ b/curriculum/src/exercises/golf-shot-checker/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Golf: Shot Checker"
+title: "Shot Checker"
 description: "Work out whether a golf shot landed close enough to sink."
 ---
 

--- a/curriculum/src/exercises/lower-pangram/instructions/en.md
+++ b/curriculum/src/exercises/lower-pangram/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Lower Pangram"
+title: "Simple Pangram"
 description: "Check if a sentence uses every letter of the alphabet."
 ---
 

--- a/curriculum/src/exercises/maze-automated-solve/instructions/en.md
+++ b/curriculum/src/exercises/maze-automated-solve/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Programmatically Solve a Maze"
+title: "Solve the Maze Programmatically"
 description: "Write code that navigates any maze by itself."
 ---
 

--- a/curriculum/src/exercises/maze-solve-basic/instructions/en.md
+++ b/curriculum/src/exercises/maze-solve-basic/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Manually Solve a Maze"
+title: "Solve the Maze"
 description: "Guide Jiki through a maze using simple instructions."
 ---
 

--- a/curriculum/src/exercises/maze-solve-repeat/instructions/en.md
+++ b/curriculum/src/exercises/maze-solve-repeat/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Solve a Maze with Repeat"
+title: "Loopy Maze"
 description: "Refactor a maze solution to use loops instead of repeated code."
 ---
 

--- a/curriculum/src/exercises/space-invaders-solve-basic/instructions/en.md
+++ b/curriculum/src/exercises/space-invaders-solve-basic/instructions/en.md
@@ -1,5 +1,5 @@
 ---
-title: "Space Invaders: Solve Basic"
+title: "Space Invaders"
 description: "Shoot down some aliens in your first taste of Space Invaders."
 ---
 


### PR DESCRIPTION
Reconciles exercise-page titles (frontmatter in `instructions/en.md`) with the canonical titles in the API's `curriculum.json`, so the dashboard and the exercise page show the same name.

Reported on the forum: **D&D Roll** showed as **DND Roll** on the dashboard. That was one of 25 title mismatches across the syllabus — the dashboard reads `lesson.title` from the API, while the exercise page reads the curriculum frontmatter, and the two had drifted apart.

This PR updates 9 frontmatter titles where the agreed canonical title differed from the existing frontmatter:

| slug | old | new |
|---|---|---|
| golf-rolling-ball-loop | Golf: Rolling Ball | Rolling Ball |
| golf-rolling-ball-state | Golf: Rolling Ball | Stateful Ball |
| golf-scenarios | Golf: Scenarios | Golf Shot Scenarios |
| golf-shot-checker | Golf: Shot Checker | Shot Checker |
| lower-pangram | Lower Pangram | Simple Pangram |
| maze-automated-solve | Programmatically Solve a Maze | Solve the Maze Programmatically |
| maze-solve-basic | Manually Solve a Maze | Solve the Maze |
| maze-solve-repeat | Solve a Maze with Repeat | Loopy Maze |
| space-invaders-solve-basic | Space Invaders: Solve Basic | Space Invaders |

Also resolves a pre-existing collision where `golf-rolling-ball-loop` and `golf-rolling-ball-state` both had the frontmatter title "Golf: Rolling Ball".

The matching API-side changes (19 lesson titles in `curriculum.json`) are in a companion PR in the api repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)