### PR TITLE
Diagnose opaque resource-load promise rejections (#587)

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -21,6 +21,15 @@ if (process.env.NODE_ENV === "production") {
       // Drop aborted-request errors - these happen when the user navigates away
       // while a fetch is still in flight, which is expected, not a bug.
       const exception = event.exception?.values?.[0];
+      // Opaque DOM resource-load rejections. A failed <img>/<audio>/<video> load
+      // (or a media player that wraps loading in a promise) rejects with a raw
+      // `Event` of type "error" that carries no stack, so Sentry can only record
+      // the useless "Event `Event` (type=error) captured as promise rejection".
+      // We re-capture these as a real Error with the failing resource URL in the
+      // unhandledrejection listener below, so drop the stackless originals here.
+      if (exception?.type === "Event" && (exception.value?.includes("(type=error)") ?? false)) {
+        return null;
+      }
       if (
         exception?.type === "RequestAbortedError" ||
         exception?.type === "AbortError" ||
@@ -42,6 +51,26 @@ if (process.env.NODE_ENV === "production") {
       });
       return hasAppFrame ? event : null;
     }
+  });
+
+  // Upgrade opaque DOM resource-load rejections into actionable errors. A failed
+  // <img>/<audio>/<video> load (or a third-party media player that wraps loading
+  // in a promise, e.g. mux-player/hls.js) surfaces as an unhandled rejection whose
+  // `reason` is a raw error `Event` with no stack - Sentry can only record the
+  // non-actionable "Event (type=error) captured as promise rejection" (see #587).
+  // Read the failing element's tag + URL and re-report a real Error so the source
+  // is diagnosable; the beforeSend rule above drops the original opaque event.
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason: unknown = event.reason;
+    if (!(reason instanceof Event) || reason.type !== "error") {
+      return;
+    }
+    const target = reason.target as (Element & { src?: string; currentSrc?: string; href?: string }) | null;
+    const tag = target?.tagName.toLowerCase() ?? "unknown";
+    const url = target?.currentSrc || target?.src || target?.href || "unknown";
+    Sentry.captureException(new Error(`Resource load failed (unhandled rejection): <${tag}> ${url}`), {
+      tags: { resource_tag: tag }
+    });
   });
 }
 


### PR DESCRIPTION
## Problem

Sentry issue [#587](https://github.com/jiki-education/front-end/issues/587) — **"Event \`Event\` (type=error) captured as promise rejection"**, culprit \`/dashboard\`. Escalated: 155 events / 117 users.

A real event shows `mechanism: onunhandledrejection`, a returning user on a plain `/projects → /dashboard` navigation, and **no stack trace**. The root cause is a browser resource-load failure: a failed `<img>`/`<audio>`/`<video>` load — or a third-party media player that wraps loading in a promise (mux-player/hls.js) — rejects with a raw DOM `Event` of type `"error"`. That Event has no JS stack, so Sentry can only record the opaque, non-actionable title, and our `beforeSend` app-frame filter intentionally keeps frameless events. There is nothing in the event to identify which resource failed, which is why it has been unpinnable.

Notably **not** the cause (verified): the recent SVG/asset PRs (#821/#823/#824), the welcome-video Mux player (not shown to returning users), and the sound preloader (`/static/sounds` is root-relative, unaffected by `assetPrefix`, files present).

## Change

`instrumentation-client.ts` only:

1. A global `unhandledrejection` listener that detects an error `Event` reason, reads the failing element's `tagName` + `currentSrc`/`src`/`href`, and re-reports a **real `Error`** carrying that URL (plus a `resource_tag`) — so the source becomes diagnosable.
2. A `beforeSend` rule dropping the original stackless `Event (type=error)` to avoid double-reporting noise.

## Why diagnostic-first

Because the opaque event names no resource, an in-place root-cause fix isn't possible yet. This stops the noise **and** makes the next occurrence report the exact failing URL, which will confirm whether it's an `assets.jiki.io` asset-path regression or something else — turning the real fix into a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)