### PR TITLE
Move penguin nose TODO to end of stub

### DIFF
--- a/curriculum/src/exercises/penguin/stub.javascript
+++ b/curriculum/src/exercises/penguin/stub.javascript
@@ -36,13 +36,13 @@ circle(43, 34, 1, "white")
 // TODO: Add the right eye
 //
 
-// Nose
-// TODO: Change the nose to be symmetrical.
-triangle(46, 38, 50, 38, 50, 47, "orange")
-
 // Left Foot
 ellipse(40, 93, 7, 4, "orange")
 
 //
 // TODO: Add the right foot
 //
+
+// Nose
+// TODO: Change the nose to be symmetrical.
+triangle(46, 38, 50, 38, 50, 47, "orange")

--- a/curriculum/src/exercises/penguin/stub.jiki
+++ b/curriculum/src/exercises/penguin/stub.jiki
@@ -36,12 +36,12 @@ circle(43, 34, 1, "white")
 // TODO: Add the right eye
 //
 
-// Nose
-triangle(46, 38, 50, 38, 50, 47, "orange") // TODO: Change the nose to be symmetrical.
-
 // Left Foot
 ellipse(40, 93, 7, 4, "orange")
 
 //
 // TODO: Add the right foot
 //
+
+// Nose
+triangle(46, 38, 50, 38, 50, 47, "orange") // TODO: Change the nose to be symmetrical.

--- a/curriculum/src/exercises/penguin/stub.py
+++ b/curriculum/src/exercises/penguin/stub.py
@@ -36,12 +36,12 @@ circle(43, 34, 1, "white")
 # TODO: Add the right eye
 #
 
-# Nose
-triangle(46, 38, 50, 38, 50, 47, "orange")  # TODO: Change the nose to be symmetrical.
-
 # Left Foot
 ellipse(40, 93, 7, 4, "orange")
 
 #
 # TODO: Add the right foot
 #
+
+# Nose
+triangle(46, 38, 50, 38, 50, 47, "orange")  # TODO: Change the nose to be symmetrical.


### PR DESCRIPTION
## Summary

A student reported on the forum that the Penguin exercise stub places the nose TODO out of order: it sits *between* the eye and foot TODOs, whereas the solution draws the nose **last** (after both feet).

This reorders the nose block in all three stubs (`.javascript`, `.py`, `.jiki`) to come after the right-foot TODO, matching the solution and giving a natural final step. No coordinates or logic change, only ordering.

Note: the same forum post also flagged trailing semicolons in the JS stub (already fixed in #634) and that a "code helper" never mentions the nose. The latter isn't a curriculum surface, the instructions, hints, and llm-metadata all mention the nose, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)