### PR TITLE
Seed maze-turn-around stub from student's previous solution

### DIFF
--- a/curriculum/src/exercises/maze-turn-around/index.ts
+++ b/curriculum/src/exercises/maze-turn-around/index.ts
@@ -59,6 +59,7 @@ const exerciseDefinition: VisualExerciseCore = {
   tasks,
   scenarios,
   functions,
+  conceptSlugs: ["creating-functions"],
   interpreterOptions: { maxTotalLoopIterations: 50 }
 };
 

--- a/curriculum/src/exercises/maze-turn-around/stub.javascript
+++ b/curriculum/src/exercises/maze-turn-around/stub.javascript
@@ -1,15 +1,1 @@
-repeat() {
-  if (canTurnLeft()) {
-    turnLeft()
-    move()
-  } else if (canMove()) {
-    move()
-  } else if (canTurnRight()) {
-    turnRight()
-    move()
-  } else {
-    turnLeft()
-    turnLeft()
-    move()
-  }
-}
+{{LESSON:maze-automated-solve}}

--- a/curriculum/src/exercises/maze-turn-around/stub.jiki
+++ b/curriculum/src/exercises/maze-turn-around/stub.jiki
@@ -1,15 +1,1 @@
-repeat_until_game_over do
-  if can_turn_left() do
-    turn_left()
-    move()
-  else if can_move() do
-    move()
-  else if can_turn_right() do
-    turn_right()
-    move()
-  else do
-    turn_left()
-    turn_left()
-    move()
-  end
-end
+{{LESSON:maze-automated-solve}}

--- a/curriculum/src/exercises/maze-turn-around/stub.py
+++ b/curriculum/src/exercises/maze-turn-around/stub.py
@@ -1,13 +1,1 @@
-repeat():
-    if can_turn_left():
-        turn_left()
-        move()
-    elif can_move():
-        move()
-    elif can_turn_right():
-        turn_right()
-        move()
-    else:
-        turn_left()
-        turn_left()
-        move()
+{{LESSON:maze-automated-solve}}


### PR DESCRIPTION
## What

Two changes to the `maze-turn-around` exercise:

1. **Seed the stub from the student's own previous solution.** The three stub files (`.javascript`, `.jiki`, `.py`) previously hardcoded a static copy of the maze solver. They now contain a single `{{LESSON:maze-automated-solve}}` placeholder. On load, the app's existing `interpolateStub()` (`app/components/coding-exercise/lib/stubInterpolation.ts`) resolves this against the student's latest submission to `maze-automated-solve` (the previous exercise), per language. So the student starts this refactor exercise from *their own* solver rather than a canonical one.

2. **Add missing `conceptSlugs`.** The exercise definition had no `conceptSlugs`; added `["creating-functions"]`, matching the `make-your-own-functions` level's taught concept.

## Why

This mirrors the bootcamp's `{{EXERCISE:...}}` mechanism (already ported to the app as `{{LESSON:...}}` but previously unused by any curriculum stub). The `turn-around` exercise is explicitly a "refactor your previous solver" task, so starting from the student's actual prior code is the intended experience.

## Trade-off

The interpolation has no static fallback: if a student has no stored submission for `maze-automated-solve` (skipped it / reset progress), the editor starts blank. This matches bootcamp behaviour and was the chosen option.

## Testing

- `pnpm typecheck` (curriculum) — passes
- Full curriculum suite — 674 tests pass
- App `stubInterpolation` unit tests — 18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)