### PR TITLE
Dedupe external-pricing fetch and stop reporting network noise (JIKI-FRONT-END-5)

### DIFF
--- a/app/components/landing-page/MonthlyPrice.tsx
+++ b/app/components/landing-page/MonthlyPrice.tsx
@@ -40,7 +40,14 @@ export function MonthlyPrice() {
       .then((data) => {
         if (!cancelled) setPrices(data.premium_prices);
       })
-      .catch(reportError);
+      .catch((error: unknown) => {
+        // A rejected fetch (blocked by an extension, dropped connection, or the
+        // visitor navigating away) throws a TypeError. That's expected ambient
+        // noise and the USD fallback already covers it, so don't report it.
+        // A bad HTTP status throws a plain Error and is worth surfacing.
+        if (error instanceof TypeError) return;
+        reportError(error);
+      });
     return () => {
       cancelled = true;
     };

--- a/app/components/landing-page/MonthlyPrice.tsx
+++ b/app/components/landing-page/MonthlyPrice.tsx
@@ -1,26 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { fetchExternalPricing } from "@/lib/api/externalPricing";
-import type { PremiumPrices } from "@/lib/pricing";
-import { reportError } from "@/lib/reportError";
-
-function fractionDigits(currency: string): number {
-  return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
-}
-
-function format(prices: PremiumPrices): string {
-  const currency = prices.currency.toUpperCase();
-  const amount = prices.monthly / Math.pow(10, fractionDigits(currency));
-  return new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency,
-    currencyDisplay: "narrowSymbol",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(amount);
-}
+import { useExternalPremiumPrices } from "@/lib/hooks/useExternalPremiumPrices";
+import { formatMonthlyPrice } from "@/lib/pricing";
 
 /**
  * Renders the Premium monthly price.
@@ -32,26 +14,7 @@ function format(prices: PremiumPrices): string {
  */
 export function MonthlyPrice() {
   const t = useTranslations("landing.monthlyPrice");
-  const [prices, setPrices] = useState<PremiumPrices | null>(null);
+  const prices = useExternalPremiumPrices();
 
-  useEffect(() => {
-    let cancelled = false;
-    fetchExternalPricing()
-      .then((data) => {
-        if (!cancelled) setPrices(data.premium_prices);
-      })
-      .catch((error: unknown) => {
-        // A rejected fetch (blocked by an extension, dropped connection, or the
-        // visitor navigating away) throws a TypeError. That's expected ambient
-        // noise and the USD fallback already covers it, so don't report it.
-        // A bad HTTP status throws a plain Error and is worth surfacing.
-        if (error instanceof TypeError) return;
-        reportError(error);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return <>{prices ? format(prices) : t("fallback")}</>;
+  return <>{prices ? formatMonthlyPrice(prices) : t("fallback")}</>;
 }

--- a/app/components/premium/PublicPremiumPrice.tsx
+++ b/app/components/premium/PublicPremiumPrice.tsx
@@ -1,56 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { fetchExternalPricing } from "@/lib/api/externalPricing";
-import type { PremiumPrices } from "@/lib/pricing";
-import { reportError } from "@/lib/reportError";
-
-function fractionDigits(currency: string): number {
-  return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
-}
-
-function formatMonthly(prices: PremiumPrices): string {
-  const currencyUpper = prices.currency.toUpperCase();
-  const divisor = Math.pow(10, fractionDigits(currencyUpper));
-  const amount = prices.monthly / divisor;
-
-  return new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: currencyUpper,
-    currencyDisplay: "narrowSymbol",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(amount);
-}
+import { useExternalPremiumPrices } from "@/lib/hooks/useExternalPremiumPrices";
+import { formatMonthlyPrice } from "@/lib/pricing";
 
 export function PublicPremiumPrice() {
   const t = useTranslations("premium.publicPrice");
   const user = useAuthStore((state) => state.user);
-  const [publicPrices, setPublicPrices] = useState<PremiumPrices | null>(null);
-
-  useEffect(() => {
-    if (user) {
-      return;
-    }
-    let cancelled = false;
-    fetchExternalPricing()
-      .then((res) => {
-        if (!cancelled) {
-          setPublicPrices(res.premium_prices);
-        }
-      })
-      .catch(reportError);
-    return () => {
-      cancelled = true;
-    };
-  }, [user]);
+  // Authenticated users already carry their geolocated prices on the user
+  // object, so only logged-out visitors need the public pricing lookup.
+  const publicPrices = useExternalPremiumPrices({ enabled: !user });
 
   const prices = user?.premium_prices ?? publicPrices;
   if (!prices) {
     return <>{t("unavailable")}</>;
   }
 
-  return <>{formatMonthly(prices)}</>;
+  return <>{formatMonthlyPrice(prices)}</>;
 }

--- a/app/lib/api/externalPricing.ts
+++ b/app/lib/api/externalPricing.ts
@@ -5,11 +5,25 @@ export interface ExternalPricingResponse {
   premium_prices: PremiumPrices;
 }
 
+let cached: Promise<ExternalPricingResponse> | null = null;
+
 /**
  * Fetch public (unauthenticated) Premium pricing for the visitor.
  * Country is detected by Cloudflare on the API side; falls back to USD.
+ *
+ * The result is memoised so that multiple <MonthlyPrice /> instances on the
+ * same page share a single request. A failed request is not cached, so a later
+ * mount can retry.
  */
-export async function fetchExternalPricing(): Promise<ExternalPricingResponse> {
+export function fetchExternalPricing(): Promise<ExternalPricingResponse> {
+  cached ??= performFetch().catch((error: unknown) => {
+    cached = null;
+    throw error;
+  });
+  return cached;
+}
+
+async function performFetch(): Promise<ExternalPricingResponse> {
   const res = await fetch(getApiUrl("/external/pricing"));
   if (!res.ok) {
     throw new Error(`Failed to fetch external pricing (${res.status})`);

--- a/app/lib/hooks/useExternalPremiumPrices.ts
+++ b/app/lib/hooks/useExternalPremiumPrices.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { fetchExternalPricing } from "@/lib/api/externalPricing";
+import type { PremiumPrices } from "@/lib/pricing";
+import { reportError } from "@/lib/reportError";
+
+/**
+ * Loads the visitor's geolocated Premium pricing from the public
+ * /external/pricing endpoint after hydration. Returns null until it resolves,
+ * so callers render a fallback in the meantime.
+ *
+ * The underlying request is memoised, so multiple mounts on the same page share
+ * a single fetch. Pass `enabled: false` to skip the fetch entirely (e.g. when an
+ * authenticated user's prices are already known).
+ */
+export function useExternalPremiumPrices({ enabled = true }: { enabled?: boolean } = {}): PremiumPrices | null {
+  const [prices, setPrices] = useState<PremiumPrices | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    let cancelled = false;
+    fetchExternalPricing()
+      .then((data) => {
+        if (!cancelled) {
+          setPrices(data.premium_prices);
+        }
+      })
+      .catch((error: unknown) => {
+        // A rejected fetch (blocked by an extension, dropped connection, or the
+        // visitor navigating away) throws a TypeError. That's expected ambient
+        // noise and the fallback already covers it, so don't report it.
+        // A bad HTTP status throws a plain Error and is worth surfacing.
+        if (error instanceof TypeError) {
+          return;
+        }
+        reportError(error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return prices;
+}

--- a/app/lib/pricing.ts
+++ b/app/lib/pricing.ts
@@ -14,6 +14,29 @@ export interface PremiumPrices {
   country_code: string | null;
 }
 
+// Prices arrive as minor units (e.g. cents/pence), so scale by the currency's
+// fraction digits before formatting.
+function currencyFractionDigits(currency: string): number {
+  return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
+}
+
+/**
+ * Formats the monthly Premium price in the visitor's locale, e.g. "£6" or
+ * "$9.99", using the currency's narrow symbol and no trailing zeroes.
+ */
+export function formatMonthlyPrice(prices: PremiumPrices): string {
+  const currency = prices.currency.toUpperCase();
+  const amount = prices.monthly / Math.pow(10, currencyFractionDigits(currency));
+
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    currencyDisplay: "narrowSymbol",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2
+  }).format(amount);
+}
+
 export interface PricingTier {
   id: MembershipTier;
   name: string;

--- a/app/tests/unit/lib/api/externalPricing.test.ts
+++ b/app/tests/unit/lib/api/externalPricing.test.ts
@@ -1,0 +1,60 @@
+import type { fetchExternalPricing as FetchExternalPricing } from "@/lib/api/externalPricing";
+
+jest.mock("@/lib/api/config", () => ({
+  getApiUrl: (path: string) => `https://api.example.test${path}`
+}));
+
+const PRICING = {
+  premium_prices: { currency: "gbp", monthly: 799, annual: 7900, country_code: "GB" }
+};
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+describe("fetchExternalPricing", () => {
+  let fetchExternalPricing: typeof FetchExternalPricing;
+  let mockFetch: jest.Mock;
+
+  beforeEach(async () => {
+    // Reset the module so its in-flight cache is fresh for every test.
+    jest.resetModules();
+    mockFetch = jest.fn();
+    global.fetch = mockFetch;
+    ({ fetchExternalPricing } = await import("@/lib/api/externalPricing"));
+  });
+
+  it("returns the parsed pricing response", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(PRICING));
+
+    const result = await fetchExternalPricing();
+
+    expect(mockFetch).toHaveBeenCalledWith("https://api.example.test/external/pricing");
+    expect(result).toEqual(PRICING);
+  });
+
+  it("shares a single request between concurrent callers", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(PRICING));
+
+    const [a, b] = await Promise.all([fetchExternalPricing(), fetchExternalPricing()]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it("throws with the status when the response is not ok", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(null, false, 503));
+
+    await expect(fetchExternalPricing()).rejects.toThrow("Failed to fetch external pricing (503)");
+  });
+
+  it("does not cache a failed request, so a later call retries", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    await expect(fetchExternalPricing()).rejects.toThrow("Failed to fetch");
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(PRICING));
+    await expect(fetchExternalPricing()).resolves.toEqual(PRICING);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/tests/unit/lib/hooks/useExternalPremiumPrices.test.ts
+++ b/app/tests/unit/lib/hooks/useExternalPremiumPrices.test.ts
@@ -1,0 +1,51 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useExternalPremiumPrices } from "@/lib/hooks/useExternalPremiumPrices";
+import { fetchExternalPricing } from "@/lib/api/externalPricing";
+import { reportError } from "@/lib/reportError";
+
+jest.mock("@/lib/api/externalPricing");
+jest.mock("@/lib/reportError");
+
+const mockFetchExternalPricing = fetchExternalPricing as jest.MockedFunction<typeof fetchExternalPricing>;
+const mockReportError = reportError as jest.MockedFunction<typeof reportError>;
+
+const PRICES = { currency: "gbp", monthly: 799, annual: 7900, country_code: "GB" };
+
+describe("useExternalPremiumPrices", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null then resolves to the fetched prices", async () => {
+    mockFetchExternalPricing.mockResolvedValue({ premium_prices: PRICES });
+
+    const { result } = renderHook(() => useExternalPremiumPrices());
+
+    expect(result.current).toBeNull();
+    await waitFor(() => expect(result.current).toEqual(PRICES));
+  });
+
+  it("does not fetch when disabled", () => {
+    renderHook(() => useExternalPremiumPrices({ enabled: false }));
+
+    expect(mockFetchExternalPricing).not.toHaveBeenCalled();
+  });
+
+  it("does not report a rejected fetch (TypeError network noise)", async () => {
+    mockFetchExternalPricing.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    renderHook(() => useExternalPremiumPrices());
+
+    await waitFor(() => expect(mockFetchExternalPricing).toHaveBeenCalled());
+    expect(mockReportError).not.toHaveBeenCalled();
+  });
+
+  it("reports a real error (bad HTTP status)", async () => {
+    const error = new Error("Failed to fetch external pricing (503)");
+    mockFetchExternalPricing.mockRejectedValue(error);
+
+    renderHook(() => useExternalPremiumPrices());
+
+    await waitFor(() => expect(mockReportError).toHaveBeenCalledWith(error));
+  });
+});

--- a/app/tests/unit/lib/pricing.test.ts
+++ b/app/tests/unit/lib/pricing.test.ts
@@ -2,7 +2,15 @@
  * Tests for pricing configuration
  */
 
-import { getPricingTier, tierIncludes, getAllTiers, PRICING_TIERS, type MembershipTier } from "@/lib/pricing";
+import {
+  getPricingTier,
+  tierIncludes,
+  getAllTiers,
+  formatMonthlyPrice,
+  PRICING_TIERS,
+  type MembershipTier,
+  type PremiumPrices
+} from "@/lib/pricing";
 
 describe("PRICING_TIERS", () => {
   it("defines standard tier correctly", () => {
@@ -116,5 +124,44 @@ describe("getAllTiers", () => {
     const tiers = getAllTiers();
     expect(tiers[0]).toBe(PRICING_TIERS.standard);
     expect(tiers[1]).toBe(PRICING_TIERS.premium);
+  });
+});
+
+describe("formatMonthlyPrice", () => {
+  function prices(overrides: Partial<PremiumPrices>): PremiumPrices {
+    return { currency: "usd", monthly: 999, annual: 9900, country_code: "US", ...overrides };
+  }
+
+  it("formats a two-decimal currency by scaling minor units", () => {
+    // 799 pence -> £7.99
+    const result = formatMonthlyPrice(prices({ currency: "gbp", monthly: 799 }));
+    expect(result).toContain("£");
+    expect(result).toContain("7.99");
+  });
+
+  it("formats a zero-decimal currency without dividing by 100", () => {
+    // JPY has no minor unit, so 500 stays 500, not 5.00
+    const result = formatMonthlyPrice(prices({ currency: "jpy", monthly: 500 }));
+    expect(result).toContain("500");
+    expect(result).not.toContain("5.00");
+  });
+
+  it("drops trailing zeroes on a whole amount", () => {
+    // £6, not £6.00
+    const result = formatMonthlyPrice(prices({ currency: "gbp", monthly: 600 }));
+    expect(result).toContain("6");
+    expect(result).not.toContain(".00");
+  });
+
+  it("accepts a lowercase currency code", () => {
+    // 1050 cents -> €10.50
+    const result = formatMonthlyPrice(prices({ currency: "eur", monthly: 1050 }));
+    expect(result).toContain("10.5");
+  });
+
+  it("uses the narrow currency symbol rather than the code", () => {
+    const result = formatMonthlyPrice(prices({ currency: "usd", monthly: 999 }));
+    expect(result).toContain("$");
+    expect(result).not.toContain("USD");
   });
 });


### PR DESCRIPTION
## Problem

Sentry issue [JIKI-FRONT-END-5](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-5) (`TypeError: Failed to fetch (api.jiki.io)`) — 396 events / 152 users, ongoing.

Two root causes:

1. **Double-fire.** `MonthlyPrice` is mounted twice on the landing page (`WelcomeSection` and `FAQs`), so every view fired `fetchExternalPricing()` twice with no shared request. This matches the identical-timestamp event pairs in Sentry.
2. **Noise reporting.** The pricing fetch is progressive enhancement over a fallback price. A rejected fetch (blocked by an extension, dropped connection, or the visitor navigating away) is expected and already handled by the fallback, but was being reported to Sentry. This happened from **two** components that both call `fetchExternalPricing()`: `MonthlyPrice` and `PublicPremiumPrice`.

## Fix

**Behaviour:**

- **`lib/api/externalPricing.ts`** — memoise the in-flight promise so concurrent callers share one request. A failed request is not cached, so a later mount can retry.
- **Skip reporting rejected fetches** (they throw a `TypeError`) while still surfacing real HTTP errors (the `!res.ok` path throws a plain `Error`).

**Refactor (removes the duplication that caused the noise-filter to drift):**

- **`lib/hooks/useExternalPremiumPrices.ts`** (new) — a shared hook owning the fetch, cancellation, and the network-noise filter in one place. Takes an `enabled` flag so `PublicPremiumPrice` can skip the fetch when a user is logged in.
- **`lib/pricing.ts`** — `formatMonthlyPrice()` replaces the two identical local currency formatters.
- **`MonthlyPrice.tsx` / `PublicPremiumPrice.tsx`** — now thin consumers of the hook + formatter. The noise-filter decision lives in a single spot and can't drift again.

## Why this is noise, not a masked bug

- Endpoint verified healthy: `200` + correct CORS (`access-control-allow-origin: https://jiki.io`) and valid geolocated JSON.
- Errors are smeared evenly across ~40 releases with no spike — the signature of ambient client-side failures, not a regression.
- ~0.6% of landing-page views.

## Tests

- `tests/unit/lib/api/externalPricing.test.ts` — parse, concurrent dedup, HTTP-error throw, retry-after-failure.
- `tests/unit/lib/hooks/useExternalPremiumPrices.test.ts` — resolves prices, skips when disabled, swallows TypeError noise, reports real errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)