### PR TITLE
Clarify MultipleStatementsPerLine error message

### DIFF
--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -23,7 +23,7 @@
       "MissingRightParenthesisAfterFunctionCall": "Did you forget the closing parenthesis `)` when calling the {{function}} function?",
       "MissingEndOfLine": "Jiki didn't expect `{{current}}` to appear here after the `{{previous}}`.",
       "MissingVariableName": "Missing variable name in declaration. You must provide a name after `let`.",
-      "MultipleStatementsPerLine": "Multiple statements found on line {{line}}. Only one statement per line is allowed when oneStatementPerLine is enabled.",
+      "MultipleStatementsPerLine": "In Jiki, you can only put one statement per line. You can't separate multiple statements with semicolons. Please put the second statement on its own line.",
       "TrailingCommaInArray": "Trailing commas are not allowed in lists.",
       "TrailingCommaInDictionary": "Trailing commas are not allowed in objects.",
       "InvalidDictionaryKey": "Invalid object key. Keys must be identifiers, strings, or numbers.",


### PR DESCRIPTION
## Problem

Reported on the forum: writing two statements on one line, e.g.

```js
move(); move()
```

produced a confusing error:

> Multiple statements found on line {{line}}. Only one statement per line is allowed when oneStatementPerLine is enabled.

Two issues:
- It leaked the internal `oneStatementPerLine` flag name, which is meaningless to a learner.
- `{{line}}` was never interpolated — the line number was passed as the `location` argument, not into the translation context — so the raw placeholder showed to students.

## Fix

Replaced the message (`interpreters/src/javascript/locales/en/translation.json`) with a student-friendly one that needs no interpolation:

> In Jiki, you can only put one statement per line. You can't separate multiple statements with semicolons. Please put the second statement on its own line.

## Testing

- `oneStatementPerLine.test.ts` passes (asserts on `error.type`, not message text).
- Full interpreter suite passes (3505 tests) via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)