### PR TITLE
Clarify bouncer-dress-code instructions

### DIFF
--- a/curriculum/src/exercises/bouncer-dress-code/instructions/en.md
+++ b/curriculum/src/exercises/bouncer-dress-code/instructions/en.md
@@ -9,9 +9,9 @@ Your job is to check what the person is wearing alongside their age and decide w
 
 ### The rules
 
-- Anyone in **formal** or **smart** clothes is let in and offered canapés.
-- Adults (18 or over) in formal clothes also get offered champagne.
-- Children (under 18) in any other clothes are allowed in only if they're on the guest list.
+- **Anyone** in **formal** or **smart** clothes is let in (regardless of whether they're on the guest list) and offered canapés.
+- **Adults** (18 or over) in **formal** clothes **also** get offered champagne.
+- **Children** (under 18) in any other clothes are allowed in **only if** they're on the guest list.
 - Everyone else is turned away.
 
 The dress code categories:


### PR DESCRIPTION
Tightens the wording of the door-policy rules in the bouncer-dress-code exercise so the guest-list exception and champagne condition are unambiguous.

Changes (instructions/en.md only):
- **Anyone** in formal/smart clothes is let in *regardless of guest-list status* and offered canapés.
- **Adults** (18+) in **formal** clothes **also** get champagne.
- **Children** (under 18) in other clothes are let in **only if** on the guest list.

Verified against `solution.javascript` and all nine scenario expectations in `scenarios.ts` — the reworded rules match the actual pass/fail logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)