### PR TITLE
Stop reporting static-asset load failures as errors

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -67,6 +67,14 @@ if (process.env.NODE_ENV === "production") {
     }
     const target = reason.target as (Element & { src?: string; currentSrc?: string; href?: string }) | null;
     const tag = target?.tagName.toLowerCase() ?? "unknown";
+    // Only media loads (mux-player/hls.js, images, audio) are worth diagnosing here (see #587).
+    // A failed <link> stylesheet or <script> chunk load is transient CDN/network noise - a user
+    // on a flaky connection, or an old page after a deploy replaced the fingerprinted asset - not
+    // an actionable app bug, and the error Event carries no HTTP status to tell 404 from a dropped
+    // connection anyway. Don't re-report those.
+    if (tag !== "img" && tag !== "audio" && tag !== "video") {
+      return;
+    }
     const url = target?.currentSrc || target?.src || target?.href || "unknown";
     Sentry.captureException(new Error(`Resource load failed (unhandled rejection): <${tag}> ${url}`), {
       tags: { resource_tag: tag }


### PR DESCRIPTION
## Problem

Sentry issue [JIKI-FRONT-END-3A](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-3A) escalated to **36 events / 22 users in ~3 hours** (GitHub #833), all reading:

> `Error: Resource load failed (unhandled rejection): <link> https://assets.jiki.io/_next/static/css/4b4222dd1b6fa30b.css`

## Cause

Not an app regression. Every event is from the two releases shipped the day #831 deployed, and the issue's first-seen is the exact minute that release went out. The `unhandledrejection` upgrader added in #831 (for opaque mux-player/hls.js **media** loads, #587) re-reports *any* failed resource load as a real `Error` — including `<link>` stylesheet and `<script>` chunk loads.

Those static-asset failures are transient CDN/network noise: a user on a flaky connection, or an old page after a deploy replaced a fingerprinted asset. The failing CSS hash returns `200` on check, so the file is fine. The error `Event` carries no HTTP status, so we can't even distinguish a 404 from a dropped connection.

## Fix

Scope the upgrader to `img`/`audio`/`video` (the media case #587 was for). `<link>`/`<script>` load failures are now dropped rather than re-reported — combined with the existing `beforeSend` rule that discards the opaque originals, they vanish from Sentry entirely.

Fixes JIKI-FRONT-END-3A

🤖 Generated with [Claude Code](https://claude.com/claude-code)