### PR TITLE
Add keyboard support to the scrubber

### DIFF
--- a/app/.context/coding-exercise/scrubber-implementation.md
+++ b/app/.context/coding-exercise/scrubber-implementation.md
@@ -67,7 +67,7 @@ The orchestrator provides key navigation methods:
    - Range input for timeline scrubbing
    - Calls `orchestrator.setCurrentTestTime` on change
    - Calls `orchestrator.snapToNearestFrame` on mouse release
-   - Keyboard event handlers (space, arrows - TODO)
+   - Keyboard event handler routes arrows/space to the orchestrator navigation methods
 
 3. **FrameStepperButtons.tsx**
    - Previous/next frame navigation buttons
@@ -82,15 +82,25 @@ The orchestrator provides key navigation methods:
 
 ## Navigation Controls
 
-### Keyboard Shortcuts (TODO)
+### Keyboard Shortcuts
 
-Planned keyboard shortcuts in ScrubberInput:
+Handled in `ScrubberInput` (the focused slider), routed to orchestrator navigation methods:
 
-- **Arrow Left**: Previous frame
-- **Arrow Right**: Next frame
-- **Arrow Down**: First frame
-- **Arrow Up**: Last frame
-- **Spacebar**: Play/pause
+- **Arrow Left**: Previous frame (`goToPrevFrame`)
+- **Arrow Right**: Next frame (`goToNextFrame`)
+- **Arrow Down**: First frame (`goToFirstFrame`)
+- **Arrow Up**: Last frame (`goToLastFrame`)
+- **Spacebar**: Play/pause (`play`/`pause`)
+
+Each handler calls `event.preventDefault()` so the native range input doesn't also move.
+
+### Shared Frame Navigation
+
+Frame and breakpoint navigation live on the orchestrator (`goToPrevFrame`,
+`goToNextFrame`, `goToFirstFrame`, `goToLastFrame`, `goToPrevBreakpoint`,
+`goToNextBreakpoint`). Each routes through a single private `moveToFrame(frame)`
+that pauses playback, seeks to the frame, and shows the information widget, so the
+stepper buttons and keyboard shortcuts all behave identically.
 
 ### Mouse Interactions
 

--- a/app/components/coding-exercise/lib/Orchestrator.ts
+++ b/app/components/coding-exercise/lib/Orchestrator.ts
@@ -3,11 +3,11 @@
 // passed around, controls the state, etc.
 
 import type { EditorView } from "@codemirror/view";
+import type { Frame } from "@jiki/interpreters/shared";
 import type { ExerciseDefinition, Language, ReadonlyRange } from "@jiki/curriculum";
 import { getLanguageFeatures } from "@jiki/curriculum";
 import { debounce } from "lodash";
 import type { StoreApi } from "zustand/vanilla";
-import { BreakpointManager } from "./orchestrator/BreakpointManager";
 import { EditorManager } from "./orchestrator/EditorManager";
 import { loadCodeMirrorContent } from "./localStorage";
 import { createOrchestratorStore } from "./orchestrator/store";
