### PR TITLE
Use correct HSL term 'lightness' instead of 'luminosity'

### DIFF
--- a/curriculum/src/exercise-categories/draw/DrawExercise.ts
+++ b/curriculum/src/exercise-categories/draw/DrawExercise.ts
@@ -238,7 +238,7 @@ export abstract class DrawExercise extends VisualExercise {
       return executionCtx.logicError("Saturation must be between 0 and 100");
     }
     if (l.value < 0 || l.value > 100) {
-      return executionCtx.logicError("Luminosity must be between 0 and 100");
+      return executionCtx.logicError("Lightness must be between 0 and 100");
     }
     return hslToHexString(h.value, s.value, l.value);
   }
@@ -519,7 +519,7 @@ export abstract class DrawExercise extends VisualExercise {
       hsl: {
         name: "hsl",
         func: this.hsl.bind(this),
-        description: "converted HSL color (hue: ${arg1}, saturation: ${arg2}, luminosity: ${arg3}) to a hex string"
+        description: "converted HSL color (hue: ${arg1}, saturation: ${arg2}, lightness: ${arg3}) to a hex string"
       },
       rgb: {
         name: "rgb",

--- a/curriculum/src/exercises/rainbow-ball/index.ts
+++ b/curriculum/src/exercises/rainbow-ball/index.ts
@@ -13,8 +13,8 @@ const functions: FunctionInfo[] = [
   },
   {
     name: "hsl",
-    signature: "hsl(hue, saturation, luminosity)",
-    description: "Convert HSL color values (hue 0-360, saturation 0-100, luminosity 0-100) to a hex color string",
+    signature: "hsl(hue, saturation, lightness)",
+    description: "Convert HSL color values (hue 0-360, saturation 0-100, lightness 0-100) to a hex color string",
     examples: ["hsl(0, 80, 50)", "hsl(120, 80, 50)"],
     category: "Colors"
   }

--- a/curriculum/src/exercises/rainbow-ball/instructions/en.md
+++ b/curriculum/src/exercises/rainbow-ball/instructions/en.md
@@ -23,12 +23,12 @@ This project is all about having some variables that are responsible for the pos
 
 - The first circle you draw should be at `(5, 5)`.
 - All the circles should have a radius of `10`.
-- The colour of the circle should use HSL, starting with a hue of `100` (green), a saturation of `80` (bold colours), and a luminosity of `50` (mid-brightness).
+- The colour of the circle should use HSL, starting with a hue of `100` (green), a saturation of `80` (bold colours), and a lightness of `50` (mid-brightness).
 
 ### Animating
 
 - To start with, in each iteration you should move the ball `2` to the right and `1` down.
-- The hue should increase by `1` each time, until it gets to the maximum (`360`), then start reducing again. The saturation and luminosity don't need to change.
+- The hue should increase by `1` each time, until it gets to the maximum (`360`), then start reducing again. The saturation and lightness don't need to change.
 
 ### Bouncing
 

--- a/curriculum/src/exercises/rainbow-ball/solution.javascript
+++ b/curriculum/src/exercises/rainbow-ball/solution.javascript
@@ -6,7 +6,7 @@ let hue = 99
 
 // These never need to change
 let saturation = 80
-let luminosity = 50
+let lightness = 50
 
 let xDirection = 2
 let yDirection = 1

--- a/curriculum/src/exercises/rainbow-ball/solution.jiki
+++ b/curriculum/src/exercises/rainbow-ball/solution.jiki
@@ -6,7 +6,7 @@ set hue to 99
 
 // These never need to change
 set saturation to 80
-set luminosity to 50
+set lightness to 50
 
 set x_direction to 2
 set y_direction to 1

--- a/curriculum/src/exercises/rainbow-ball/solution.py
+++ b/curriculum/src/exercises/rainbow-ball/solution.py
@@ -6,7 +6,7 @@ hue = 99
 
 # These never need to change
 saturation = 80
-luminosity = 50
+lightness = 50
 
 x_direction = 2
 y_direction = 1

--- a/curriculum/src/exercises/rainbow-splodges/Exercise.ts
+++ b/curriculum/src/exercises/rainbow-splodges/Exercise.ts
@@ -36,7 +36,7 @@ export class RainbowSplodgesExercise extends DrawExercise {
     );
   }
 
-  public checkSaturationAndLuminosityInRange(min: number, max: number): boolean {
+  public checkSaturationAndLightnessInRange(min: number, max: number): boolean {
     if (this.circles.length === 0) return false;
     return this.circles.every((c) => {
       const { s, l } = hexToHsl(c.fillColor);

--- a/curriculum/src/exercises/rainbow-splodges/index.ts
+++ b/curriculum/src/exercises/rainbow-splodges/index.ts
@@ -13,8 +13,8 @@ const functions: FunctionInfo[] = [
   },
   {
     name: "hsl",
-    signature: "hsl(hue, saturation, luminosity)",
-    description: "Convert HSL color values (hue 0-360, saturation 0-100, luminosity 0-100) to a hex color string",
+    signature: "hsl(hue, saturation, lightness)",
+    description: "Convert HSL color values (hue 0-360, saturation 0-100, lightness 0-100) to a hex color string",
     examples: ["hsl(0, 80, 50)", "hsl(120, 80, 50)"],
     category: "Colors"
   }

--- a/curriculum/src/exercises/rainbow-splodges/instructions/en.md
+++ b/curriculum/src/exercises/rainbow-splodges/instructions/en.md
@@ -11,7 +11,7 @@ You need to draw **200 circles** with random radii, at random positions, with ra
 
 There are only three rules:
 
-1. Keep saturation and luminosity in the range of between 20 and 80. You can either just stick to fixed values (maybe 50 for each, which will probably look better) or go more wild and vary them both.
+1. Keep saturation and lightness in the range of between 20 and 80. You can either just stick to fixed values (maybe 50 for each, which will probably look better) or go more wild and vary them both.
 2. The radius of the circles needs to be greater than 1 and less than 30 (else the circles will be waaaaaay too big!). You can choose a different range, but you can't go outside of this.
 3. The circles cannot go outside of the box. But lots of circles should touch the edges.
 

--- a/curriculum/src/exercises/rainbow-splodges/scenarios.ts
+++ b/curriculum/src/exercises/rainbow-splodges/scenarios.ts
@@ -45,8 +45,8 @@ export const scenarios: VisualScenario[] = [
             "None of your circles touched the edges of the canvas. If you're confident your code is correct, it might be that the random numbers didn't happen to land a circle exactly on an edge. Try running it again!"
         },
         {
-          pass: ex.checkSaturationAndLuminosityInRange(20, 80),
-          errorHtml: "Saturation and luminosity must both be between 20 and 80."
+          pass: ex.checkSaturationAndLightnessInRange(20, 80),
+          errorHtml: "Saturation and lightness must both be between 20 and 80."
         }
       ];
     }

--- a/curriculum/src/exercises/rainbow/Exercise.ts
+++ b/curriculum/src/exercises/rainbow/Exercise.ts
@@ -20,7 +20,7 @@ export class RainbowExercise extends DrawExercise {
     });
   }
 
-  public allRectanglesHaveMinSaturationAndLuminosity(minSat: number, minLum: number): boolean {
+  public allRectanglesHaveMinSaturationAndLightness(minSat: number, minLum: number): boolean {
     const rects = this.shapes.filter((s) => s instanceof Rectangle);
     if (rects.length === 0) return false;
     return rects.every((shape) => {

--- a/curriculum/src/exercises/rainbow/index.ts
+++ b/curriculum/src/exercises/rainbow/index.ts
@@ -13,8 +13,8 @@ const functions: FunctionInfo[] = [
   },
   {
     name: "hsl",
-    signature: "hsl(hue, saturation, luminosity)",
-    description: "Convert HSL color values (hue 0-360, saturation 0-100, luminosity 0-100) to a color string",
+    signature: "hsl(hue, saturation, lightness)",
+    description: "Convert HSL color values (hue 0-360, saturation 0-100, lightness 0-100) to a color string",
     examples: ["hsl(0, 50, 50)", "hsl(120, 50, 50)"],
     category: "Colors"
   }

--- a/curriculum/src/exercises/rainbow/instructions/en.md
+++ b/curriculum/src/exercises/rainbow/instructions/en.md
@@ -9,4 +9,4 @@ Your task is to make a beautiful rainbow pattern made up of 100 vertical bars. I
 
 The rainbow is made up of `100` bars, each going from top to bottom with a width of `1`. The first bar should have an `x` of `0`, and the final bar should have an `x` of `99`.
 
-To set the color, use the `hsl(...)` function. This returns a color string that you can then use as the final input in `rectangle(...)`. Setting the saturation and luminosity values to around `50` is probably best. The first bar should have a **hue** of `0`. The hue should increase for each bar and end up somewhere near 300.
+To set the color, use the `hsl(...)` function. This returns a color string that you can then use as the final input in `rectangle(...)`. Setting the saturation and lightness values to around `50` is probably best. The first bar should have a **hue** of `0`. The hue should increase for each bar and end up somewhere near 300.

--- a/curriculum/src/exercises/rainbow/llm-metadata.ts
+++ b/curriculum/src/exercises/rainbow/llm-metadata.ts
@@ -22,7 +22,7 @@ export const llmMetadata: LLMMetadata = {
 
         Drawing before updating is the key ordering point: update-first pushes the
         first bar to x=1 and skips x=0. Other slips are forgetting to change hue
-        (uniform color) and using saturation/luminosity that's too low.
+        (uniform color) and using saturation/lightness that's too low.
       `
     }
   }

--- a/curriculum/src/exercises/rainbow/scenarios.ts
+++ b/curriculum/src/exercises/rainbow/scenarios.ts
@@ -32,8 +32,8 @@ export const scenarios: VisualScenario[] = [
           errorHtml: "The last rectangle is missing."
         },
         {
-          pass: ex.allRectanglesHaveMinSaturationAndLuminosity(20, 20),
-          errorHtml: "All rectangles should have saturation and luminosity of at least 20."
+          pass: ex.allRectanglesHaveMinSaturationAndLightness(20, 20),
+          errorHtml: "All rectangles should have saturation and lightness of at least 20."
         },
         {
           pass: ex.checkUniqueColoredRectangles(100),

--- a/curriculum/src/exercises/sunset/index.ts
+++ b/curriculum/src/exercises/sunset/index.ts
@@ -27,8 +27,8 @@ const functions: FunctionInfo[] = [
   },
   {
     name: "hsl",
-    signature: "hsl(hue, saturation, luminosity)",
-    description: "Convert HSL color values (hue 0-360, saturation 0-100, luminosity 0-100) to a hex color string",
+    signature: "hsl(hue, saturation, lightness)",
+    description: "Convert HSL color values (hue 0-360, saturation 0-100, lightness 0-100) to a hex color string",
     examples: ["hsl(210, 70, 60)", "hsl(0, 100, 50)"],
     category: "Colors"
   }

--- a/curriculum/src/exercises/sunset/llm-metadata.ts
+++ b/curriculum/src/exercises/sunset/llm-metadata.ts
@@ -22,7 +22,7 @@ export const llmMetadata: LLMMetadata = {
         - Updating variables after drawing instead of before (animation runs one frame behind)
         - Wrong draw order (the sun ends up hidden behind the sky rectangle)
         - Mixing up the two color systems: rgb is 0-255 per channel; hsl is hue 0-360,
-          saturation/luminosity 0-100
+          saturation/lightness 0-100
       `
     }
   }


### PR DESCRIPTION
The lesson video correctly defines HSL as **Hue, Saturation, Lightness**, but the drawing exercises referred to the L channel as *luminosity*. Luminance/luminosity is a different concept (perceived brightness — two HSL colours with the same lightness can have very different luminance), so this renames it to **lightness** everywhere.

Reported on the forum by Phil (rainbow-ball and sunset), swept across all affected exercises.

### Changes
- `exercise-categories/draw/DrawExercise.ts` — `hsl()` logic-error message + function description (shared base for all four exercises)
- **rainbow** — index signature/description, instructions, llm-metadata, scenario errorHtml, and `allRectanglesHaveMinSaturationAndLightness` helper
- **rainbow-ball** — index signature/description, instructions, and `lightness` variable in all three solution files
- **rainbow-splodges** — index signature/description, instructions, scenario errorHtml, and `checkSaturationAndLightnessInRange` helper
- **sunset** — index signature/description, llm-metadata

No functional/behavioural change; terminology only. Typecheck and all 674 exercise tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)