### PR TITLE
Suppress contradictory expectations when student code throws at runtime

### DIFF
--- a/app/components/coding-exercise/lib/test-runner/runVisualScenario.ts
+++ b/app/components/coding-exercise/lib/test-runner/runVisualScenario.ts
@@ -25,13 +25,37 @@ export function runVisualScenario(
     resolvedSeed
   );
 
-  const isolatedExpects: VisualTestExpect[] = (scenario.isolatedChecks ?? []).flatMap((check) =>
-    runIsolatedCheck(check, scenario, studentCode, ExerciseClass, language, interpreter, languageFeatures, resolvedSeed)
-  );
-
-  const expects = [...primary.expects, ...isolatedExpects];
-
   const hasFrameError = primary.frames.some((f) => f.status === "ERROR");
+
+  // When the student's code throws at runtime, the scenario's expectations are
+  // meaningless (nothing was drawn), and surfacing them produces contradictory
+  // messages like "The left brick isn't correct" alongside the real runtime error.
+  // Suppress them and surface a single message pointing at the actual error on the
+  // timeline, mirroring how runIsolatedCheck already behaves on a frame error.
+  let expects: VisualTestExpect[];
+  if (hasFrameError) {
+    expects = [
+      {
+        pass: false,
+        errorHtml: "Your code threw an error while running. Look at the error message on the timeline below."
+      }
+    ];
+  } else {
+    const isolatedExpects: VisualTestExpect[] = (scenario.isolatedChecks ?? []).flatMap((check) =>
+      runIsolatedCheck(
+        check,
+        scenario,
+        studentCode,
+        ExerciseClass,
+        language,
+        interpreter,
+        languageFeatures,
+        resolvedSeed
+      )
+    );
+    expects = [...primary.expects, ...isolatedExpects];
+  }
+
   const allExpectsPass = expects.every((e) => e.pass) && !hasFrameError;
   const status = allExpectsPass ? (primary.lintErrors.length > 0 ? "lint_warning" : "pass") : "fail";
 