@@ -21,7 +21,6 @@ import type { ExerciseContext, InformationWidgetData, OrchestratorStore, Underli
 class Orchestrator {
   readonly store: StoreApi<OrchestratorStore>; // Made readonly instead of private for methods to access
   private readonly timelineManager: TimelineManager;
-  private readonly breakpointManager: BreakpointManager;
   private readonly testSuiteManager: TestSuiteManager;
   private readonly taskManager: TaskManager;
   private editorManager: EditorManager | null = null;
@@ -47,7 +46,6 @@ class Orchestrator {
 
     // Initialize managers
     this.timelineManager = new TimelineManager(this.store);
-    this.breakpointManager = new BreakpointManager(this.store);
     this.taskManager = new TaskManager(this.store);
     this.testSuiteManager = new TestSuiteManager(this.store, this.taskManager, context);
     // EditorManager will be created lazily when setupEditor is called
@@ -242,13 +240,43 @@ class Orchestrator {
     return this.timelineManager.getNearestCurrentFrame();
   }
 
-  // Breakpoint navigation methods - delegate to BreakpointManager
+  // Frame navigation methods
+  goToPrevFrame() {
+    this.moveToFrame(this.store.getState().prevFrame);
+  }
+
+  goToNextFrame() {
+    this.moveToFrame(this.store.getState().nextFrame);
+  }
+
+  goToFirstFrame() {
+    const frames = this.store.getState().currentTest?.frames ?? [];
+    this.moveToFrame(frames[0]);
+  }
+
+  goToLastFrame() {
+    const frames = this.store.getState().currentTest?.frames ?? [];
+    this.moveToFrame(frames[frames.length - 1]);
+  }
+
+  // Breakpoint navigation methods
   goToPrevBreakpoint() {
-    this.breakpointManager.goToPrevBreakpoint();
+    this.moveToFrame(this.store.getState().prevBreakpointFrame);
   }
 
   goToNextBreakpoint() {
-    this.breakpointManager.goToNextBreakpoint();
+    this.moveToFrame(this.store.getState().nextBreakpointFrame);
+  }
+
+  // Shared navigation behaviour for every stepper (frame + breakpoint) and the
+  // scrubber keyboard shortcuts: pause playback, jump to the frame, and surface
+  // the information widget so they all behave identically.
+  private moveToFrame(frame: Frame | undefined) {
+    this.pause();
+    if (frame) {
+      this.setCurrentTestTime(frame.time);
+    }
+    this.showInformationWidget();
   }
 
   private readonly lintCodeDebounced = debounce((code: string) => {

--- a/app/components/coding-exercise/lib/orchestrator/BreakpointManager.ts
+++ b/app/components/coding-exercise/lib/orchestrator/BreakpointManager.ts
@@ -1,13 +1,10 @@
-import type { StoreApi } from "zustand/vanilla";
 import type { Frame } from "@jiki/interpreters/shared";
-import type { OrchestratorStore } from "../types";
 
 /**
- * Manages breakpoint-related navigation and state
+ * Static helpers for locating breakpoint frames. Navigation itself lives on the
+ * Orchestrator (see `goToPrevBreakpoint`/`goToNextBreakpoint`).
  */
 export class BreakpointManager {
-  constructor(private readonly store: StoreApi<OrchestratorStore>) {}
-
   /**
    * Static helper to find the previous frame that matches a breakpoint line
    * @param currentFrame - The current frame
@@ -77,25 +74,5 @@ export class BreakpointManager {
     }
 
     return undefined;
-  }
-
-  /**
-   * Navigate to the previous breakpoint
-   */
-  goToPrevBreakpoint(): void {
-    const state = this.store.getState();
-    if (state.prevBreakpointFrame) {
-      state.setCurrentTestTime(state.prevBreakpointFrame.time);
-    }
-  }
-
-  /**
-   * Navigate to the next breakpoint
-   */
-  goToNextBreakpoint(): void {
-    const state = this.store.getState();
-    if (state.nextBreakpointFrame) {
-      state.setCurrentTestTime(state.nextBreakpointFrame.time);
-    }
   }
 }

--- a/app/components/coding-exercise/ui/scrubber/BreakpointStepperButtons.tsx
+++ b/app/components/coding-exercise/ui/scrubber/BreakpointStepperButtons.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useOrchestratorStore } from "../../lib/Orchestrator";
 import { useOrchestrator } from "../../lib/OrchestratorContext";
-import type { Frame } from "@jiki/interpreters/shared";
 import styles from "../../CodingExercise.module.css";
 
 interface BreakpointStepperButtonsProps {
@@ -18,7 +17,7 @@ export default function BreakpointStepperButtons({ enabled }: BreakpointStepperB
         <>
           <button
             disabled={!enabled || !prevBreakpointFrame}
-            onClick={() => handleGoToPrevBreakpoint(orchestrator, prevBreakpointFrame)}
+            onClick={() => orchestrator.goToPrevBreakpoint()}
             className={styles.codeNavBtn}
             aria-label="Previous breakpoint"
           >
@@ -26,7 +25,7 @@ export default function BreakpointStepperButtons({ enabled }: BreakpointStepperB
           </button>
           <button
             disabled={!enabled || !nextBreakpointFrame}
-            onClick={() => handleGoToNextBreakpoint(orchestrator, nextBreakpointFrame)}
+            onClick={() => orchestrator.goToNextBreakpoint()}
             className={styles.codeNavBtn}
             aria-label="Next breakpoint"
           >
@@ -36,28 +35,4 @@ export default function BreakpointStepperButtons({ enabled }: BreakpointStepperB
       )}
     </>
   );
-}
-
-/* **************** */
-/* EVENT HANDLERS */
-/* **************** */
-
-function handleGoToPrevBreakpoint(
-  orchestrator: ReturnType<typeof useOrchestrator>,
-  prevBreakpointFrame: Frame | undefined
-) {
-  orchestrator.pause();
-  if (prevBreakpointFrame) {
-    orchestrator.goToPrevBreakpoint();
-  }
-}
-
-function handleGoToNextBreakpoint(
-  orchestrator: ReturnType<typeof useOrchestrator>,
-  nextBreakpointFrame: Frame | undefined
-) {
-  orchestrator.pause();
-  if (nextBreakpointFrame) {
-    orchestrator.goToNextBreakpoint();
-  }
 }

--- a/app/components/coding-exercise/ui/scrubber/FrameStepperButtons.tsx
+++ b/app/components/coding-exercise/ui/scrubber/FrameStepperButtons.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useOrchestratorStore } from "../../lib/Orchestrator";
 import { useOrchestrator } from "../../lib/OrchestratorContext";
-import type { Frame } from "@jiki/interpreters/shared";
 import styles from "../../CodingExercise.module.css";
 
 interface FrameStepperButtonsProps {
@@ -16,7 +15,7 @@ export default function FrameStepperButtons({ enabled }: FrameStepperButtonsProp
     <>
       <button
         disabled={!enabled || !prevFrame}
-        onClick={() => handleGoToPreviousFrame(orchestrator, prevFrame)}
+        onClick={() => orchestrator.goToPrevFrame()}
         className={styles.navBtn}
         aria-label="Previous frame"
       >
@@ -24,7 +23,7 @@ export default function FrameStepperButtons({ enabled }: FrameStepperButtonsProp
       </button>
       <button
         disabled={!enabled || !nextFrame}
-        onClick={() => handleGoToNextFrame(orchestrator, nextFrame)}
+        onClick={() => orchestrator.goToNextFrame()}
         className={styles.navBtn}
         aria-label="Next frame"
       >
@@ -32,24 +31,4 @@ export default function FrameStepperButtons({ enabled }: FrameStepperButtonsProp
       </button>
     </>
   );
-}
-
-/* **************** */
-/* EVENT HANDLERS */
-/* **************** */
-
-function handleGoToPreviousFrame(orchestrator: ReturnType<typeof useOrchestrator>, prevFrame: Frame | undefined) {
-  orchestrator.pause();
-  if (prevFrame) {
-    orchestrator.setCurrentTestTime(prevFrame.time);
-  }
-  orchestrator.showInformationWidget();
-}
-
-function handleGoToNextFrame(orchestrator: ReturnType<typeof useOrchestrator>, nextFrame: Frame | undefined) {
-  orchestrator.pause();
-  if (nextFrame) {
-    orchestrator.setCurrentTestTime(nextFrame.time);
-  }
-  orchestrator.showInformationWidget();
 }

--- a/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
+++ b/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
@@ -1,6 +1,8 @@
 import React, { forwardRef, useRef, useCallback, useEffect } from "react";
 import type { Frame } from "@jiki/interpreters/shared";
 import type { AnimationTimeline } from "../../lib/AnimationTimeline";
+import type { Orchestrator } from "../../lib/Orchestrator";
+import { useOrchestratorStore } from "../../lib/Orchestrator";
 import { useOrchestrator } from "../../lib/OrchestratorContext";
 import styles from "../../CodingExercise.module.css";
 
@@ -14,6 +16,7 @@ interface ScrubberInputProps {
 const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
   ({ frames, animationTimeline, time, enabled }, ref) => {
     const orchestrator = useOrchestrator();
+    const { isPlaying } = useOrchestratorStore(orchestrator);
     const isDraggingRef = useRef(false);
 
     const min = calculateMinInputValue(frames);
@@ -82,19 +85,9 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
         if (!enabled) {
           return;
         }
-        handleOnKeyDown(event, animationTimeline, frames);
+        handleOnKeyDown(event, orchestrator, isPlaying);
       },
-      [enabled, animationTimeline, frames]
-    );
-
-    const handleKeyUp = useCallback(
-      (event: React.KeyboardEvent) => {
-        if (!enabled) {
-          return;
-        }
-        handleOnKeyUp(event, animationTimeline);
-      },
-      [enabled, animationTimeline]
+      [enabled, orchestrator, isPlaying]
     );
 
     // Cleanup event listeners on unmount
@@ -119,7 +112,6 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
         aria-disabled={!enabled}
         onMouseDown={handleMouseDown}
         onKeyDown={handleKeyDown}
-        onKeyUp={handleKeyUp}
       >
         <div className={styles.scrubberProgress} style={{ width: `${progress}%` }} />
       </div>
@@ -135,12 +127,42 @@ export default ScrubberInput;
 /* EVENT HANDLERS */
 /* **************** */
 
-function handleOnKeyUp(_event: React.KeyboardEvent, _animationTimeline: AnimationTimeline | null) {
-  // TODO: Implement keyboard shortcuts
-}
+function handleOnKeyDown(event: React.KeyboardEvent, orchestrator: Orchestrator, isPlaying: boolean) {
+  switch (event.key) {
+    case "ArrowLeft":
+      // Preventing default stops the range input from also nudging itself,
+      // which would fight the frame we're snapping to.
+      event.preventDefault();
+      orchestrator.goToPrevFrame();
+      break;
 
-function handleOnKeyDown(_event: React.KeyboardEvent, _animationTimeline: AnimationTimeline | null, _frames: Frame[]) {
-  // TODO: Implement keyboard shortcuts
+    case "ArrowRight":
+      event.preventDefault();
+      orchestrator.goToNextFrame();
+      break;
+
+    case "ArrowDown":
+      event.preventDefault();
+      orchestrator.goToFirstFrame();
+      break;
+
+    case "ArrowUp":
+      event.preventDefault();
+      orchestrator.goToLastFrame();
+      break;
+
+    case " ":
+      event.preventDefault();
+      if (isPlaying) {
+        orchestrator.pause();
+      } else {
+        orchestrator.play();
+      }
+      break;
+
+    default:
+      break;
+  }
 }
 
 /* **************** */

--- a/app/tests/integration/coding-exercise/breakpoint-navigation.test.tsx
+++ b/app/tests/integration/coding-exercise/breakpoint-navigation.test.tsx
@@ -123,6 +123,25 @@ describe("Breakpoint Navigation Integration", () => {
       expect(state.currentFrame?.line).toBe(3);
     });
 
+    it("pauses playback and shows the information widget, like the frame steppers", () => {
+      const frames = [
+        createMockFrame(0, { line: 1 }),
+        createMockFrame(100, { line: 2 }),
+        createMockFrame(200, { line: 3 })
+      ];
+      const breakpoints = [1, 3];
+      const orchestrator = setupOrchestrator(frames, breakpoints);
+      orchestrator.setCurrentTestTime(0);
+
+      const pauseSpy = jest.spyOn(orchestrator, "pause");
+      const showWidgetSpy = jest.spyOn(orchestrator, "showInformationWidget");
+
+      orchestrator.goToNextBreakpoint();
+
+      expect(pauseSpy).toHaveBeenCalledTimes(1);
+      expect(showWidgetSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("should skip folded lines when navigating", () => {
       const frames = [
         createMockFrame(0, { line: 1 }),

--- a/app/tests/integration/coding-exercise/frame-navigation.test.tsx
+++ b/app/tests/integration/coding-exercise/frame-navigation.test.tsx
@@ -1,0 +1,173 @@
+import Orchestrator from "@/components/coding-exercise/lib/Orchestrator";
+import { createMockFrame } from "@/tests/mocks";
+import { createMockExercise } from "@/tests/mocks/exercise";
+import type { Frame } from "@jiki/interpreters";
+import "@testing-library/jest-dom";
+
+// Helper to setup orchestrator with test frames
+function setupOrchestrator(frames: Frame[], foldedLines: number[] = []) {
+  const exercise = createMockExercise({
+    slug: "test-uuid",
+    stubs: { javascript: "// test code", python: "// test code", jikiscript: "// test code" }
+  });
+  const orchestrator = new Orchestrator(exercise, "jikiscript", { type: "lesson", slug: "test-lesson" });
+
+  orchestrator.getStore().setState({
+    currentTest: {
+      type: "visual" as const,
+      slug: "test-1",
+      name: "Test 1",
+      status: "pass" as const,
+      expects: [],
+      view: document.createElement("div"),
+      frames,
+      logLines: [],
+      lintErrors: [],
+      animationTimeline: {
+        duration: 5,
+        paused: true,
+        seek: jest.fn(),
+        play: jest.fn(),
+        pause: jest.fn(),
+        progress: 0,
+        currentTime: 0,
+        completed: false,
+        hasPlayedOrScrubbed: false,
+        seekEndOfTimeline: jest.fn(),
+        onUpdate: jest.fn(),
+        timeline: {
+          duration: 5,
+          currentTime: 0
+        }
+      } as any
+    },
+    foldedLines
+  });
+
+  // Trigger recalculation of prev/next frames
+  orchestrator.setCurrentTestTime(100);
+  orchestrator.setCurrentTestTime(0);
+
+  return orchestrator;
+}
+
+function buildFrames() {
+  return [
+    createMockFrame(0, { line: 1 }),
+    createMockFrame(100, { line: 2 }),
+    createMockFrame(200, { line: 3 }),
+    createMockFrame(300, { line: 4 }),
+    createMockFrame(400, { line: 5 })
+  ];
+}
+
+describe("Frame Navigation Integration", () => {
+  describe("Orchestrator frame methods", () => {
+    it("goToNextFrame moves to the next frame", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(200);
+
+      orchestrator.goToNextFrame();
+
+      const state = orchestrator.getStore().getState();
+      expect(state.currentTestTime).toBe(300);
+      expect(state.currentFrame?.line).toBe(4);
+    });
+
+    it("goToPrevFrame moves to the previous frame", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(200);
+
+      orchestrator.goToPrevFrame();
+
+      const state = orchestrator.getStore().getState();
+      expect(state.currentTestTime).toBe(100);
+      expect(state.currentFrame?.line).toBe(2);
+    });
+
+    it("goToFirstFrame moves to the first frame", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(400);
+
+      orchestrator.goToFirstFrame();
+
+      const state = orchestrator.getStore().getState();
+      expect(state.currentTestTime).toBe(0);
+      expect(state.currentFrame?.line).toBe(1);
+    });
+
+    it("goToLastFrame moves to the last frame", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(0);
+
+      orchestrator.goToLastFrame();
+
+      const state = orchestrator.getStore().getState();
+      expect(state.currentTestTime).toBe(400);
+      expect(state.currentFrame?.line).toBe(5);
+    });
+
+    it("goToNextFrame at the last frame stays put", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(400);
+
+      orchestrator.goToNextFrame();
+
+      const state = orchestrator.getStore().getState();
+      expect(state.currentTestTime).toBe(400);
+      expect(state.currentFrame?.line).toBe(5);
+    });
+
+    it("goToPrevFrame at the first frame stays put", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(0);
+
+      orchestrator.goToPrevFrame();
+
+      const state = orchestrator.getStore().getState();
+      expect(state.currentTestTime).toBe(0);
+      expect(state.currentFrame?.line).toBe(1);
+    });
+
+    it("skips folded lines when navigating", () => {
+      const orchestrator = setupOrchestrator(buildFrames(), [2, 3]);
+      orchestrator.setCurrentTestTime(0);
+
+      orchestrator.goToNextFrame();
+
+      const state = orchestrator.getStore().getState();
+      expect(state.currentTestTime).toBe(300);
+      expect(state.currentFrame?.line).toBe(4);
+    });
+  });
+
+  describe("shared navigation behaviour", () => {
+    // Every stepper (frame + breakpoint) and the scrubber keyboard shortcuts route
+    // through the same path, so they all pause playback and surface the widget.
+    it("pauses playback and shows the information widget", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(0);
+
+      const pauseSpy = jest.spyOn(orchestrator, "pause");
+      const showWidgetSpy = jest.spyOn(orchestrator, "showInformationWidget");
+
+      orchestrator.goToNextFrame();
+
+      expect(pauseSpy).toHaveBeenCalledTimes(1);
+      expect(showWidgetSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("pauses and shows the widget even when there is nowhere to move", () => {
+      const orchestrator = setupOrchestrator(buildFrames());
+      orchestrator.setCurrentTestTime(400);
+
+      const pauseSpy = jest.spyOn(orchestrator, "pause");
+      const showWidgetSpy = jest.spyOn(orchestrator, "showInformationWidget");
+
+      orchestrator.goToNextFrame();
+
+      expect(pauseSpy).toHaveBeenCalledTimes(1);
+      expect(showWidgetSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/tests/mocks/orchestrator.ts
+++ b/app/tests/mocks/orchestrator.ts
@@ -14,6 +14,12 @@ export function createMockOrchestrator(): Orchestrator {
     snapToNearestFrame: jest.fn(),
     runCode: jest.fn(),
     getStore: jest.fn(),
+    play: jest.fn(),
+    showInformationWidget: jest.fn(),
+    goToPrevFrame: jest.fn(),
+    goToNextFrame: jest.fn(),
+    goToFirstFrame: jest.fn(),
+    goToLastFrame: jest.fn(),
     goToPrevBreakpoint: jest.fn(),
     goToNextBreakpoint: jest.fn(),
     setCurrentTask: jest.fn()

--- a/app/tests/unit/components/coding-exercise/scrubber/BreakpointStepperButtons.test.tsx
+++ b/app/tests/unit/components/coding-exercise/scrubber/BreakpointStepperButtons.test.tsx
@@ -230,7 +230,6 @@ describe("BreakpointStepperButtons Component", () => {
       const prevButton = screen.getByLabelText("Previous breakpoint");
       fireEvent.click(prevButton);
 
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
       expect(mockOrchestrator.goToPrevBreakpoint).toHaveBeenCalledTimes(1);
     });
 
@@ -346,7 +345,6 @@ describe("BreakpointStepperButtons Component", () => {
       const nextButton = screen.getByLabelText("Next breakpoint");
       fireEvent.click(nextButton);
 
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
       expect(mockOrchestrator.goToNextBreakpoint).toHaveBeenCalledTimes(1);
     });
 
@@ -501,14 +499,12 @@ describe("BreakpointStepperButtons Component", () => {
 
       // Navigate to next breakpoint
       fireEvent.click(nextButton);
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
       expect(mockOrchestrator.goToNextBreakpoint).toHaveBeenCalledTimes(1);
 
       jest.clearAllMocks();
 
       // Navigate to previous breakpoint
       fireEvent.click(prevButton);
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
       expect(mockOrchestrator.goToPrevBreakpoint).toHaveBeenCalledTimes(1);
     });
   });

--- a/app/tests/unit/components/coding-exercise/scrubber/FrameStepperButtons.test.tsx
+++ b/app/tests/unit/components/coding-exercise/scrubber/FrameStepperButtons.test.tsx
@@ -36,6 +36,8 @@ function createMockOrchestrator(): Orchestrator {
     pause: jest.fn(),
     runCode: jest.fn(),
     showInformationWidget: jest.fn(),
+    goToPrevFrame: jest.fn(),
+    goToNextFrame: jest.fn(),
     getStore: jest.fn()
   } as unknown as Orchestrator;
 }
@@ -161,10 +163,7 @@ describe("FrameStepperButtons Component", () => {
       const prevButton = screen.getByLabelText("Previous frame");
       fireEvent.click(prevButton);
 
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
-      expect(mockOrchestrator.setCurrentTestTime).toHaveBeenCalledWith(200000);
-      expect(mockOrchestrator.setCurrentTestTime).toHaveBeenCalledTimes(1);
-      expect(mockOrchestrator.showInformationWidget).toHaveBeenCalledTimes(1);
+      expect(mockOrchestrator.goToPrevFrame).toHaveBeenCalledTimes(1);
     });
 
     it("should not navigate when no previous frame exists", () => {
@@ -180,11 +179,10 @@ describe("FrameStepperButtons Component", () => {
       );
 
       const prevButton = screen.getByLabelText("Previous frame");
-      // Button should be disabled, but let's test the handler logic
+      // Button should be disabled, so clicking does nothing
       fireEvent.click(prevButton);
 
-      // Should not call setCurrentTestTime
-      expect(mockOrchestrator.setCurrentTestTime).not.toHaveBeenCalled();
+      expect(mockOrchestrator.goToPrevFrame).not.toHaveBeenCalled();
     });
   });
 
@@ -252,10 +250,7 @@ describe("FrameStepperButtons Component", () => {
       const nextButton = screen.getByLabelText("Next frame");
       fireEvent.click(nextButton);
 
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
-      expect(mockOrchestrator.setCurrentTestTime).toHaveBeenCalledWith(300000);
-      expect(mockOrchestrator.setCurrentTestTime).toHaveBeenCalledTimes(1);
-      expect(mockOrchestrator.showInformationWidget).toHaveBeenCalledTimes(1);
+      expect(mockOrchestrator.goToNextFrame).toHaveBeenCalledTimes(1);
     });
 
     it("should not navigate when no next frame exists", () => {
@@ -271,11 +266,10 @@ describe("FrameStepperButtons Component", () => {
       );
 
       const nextButton = screen.getByLabelText("Next frame");
-      // Button should be disabled, but let's test the handler logic
+      // Button should be disabled, so clicking does nothing
       fireEvent.click(nextButton);
 
-      // Should not call setCurrentTestTime
-      expect(mockOrchestrator.setCurrentTestTime).not.toHaveBeenCalled();
+      expect(mockOrchestrator.goToNextFrame).not.toHaveBeenCalled();
     });
   });
 
@@ -355,15 +349,13 @@ describe("FrameStepperButtons Component", () => {
 
       // Navigate to next frame
       fireEvent.click(nextButton);
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
-      expect(mockOrchestrator.setCurrentTestTime).toHaveBeenCalledWith(300000);
+      expect(mockOrchestrator.goToNextFrame).toHaveBeenCalledTimes(1);
 
       jest.clearAllMocks();
 
       // Navigate to previous frame
       fireEvent.click(prevButton);
-      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
-      expect(mockOrchestrator.setCurrentTestTime).toHaveBeenCalledWith(100000);
+      expect(mockOrchestrator.goToPrevFrame).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/tests/unit/components/coding-exercise/scrubber/ScrubberInput.test.tsx
+++ b/app/tests/unit/components/coding-exercise/scrubber/ScrubberInput.test.tsx
@@ -1,4 +1,5 @@
 import type { Orchestrator } from "@/components/coding-exercise/lib/Orchestrator";
+import { useOrchestratorStore } from "@/components/coding-exercise/lib/Orchestrator";
 import ScrubberInput from "@/components/coding-exercise/ui/scrubber/ScrubberInput";
 import { createMockAnimationTimeline, createMockFrame } from "@/tests/mocks";
 import OrchestratorTestProvider from "@/tests/test-utils/OrchestratorTestProvider";
@@ -6,6 +7,11 @@ import type { Frame } from "@jiki/interpreters";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
+
+// Mock the orchestrator store hook so we can control prev/next frame and play state
+jest.mock("@/components/coding-exercise/lib/Orchestrator", () => ({
+  useOrchestratorStore: jest.fn()
+}));
 
 // Helper to create mock frames
 function createMockFrames(count: number): Frame[] {
@@ -30,14 +36,27 @@ function createMockOrchestrator(): Orchestrator {
     getNearestCurrentFrame: jest.fn().mockReturnValue(null),
     runCode: jest.fn(),
     getStore: jest.fn(),
+    play: jest.fn(),
     pause: jest.fn(),
+    showInformationWidget: jest.fn(),
+    goToPrevFrame: jest.fn(),
+    goToNextFrame: jest.fn(),
+    goToFirstFrame: jest.fn(),
+    goToLastFrame: jest.fn(),
     snapToNearestFrame: jest.fn()
   } as unknown as Orchestrator;
+}
+
+// Helper to setup store mock. ScrubberInput only reads isPlaying (for the
+// space-bar toggle); frame navigation targets are resolved inside the orchestrator.
+function setupStoreMock({ isPlaying = false }: { isPlaying?: boolean } = {}) {
+  (useOrchestratorStore as jest.Mock).mockReturnValue({ isPlaying });
 }
 
 describe("ScrubberInput Component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setupStoreMock();
   });
 
   describe("range input properties", () => {
@@ -347,44 +366,93 @@ describe("ScrubberInput Component", () => {
   });
 
   describe("keyboard handlers", () => {
-    it("should handle keyUp events", () => {
-      const mockOrchestrator = createMockOrchestrator();
+    function renderScrubber(mockOrchestrator: Orchestrator, enabled = true) {
       const mockTimeline = createMockAnimationTimeline({ duration: 10 });
-
       render(
         <OrchestratorTestProvider orchestrator={mockOrchestrator}>
-          <ScrubberInput frames={createMockFrames(5)} animationTimeline={mockTimeline} time={0} enabled={true} />
+          <ScrubberInput frames={createMockFrames(5)} animationTimeline={mockTimeline} time={0} enabled={enabled} />
         </OrchestratorTestProvider>
       );
+      return screen.getByRole("slider");
+    }
 
-      const input = screen.getByRole("slider");
+    it("ArrowLeft goes to the previous frame", () => {
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
 
-      // Currently these are TODO implementations, so just verify they don't crash
-      fireEvent.keyUp(input, { key: "ArrowRight" });
-      fireEvent.keyUp(input, { key: "Space" });
+      fireEvent.keyDown(input, { key: "ArrowLeft" });
 
-      // No specific assertions as handlers are not yet implemented
-      expect(true).toBe(true);
+      expect(mockOrchestrator.goToPrevFrame).toHaveBeenCalledTimes(1);
     });
 
-    it("should handle keyDown events", () => {
+    it("ArrowRight goes to the next frame", () => {
       const mockOrchestrator = createMockOrchestrator();
-      const mockTimeline = createMockAnimationTimeline({ duration: 10 });
+      const input = renderScrubber(mockOrchestrator);
 
-      render(
-        <OrchestratorTestProvider orchestrator={mockOrchestrator}>
-          <ScrubberInput frames={createMockFrames(5)} animationTimeline={mockTimeline} time={0} enabled={true} />
-        </OrchestratorTestProvider>
-      );
+      fireEvent.keyDown(input, { key: "ArrowRight" });
 
-      const input = screen.getByRole("slider");
+      expect(mockOrchestrator.goToNextFrame).toHaveBeenCalledTimes(1);
+    });
 
-      // Currently these are TODO implementations, so just verify they don't crash
-      fireEvent.keyDown(input, { key: "ArrowLeft" });
+    it("ArrowDown goes to the first frame", () => {
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      expect(mockOrchestrator.goToFirstFrame).toHaveBeenCalledTimes(1);
+    });
+
+    it("ArrowUp goes to the last frame", () => {
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
+
+      fireEvent.keyDown(input, { key: "ArrowUp" });
+
+      expect(mockOrchestrator.goToLastFrame).toHaveBeenCalledTimes(1);
+    });
+
+    it("Space plays when paused", () => {
+      setupStoreMock({ isPlaying: false });
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
+
+      fireEvent.keyDown(input, { key: " " });
+
+      expect(mockOrchestrator.play).toHaveBeenCalledTimes(1);
+      expect(mockOrchestrator.pause).not.toHaveBeenCalled();
+    });
+
+    it("Space pauses when playing", () => {
+      setupStoreMock({ isPlaying: true });
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
+
+      fireEvent.keyDown(input, { key: " " });
+
+      expect(mockOrchestrator.pause).toHaveBeenCalledTimes(1);
+      expect(mockOrchestrator.play).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when disabled", () => {
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator, false);
+
+      fireEvent.keyDown(input, { key: "ArrowRight" });
+
+      expect(mockOrchestrator.goToNextFrame).not.toHaveBeenCalled();
+    });
+
+    it("ignores unrelated keys", () => {
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
+
       fireEvent.keyDown(input, { key: "Enter" });
 
-      // No specific assertions as handlers are not yet implemented
-      expect(true).toBe(true);
+      expect(mockOrchestrator.goToPrevFrame).not.toHaveBeenCalled();
+      expect(mockOrchestrator.goToNextFrame).not.toHaveBeenCalled();
+      expect(mockOrchestrator.play).not.toHaveBeenCalled();
+      expect(mockOrchestrator.pause).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

The scrubber was mouse-only. Its keyboard handlers were empty `// TODO` stubs even though the slider was already focusable (`tabIndex`, `role="slider"`, and a container `onClick` that focuses it). This wires up the shortcuts the bootcamp IDE offers, addressing the forum report [\[a11y\] No keyboard support for Scrubber](https://jiki.io/r/forum).

Once any part of the scrubber is focused, the timeline can be driven entirely from the keyboard:

| Key | Action |
| --- | --- |
| ArrowLeft | Previous frame |
| ArrowRight | Next frame |
| ArrowDown | First frame |
| ArrowUp | Last frame |
| Space | Play / pause |

Arrow/space handlers call `event.preventDefault()` so the native range input doesn't also nudge itself (which caused a jarring double-jump).

## Refactor: shared navigation on the Orchestrator

The frame-navigation logic (pause → seek → show information widget) was duplicated inline across `FrameStepperButtons`, and the keyboard handler would have made a third copy. Instead, frame and breakpoint navigation now live on the `Orchestrator` as `goToPrevFrame` / `goToNextFrame` / `goToFirstFrame` / `goToLastFrame` / `goToPrevBreakpoint` / `goToNextBreakpoint`, all routing through one private `moveToFrame(frame)`.

Consequences:
- Stepper buttons and keyboard shortcuts now behave identically.
- **Breakpoint navigation is now consistent with frame navigation** — it also pauses and shows the information widget, which it previously did not.
- `BreakpointManager` is now a static-only helper (its unused instance nav methods were removed).

## Testing

- New `tests/integration/coding-exercise/frame-navigation.test.tsx` covering the four frame methods (including folded-line skipping and end-of-timeline no-ops) plus the shared pause/widget behaviour.
- `ScrubberInput` unit tests now assert each key routes to the right orchestrator method.
- Breakpoint integration test gains a consistency assertion (pauses + shows widget).
- Full app suite: 1851 tests passing; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)