### PR TITLE
Remove unnecessary optional chaining on Next navigation hooks

### DIFF
--- a/app/components/articles/FilterSidebar.tsx
+++ b/app/components/articles/FilterSidebar.tsx
@@ -13,7 +13,7 @@ interface FilterSidebarProps {
 }
 
 export default function FilterSidebar({ tagSlugs, selectedTag, locale }: FilterSidebarProps) {
-  const pathname = usePathname() ?? "";
+  const pathname = usePathname();
   const routes = useLocaleRoutes();
 
   const buildTagUrl = (tag: ArticleTagSlug | null) => {

--- a/app/components/auth/ConfirmEmailForm.tsx
+++ b/app/components/auth/ConfirmEmailForm.tsx
@@ -15,7 +15,7 @@ export function ConfirmEmailForm() {
   const routes = useLocaleRoutes();
   const dashboardPath = routes.dashboard();
   const searchParams = useSearchParams();
-  const token = searchParams?.get("token") ?? null;
+  const token = searchParams.get("token");
   const router = useRouter();
   const setUser = useAuthStore((state) => state.setUser);
 

--- a/app/components/auth/ExercismCallbackHandler.tsx
+++ b/app/components/auth/ExercismCallbackHandler.tsx
@@ -28,7 +28,7 @@ export function ExercismCallbackHandler() {
     }
     hasStartedRef.current = true;
 
-    const callback = consumeExercismCallback(searchParams?.get("code") ?? null, searchParams?.get("state") ?? null);
+    const callback = consumeExercismCallback(searchParams.get("code"), searchParams.get("state"));
     if (callback.status === "error") {
       setError(callback.message);
       return;

--- a/app/components/auth/ResendConfirmationForm.tsx
+++ b/app/components/auth/ResendConfirmationForm.tsx
@@ -17,7 +17,7 @@ export function ResendConfirmationForm() {
   const { resendConfirmation, isLoading, error, clearError } = useAuthStore();
   const searchParams = useSearchParams();
 
-  const [email, setEmail] = useState(searchParams?.get("email") || "");
+  const [email, setEmail] = useState(searchParams.get("email") || "");
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [successMessage, setSuccessMessage] = useState("");
 

--- a/app/components/delete-account/DeleteAccountConfirmContent.tsx
+++ b/app/components/delete-account/DeleteAccountConfirmContent.tsx
@@ -14,7 +14,7 @@ type Status = "deleting" | "success" | "expired" | "error";
 
 export default function DeleteAccountConfirmContent() {
   const searchParams = useSearchParams();
-  const token = searchParams?.get("token") ?? null;
+  const token = searchParams.get("token");
   const setNoUser = useAuthStore((state) => state.setNoUser);
 
   const [status, setStatus] = useState<Status>("deleting");

--- a/app/lib/auth/useAuth.tsx
+++ b/app/lib/auth/useAuth.tsx
@@ -29,7 +29,7 @@ export function useAuth(): UseAuthReturn {
   const [twoFactorState, setTwoFactorState] = useState<TwoFactorState>({ type: "none" });
   const [googleAuthError, setGoogleAuthError] = useState<string | null>(null);
 
-  const returnTo = searchParams?.get("return_to") ?? null;
+  const returnTo = searchParams.get("return_to");
 
   // Store return_to in sessionStorage on mount so it persists across page navigations
   useEffect(() => {


### PR DESCRIPTION
## Summary

`useSearchParams()` and `usePathname()` are typed non-nullable in the App Router, so ESLint flagged the `?.` optional chains and `?? ""` fallbacks on them as unnecessary conditions (`@typescript-eslint/no-unnecessary-condition`). This drops them to clear the CI lint warnings.

Affected files:
- `components/articles/FilterSidebar.tsx`
- `components/auth/ConfirmEmailForm.tsx`
- `components/auth/ExercismCallbackHandler.tsx`
- `components/auth/ResendConfirmationForm.tsx`
- `components/delete-account/DeleteAccountConfirmContent.tsx`
- `lib/auth/useAuth.tsx`

## Test plan

- `pnpm run lint` clean
- `pnpm typecheck` clean
- Full app test suite passes (1852 tests, via pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)