--- a/app/components/coding-exercise/lib/test-runner/runVisualScenario.ts
+++ b/app/components/coding-exercise/lib/test-runner/runVisualScenario.ts
@@ -37,7 +37,7 @@ export function runVisualScenario(
     expects = [
       {
         pass: false,
-        errorHtml: "Your code threw an error while running. Look at the error message on the timeline below."
+        errorHtml: "Your code hit an error while it was running. Fix the error message above to continue."
       }
     ];
   } else {

--- a/app/tests/unit/components/coding-exercise/test-runner/runVisualScenario.test.ts
+++ b/app/tests/unit/components/coding-exercise/test-runner/runVisualScenario.test.ts
@@ -253,9 +253,55 @@ describe("runVisualScenario", () => {
       const result = runVisualScenario(scenario, "move()", MockExercise as any, "jikiscript", mockInterpreter);
 
       expect(result.status).toBe("fail");
-      expect(result.expects[0].pass).toBe(true); // Expectations still pass
+      // On a frame error the scenario's expectations are suppressed (they would be
+      // meaningless / contradictory) and replaced with a single pointer message.
+      expect(result.expects).toHaveLength(1);
+      expect(result.expects[0].pass).toBe(false);
+      expect(result.expects[0].errorHtml).toBe(
+        "Your code threw an error while running. Look at the error message on the timeline below."
+      );
       expect(result.frames).toHaveLength(3);
       expect(result.frames[2].status).toBe("ERROR");
+    });
+
+    it("should not surface contradictory failing expectations when a frame errored", () => {
+      // Regression: finish-wall student calls rectangle() with too few args. The
+      // interpreter throws (frame ERROR) before anything is drawn, yet the scenario's
+      // per-shape expectations still failed with "The left brick isn't correct" etc.
+      // Those messages contradict the real error and must be suppressed.
+      mockInterpreter = createMockInterpreter({
+        interpret: jest.fn().mockReturnValue({
+          frames: [{ time: 100, line: 3, status: "ERROR", error: { message: "InvalidNumberOfArguments" } }],
+          logLines: [],
+          meta: { sourceCode: "rectangle(0, 0, 20, 10)" }
+        })
+      });
+
+      const scenario: VisualScenario = {
+        slug: "finish-wall",
+        name: "Finish off the wall",
+        description: "Add a top layer to the wall!",
+        taskId: "task-1",
+        expectations: jest.fn().mockReturnValue([
+          { pass: false, errorHtml: "The left brick isn't correct." },
+          { pass: false, errorHtml: "The second brick isn't correct." }
+        ])
+      };
+
+      const result = runVisualScenario(
+        scenario,
+        "rectangle(0, 0, 20, 10)",
+        MockExercise as any,
+        "javascript",
+        mockInterpreter
+      );
+
+      expect(result.status).toBe("fail");
+      expect(result.expects).toHaveLength(1);
+      expect(result.expects[0].errorHtml).not.toContain("brick");
+      expect(result.expects[0].errorHtml).toBe(
+        "Your code threw an error while running. Look at the error message on the timeline below."
+      );
     });
 
     it("should pass when all frames have SUCCESS status and expectations pass", () => {

--- a/app/tests/unit/components/coding-exercise/test-runner/runVisualScenario.test.ts
+++ b/app/tests/unit/components/coding-exercise/test-runner/runVisualScenario.test.ts
@@ -258,7 +258,7 @@ describe("runVisualScenario", () => {
       expect(result.expects).toHaveLength(1);
       expect(result.expects[0].pass).toBe(false);
       expect(result.expects[0].errorHtml).toBe(
-        "Your code threw an error while running. Look at the error message on the timeline below."
+        "Your code hit an error while it was running. Fix the error message above to continue."
       );
       expect(result.frames).toHaveLength(3);
       expect(result.frames[2].status).toBe("ERROR");
@@ -300,7 +300,7 @@ describe("runVisualScenario", () => {
       expect(result.expects).toHaveLength(1);
       expect(result.expects[0].errorHtml).not.toContain("brick");
       expect(result.expects[0].errorHtml).toBe(
-        "Your code threw an error while running. Look at the error message on the timeline below."
+        "Your code hit an error while it was running. Fix the error message above to continue."
       );
     });
 


### PR DESCRIPTION
## Problem

Reported on the forum for `finish-wall`: a student wrote `rectangle(pos, 0, 20, 10)` (4 args) when the exercise requires a colour as the 5th arg. They saw two contradictory messages:

- A runtime error popup: *"This function has 5 input slots but you provided 4 inputs…"* (correct)
- A test-result message: *"The left brick isn't correct"* (misleading — the brick was never drawn, because execution threw before any `rectangle` call completed)

## Root cause

The bug isn't in the exercise — it's in the shared visual test runner. `runPrimaryCheck` in `runVisualScenario.ts` **always** evaluated `scenario.expectations()`, even when a frame errored. The frame error was only used to force `status: "fail"`, so the meaningless per-shape expectation failures were still surfaced alongside the real runtime error.

The isolated-check path (`runIsolatedCheck`) already guarded against this — on a frame error it returns a single clean message instead of the expectations. The primary path just lacked the equivalent guard.

## Fix

When the primary run has a frame `ERROR`, suppress the scenario expectations and surface one message pointing the student at the actual error on the timeline. Applies to **all** visual exercises, not just `finish-wall`.

## Notes

- The runtime error popup (from the interpreter, shown on the scrubber) is unchanged — it's correct and helpful.
- The new message is a hardcoded English string, matching the existing (un-i18n'd) `runIsolatedCheck` string two functions down. i18n of the test-runner error surface is deferred (see `app/.context/i18n.md`).

## Tests

- Updated the existing frame-error test to assert expectations are now suppressed.
- Added a regression test reproducing the `finish-wall` case (failing per-shape expectations + frame error → only the pointer message surfaces, no "brick" text).
- Full app suite (1836 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)