### PR TITLE
Guard Foxy Face triangle colours and draw order

### DIFF
--- a/curriculum/src/exercise-categories/draw/DrawExercise.ts
+++ b/curriculum/src/exercise-categories/draw/DrawExercise.ts
@@ -191,6 +191,55 @@ export abstract class DrawExercise extends VisualExercise {
   public hasTriangleAt(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): boolean {
     return getTriangleAt(this.shapes, x1, y1, x2, y2, x3, y3) !== undefined;
   }
+  public hasTriangleAtWithColor(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    x3: number,
+    y3: number,
+    color: string
+  ): boolean {
+    const triangle = getTriangleAt(this.shapes, x1, y1, x2, y2, x3, y3);
+    return triangle !== undefined && triangle.fillColor === resolveNamedColor(color);
+  }
+  // True if the `lower` triangle is drawn before the `upper` triangle, so `upper` renders
+  // on top where they overlap. Both triangles must exist. Coordinates are order-agnostic
+  // (they delegate to getTriangleAt's vertex matching).
+  public triangleDrawnBefore(
+    lower: [number, number, number, number, number, number],
+    upper: [number, number, number, number, number, number]
+  ): boolean {
+    const lowerTriangle = getTriangleAt(this.shapes, ...lower);
+    const upperTriangle = getTriangleAt(this.shapes, ...upper);
+    if (lowerTriangle === undefined || upperTriangle === undefined) {
+      return false;
+    }
+    return this.shapes.indexOf(lowerTriangle) < this.shapes.indexOf(upperTriangle);
+  }
+  // True if every triangle filled with `topColor` is drawn after every triangle filled with
+  // `bottomColor`, so the top colour always renders above the bottom colour where they overlap.
+  public trianglesColorDrawnAbove(topColor: string, bottomColor: string): boolean {
+    const resolvedTop = resolveNamedColor(topColor);
+    const resolvedBottom = resolveNamedColor(bottomColor);
+    const topIndices: number[] = [];
+    const bottomIndices: number[] = [];
+    this.shapes.forEach((shape, index) => {
+      if (!(shape instanceof Triangle)) {
+        return;
+      }
+      if (shape.fillColor === resolvedTop) {
+        topIndices.push(index);
+      }
+      if (shape.fillColor === resolvedBottom) {
+        bottomIndices.push(index);
+      }
+    });
+    if (topIndices.length === 0 || bottomIndices.length === 0) {
+      return false;
+    }
+    return Math.min(...topIndices) > Math.max(...bottomIndices);
+  }
 
   // These all delegate to checks.
   public checkUniqueColoredLines(count: number) {

--- a/curriculum/src/exercises/foxy-face/scenarios.ts
+++ b/curriculum/src/exercises/foxy-face/scenarios.ts
@@ -29,34 +29,48 @@ export const scenarios: VisualScenario[] = [
 
       return [
         {
-          pass: ex.hasTriangleAt(10, 40, 5, 60, 50, 95),
-          errorHtml: "The left cheek triangle isn't right."
+          pass: ex.hasTriangleAtWithColor(10, 40, 5, 60, 50, 95, "white"),
+          errorHtml: "The left cheek should be a white triangle in the right place."
         },
         {
-          pass: ex.hasTriangleAt(90, 40, 95, 60, 50, 95),
-          errorHtml: "The right cheek triangle isn't right."
+          pass: ex.hasTriangleAtWithColor(90, 40, 95, 60, 50, 95, "white"),
+          errorHtml: "The right cheek should be a white triangle in the right place."
         },
         {
-          pass: ex.hasTriangleAt(10, 40, 10, 5, 50, 40),
-          errorHtml: "The left ear triangle isn't right."
+          pass: ex.hasTriangleAtWithColor(10, 40, 10, 5, 50, 40, "brown"),
+          errorHtml: "The left ear should be a brown triangle in the right place."
         },
         {
-          pass: ex.hasTriangleAt(90, 40, 90, 5, 50, 40),
-          errorHtml: "The right ear triangle isn't right."
+          pass: ex.hasTriangleAtWithColor(90, 40, 90, 5, 50, 40, "brown"),
+          errorHtml: "The right ear should be a brown triangle in the right place."
         },
         {
-          pass: ex.hasTriangleAt(50, 30, 50, 95, 10, 40),
-          errorHtml: "The left face triangle isn't right."
+          pass: ex.hasTriangleAtWithColor(50, 30, 50, 95, 10, 40, "orange"),
+          errorHtml: "The left face should be an orange triangle in the right place."
         },
         {
-          pass: ex.hasTriangleAt(50, 30, 50, 95, 90, 40),
-          errorHtml: "The right face triangle isn't right."
+          pass: ex.hasTriangleAtWithColor(50, 30, 50, 95, 90, 40, "orange"),
+          errorHtml: "The right face should be an orange triangle in the right place."
         },
         {
           pass:
-            (ex.hasTriangleAt(40, 90, 50, 85, 60, 90) && ex.hasTriangleAt(50, 95, 40, 90, 60, 90)) ||
-            (ex.hasTriangleAt(40, 90, 50, 85, 50, 95) && ex.hasTriangleAt(60, 90, 50, 85, 50, 95)),
+            (ex.hasTriangleAtWithColor(40, 90, 50, 85, 60, 90, "charcoal") &&
+              ex.hasTriangleAtWithColor(50, 95, 40, 90, 60, 90, "charcoal")) ||
+            (ex.hasTriangleAtWithColor(40, 90, 50, 85, 50, 95, "charcoal") &&
+              ex.hasTriangleAtWithColor(60, 90, 50, 85, 50, 95, "charcoal")),
           errorHtml: "The nose needs two charcoal triangles. You can split it top/bottom or left/right."
+        },
+        {
+          pass: ex.triangleDrawnBefore([10, 40, 10, 5, 50, 40], [50, 30, 50, 95, 10, 40]),
+          errorHtml: "The left face should be drawn **on top of** the left ear."
+        },
+        {
+          pass: ex.triangleDrawnBefore([90, 40, 90, 5, 50, 40], [50, 30, 50, 95, 90, 40]),
+          errorHtml: "The right face should be drawn **on top of** the right ear."
+        },
+        {
+          pass: ex.trianglesColorDrawnAbove("charcoal", "orange"),
+          errorHtml: "The nose should sit **on top of** the face."
         }
       ];
     }


### PR DESCRIPTION
## Problem

The Foxy Face scenario only matched triangle **coordinates** (`hasTriangleAt`), ignoring colour and draw order. So a solution could pass every check yet render incorrectly, for example an ear drawn *on top of* the face (producing the dark overlap sliver below) or ears in the wrong colour.

## Changes

New helpers on `DrawExercise`:
- `hasTriangleAtWithColor(...)` — coordinate match plus `fillColor` check.
- `triangleDrawnBefore(lower, upper)` — true only if `lower` is drawn before `upper` (shapes-array index is the z-order).
- `trianglesColorDrawnAbove(topColor, bottomColor)` — true if every triangle of the top colour is drawn after every triangle of the bottom colour.

Foxy Face scenario now checks:
- **Colours**: brown ears, orange face, white cheeks, charcoal nose.
- **Meaningful order only**: each face on top of its ear, and the nose on top of the face. Cheeks and the two faces are left unconstrained since they only share edges (no overlap), so pinning their order would fail legitimate solutions without changing the render.

## Verification

- Reference `solution.javascript` passes all scenarios.
- Confirmed via a throwaway test using the real `runExerciseTests` harness that the ear-on-top, nose-under-face, and wrong-ear-colour attempts each now fail with the intended messages.
- Full curriculum suite (674 tests) and pre-commit checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)