### PR TITLE
Patch animejs to fix skipped 1ms tweens on first playthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
   "pnpm": {
     "overrides": {
       "@lezer/javascript": "npm:@jiki.io/lezer-javascript@^1.5.4"
+    },
+    "patchedDependencies": {
+      "animejs@4.2.2": "patches/animejs@4.2.2.patch"
     }
   }
 }

--- a/patches/animejs@4.2.2.patch
+++ b/patches/animejs@4.2.2.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/modules/core/render.cjs b/dist/modules/core/render.cjs
+index d4349157fc329c30a320a8f17ab20581a505bbd1..18e5ad235d93fba28a27cffcb97fdb33234e2797 100644
+--- a/dist/modules/core/render.cjs
++++ b/dist/modules/core/render.cjs
+@@ -133,7 +133,10 @@ const render = (tickable, time, muteCallbacks, internalRender, tickMode) => {
+ 
+       // Time has jumped more than globals.tickThreshold so consider this tick manual
+       const forcedRender = forcedTick || (isRunningBackwards ? deltaTime * -1 : deltaTime) >= globals.globals.tickThreshold;
+-      const absoluteTime = tickable._offset + (parent ? parent._offset : 0) + tickableDelay + iterationTime;
++      // Rounding is necessary here to match the rounding applied to tween._absoluteStartTime at creation time,
++      // otherwise floating point residue in offsets can make `absoluteTime <= tweenAbsEndTime` style
++      // comparisons fail by ~1e-13 and permanently skip short tweens during playback.
++      const absoluteTime = helpers.round(tickable._offset + (parent ? parent._offset : 0) + tickableDelay + iterationTime, 12);
+ 
+       // Only Animation can have tweens, Timer returns undefined
+       let tween = /** @type {Tween} */(/** @type {JSAnimation} */(tickable)._head);
+diff --git a/dist/modules/core/render.js b/dist/modules/core/render.js
+index 1ea5f8dd14b3759dc36a97fdf5f84e5bbe399e0c..c2dca2bb40b42599d8451f60eb1c30a8e3215647 100644
+--- a/dist/modules/core/render.js
++++ b/dist/modules/core/render.js
+@@ -131,7 +131,10 @@ const render = (tickable, time, muteCallbacks, internalRender, tickMode) => {
+ 
+       // Time has jumped more than globals.tickThreshold so consider this tick manual
+       const forcedRender = forcedTick || (isRunningBackwards ? deltaTime * -1 : deltaTime) >= globals.tickThreshold;
+-      const absoluteTime = tickable._offset + (parent ? parent._offset : 0) + tickableDelay + iterationTime;
++      // Rounding is necessary here to match the rounding applied to tween._absoluteStartTime at creation time,
++      // otherwise floating point residue in offsets can make `absoluteTime <= tweenAbsEndTime` style
++      // comparisons fail by ~1e-13 and permanently skip short tweens during playback.
++      const absoluteTime = round(tickable._offset + (parent ? parent._offset : 0) + tickableDelay + iterationTime, 12);
+ 
+       // Only Animation can have tweens, Timer returns undefined
+       let tween = /** @type {Tween} */(/** @type {JSAnimation} */(tickable)._head);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   '@lezer/javascript': npm:@jiki.io/lezer-javascript@^1.5.4
 
+patchedDependencies:
+  animejs@4.2.2:
+    hash: 171f5353695b4337495b7f49e28dae68b5483b5753ebc1ccb6d476f7b1216508
+    path: patches/animejs@4.2.2.patch
+
 importers:
 
   .:
@@ -98,7 +103,7 @@ importers:
         version: 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
       animejs:
         specifier: 4.2.2
-        version: 4.2.2
+        version: 4.2.2(patch_hash=171f5353695b4337495b7f49e28dae68b5483b5753ebc1ccb6d476f7b1216508)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -12965,7 +12970,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  animejs@4.2.2: {}
+  animejs@4.2.2(patch_hash=171f5353695b4337495b7f49e28dae68b5483b5753ebc1ccb6d476f7b1216508): {}
 
   ansi-colors@4.1.3: {}
 


### PR DESCRIPTION
## Problem

At the end of exercises like battle-procedures, some shots sometimes never fade out on the **first** playthrough (see forum-style report: white shot rectangles left on screen). Scrubbing back and forward makes them disappear.

## Root cause (anime.js v4 bug)

Three conditions combine:

1. **Chained tweens enter playback in a dirty state.** Each `timeline.add()` internally ticks the whole timeline to the new child's position, then resets to 0. The reset cannot rewind a tween past its composition predecessor (same element + property, e.g. a shot's fade-out chained after its fade-in), so the fade-out is left internally marked "already at end state".
2. **1ms tweens only get one render chance.** Their whole window falls between engine ticks (~16ms), so the only render opportunity is the "you've passed the end" path, which for a dirty tween hinges on `absoluteTime <= tweenAbsEndTime`.
3. **That comparison mixes rounded and unrounded floats.** `_absoluteStartTime` is rounded to 12 decimals at creation; `absoluteTime` is an unrounded sum at render time. Offsets with float residue (e.g. `1901.0320000000002`) fail the check by ~2e-13 and the tween is skipped permanently.

Scrubbing "fixes" it because scrub jumps exceed anime's 200ms `tickThreshold` and take the forced-render path that bypasses the fragile clause.

## Fix

`pnpm patch` on `animejs@4.2.2`: apply the same `round(..., 12)` to `absoluteTime` in `dist/modules/core/render.js` and `render.cjs`, so both sides of the comparison are quantised identically. (Worth reporting upstream to juliangarnier/anime.)

## Test plan

- Reproduced with a jest harness driving the real anime engine over the battle-procedures scenario: unpatched lingers within two playthroughs; patched is clean across six.
- Full app unit + integration suites pass (1852 tests).
- Manual check in the browser: run battle-procedures to completion a few times and confirm no shots remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)