### PR TITLE
Bump animejs to 4.5.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -62,7 +62,7 @@
     "@stripe/stripe-js": "^8.6.1",
     "@types/react-modal": "^3.16.3",
     "@uiw/codemirror-themes": "^4.25.4",
-    "animejs": "4.2.2",
+    "animejs": "4.5.0",
     "canvas-confetti": "^1.9.4",
     "codemirror": "^6.0.2",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^4.25.4
         version: 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
       animejs:
-        specifier: 4.2.2
-        version: 4.2.2
+        specifier: 4.5.0
+        version: 4.5.0
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -4588,8 +4588,16 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  animejs@4.2.2:
-    resolution: {integrity: sha512-Ys3RuvLdAeI14fsdKCQy7ytu4057QX6Bb7m4jwmfd6iKmUmLquTwk1ut0e4NtRQgCeq/s2Lv5+oMBjz6c7ZuIg==}
+  animejs@4.5.0:
+    resolution: {integrity: sha512-NQimYX+lz8WaXonGS9zVVoviCIAjONeJayxacUditaivYLqyXgGjFKjuyl0aUUhFKm5MriX9ty1TGovNzoJQWA==}
+    peerDependencies:
+      '@types/three': '>=0.150.0'
+      three: '>=0.150.0'
+    peerDependenciesMeta:
+      '@types/three':
+        optional: true
+      three:
+        optional: true
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -12965,7 +12973,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  animejs@4.2.2: {}
+  animejs@4.5.0: {}
 
   ansi-colors@4.1.3: {}
 


### PR DESCRIPTION
Updates `animejs` from 4.2.2 to the latest release (4.5.0).

## Testing
- `pnpm typecheck` passes
- Full app unit + integration suite passes (1852 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)