### PR TITLE
Rename rollTo to moveTo in golf step-at-a-time exercises

### DIFF
--- a/curriculum/src/exercise-categories/golf/GolfExercise.ts
+++ b/curriculum/src/exercise-categories/golf/GolfExercise.ts
@@ -29,9 +29,9 @@ export default class GolfExercise extends VisualExercise {
       description: "rolled the ball one unit to the right"
     },
     {
-      name: "roll_to",
-      func: this.rollTo.bind(this),
-      description: "rolled the ball to the given position"
+      name: "move_to",
+      func: this.moveTo.bind(this),
+      description: "moved the ball to the given position"
     },
     {
       name: "get_shot_length",
@@ -59,7 +59,7 @@ export default class GolfExercise extends VisualExercise {
     executionCtx.fastForward(this.moveDuration);
   }
 
-  rollTo(executionCtx: ExecutionContext, x: Shared.JikiObject, y?: Shared.JikiObject) {
+  moveTo(executionCtx: ExecutionContext, x: Shared.JikiObject, y?: Shared.JikiObject) {
     if (!isNumber(x)) {
       return executionCtx.logicError("x must be a number");
     }

--- a/curriculum/src/exercises/golf-rolling-ball-state/instructions/en.md
+++ b/curriculum/src/exercises/golf-rolling-ball-state/instructions/en.md
@@ -7,7 +7,7 @@ We're back in the world of building a golf game, but this time what we're buildi
 
 Instead of the `roll()` function we had before, we now have a `moveTo(position)` function that moves the ball to a spot instantly.
 
-Now, when the player hits the ball, we could just move it directly to the final place, but it's very unsatisfying seeing it not animate. So instead we want to use `moveTo(position)` lots of time to make it look like it's rolling.
+Now, when the player hits the ball, we could just move it directly to the final place, but it's very unsatisfying seeing it not animate. So instead we want to use `moveTo(position)` lots of times to make it look like it's rolling.
 
 The ball starts at position **28** and needs to reach position **88**.
 

--- a/curriculum/src/exercises/golf-scenarios/Exercise.ts
+++ b/curriculum/src/exercises/golf-scenarios/Exercise.ts
@@ -8,9 +8,9 @@ export default class GolfScenariosExercise extends GolfExercise {
 
   public availableFunctions = [
     {
-      name: "roll_to",
-      func: this.rollTo.bind(this),
-      description: "rolled the ball to position ${arg1}",
+      name: "move_to",
+      func: this.moveTo.bind(this),
+      description: "moved the ball to position ${arg1}",
       arity: 1 as const
     },
     {

--- a/curriculum/src/exercises/golf-scenarios/index.ts
+++ b/curriculum/src/exercises/golf-scenarios/index.ts
@@ -6,10 +6,10 @@ import type { VisualExerciseCore, FunctionInfo } from "../types";
 
 const functions: FunctionInfo[] = [
   {
-    name: "rollTo",
-    signature: "rollTo(x)",
-    description: "Rolls the ball to position **x**.",
-    examples: ["rollTo(30)", "rollTo(50)"],
+    name: "moveTo",
+    signature: "moveTo(x)",
+    description: "Moves the ball to position **x**.",
+    examples: ["moveTo(30)", "moveTo(50)"],
     category: "Movement"
   },
   {

--- a/curriculum/src/exercises/golf-scenarios/instructions/en.md
+++ b/curriculum/src/exercises/golf-scenarios/instructions/en.md
@@ -5,7 +5,7 @@ description: "Roll a ball to the correct spot in different scenarios."
 
 Welcome to your first exercise with scenarios.
 
-We're back at the golf course. In this exercise, you're going to build on the previous exercises but with a new twist. As before you need to roll the ball using the `rollTo(x)` function, moving **one step at a time**, not just jumping it to the end. The ball **starts on the tee at position 28.**
+We're back at the golf course. In this exercise, you're going to build on the previous exercises but with a new twist. As before you need to move the ball using the `moveTo(x)` function, moving **one step at a time**, not just jumping it to the end. The ball **starts on the tee at position 28.**
 
 What's new is that rather than moving a fixed amount, we're going to move a different amount depending on how far the golfer has hit the ball. To get the distance the golfer has hit the ball, you can use the `getShotLength()` function which returns a number.
 

--- a/curriculum/src/exercises/golf-scenarios/llm-metadata.ts
+++ b/curriculum/src/exercises/golf-scenarios/llm-metadata.ts
@@ -18,7 +18,7 @@ export const llmMetadata: LLMMetadata = {
     "roll-and-celebrate": {
       description: `
         The student needs to store getShotLength() in a variable and loop that many times,
-        incrementing x before each rollTo so the ball passes through every position.
+        incrementing x before each moveTo so the ball passes through every position.
 
         The most common trap is hardcoding the loop count to one scenario's value instead of
         using the returned shotLength, which then fails the other scenarios.

--- a/curriculum/src/exercises/golf-scenarios/solution.javascript
+++ b/curriculum/src/exercises/golf-scenarios/solution.javascript
@@ -3,5 +3,5 @@ let shotLength = getShotLength()
 
 repeat(shotLength) {
   x = x + 1
-  rollTo(x)
+  moveTo(x)
 }

--- a/curriculum/src/exercises/golf-scenarios/solution.jiki
+++ b/curriculum/src/exercises/golf-scenarios/solution.jiki
@@ -3,5 +3,5 @@ set shot_length to get_shot_length()
 
 repeat shot_length times do
   change x to x + 1
-  roll_to(x)
+  move_to(x)
 end

--- a/curriculum/src/exercises/golf-scenarios/solution.py
+++ b/curriculum/src/exercises/golf-scenarios/solution.py
@@ -3,4 +3,4 @@ shot_length = get_shot_length()
 
 repeat(shot_length):
     x = x + 1
-    roll_to(x)
+    move_to(x)

--- a/curriculum/src/exercises/golf-shot-checker/Exercise.ts
+++ b/curriculum/src/exercises/golf-shot-checker/Exercise.ts
@@ -8,9 +8,9 @@ export default class GolfShotCheckerExercise extends GolfExercise {
 
   public availableFunctions = [
     {
-      name: "roll_to",
-      func: this.rollTo.bind(this),
-      description: "rolled the ball to position (${arg1}, ${arg2})"
+      name: "move_to",
+      func: this.moveTo.bind(this),
+      description: "moved the ball to position (${arg1}, ${arg2})"
     },
     {
       name: "get_shot_length",

--- a/curriculum/src/exercises/golf-shot-checker/index.ts
+++ b/curriculum/src/exercises/golf-shot-checker/index.ts
@@ -6,10 +6,10 @@ import type { VisualExerciseCore, FunctionInfo } from "../types";
 
 const functions: FunctionInfo[] = [
   {
-    name: "rollTo",
-    signature: "rollTo(x, y)",
-    description: "Rolls the ball to position **(x, y)**.",
-    examples: ["rollTo(30, 75)", "rollTo(50, 84)"],
+    name: "moveTo",
+    signature: "moveTo(x, y)",
+    description: "Moves the ball to position **(x, y)**.",
+    examples: ["moveTo(30, 75)", "moveTo(50, 84)"],
     category: "Movement"
   },
   {

--- a/curriculum/src/exercises/golf-shot-checker/instructions/en.md
+++ b/curriculum/src/exercises/golf-shot-checker/instructions/en.md
@@ -5,7 +5,7 @@ description: "Work out whether a golf shot landed close enough to sink."
 
 Welcome back to the golf course. So far you've only been rolling the ball horizontally. When it got to the hole, it just sat above it. Now we're going to actually animate it down into the hole.
 
-The first change is that the `rollTo` function now has inputs for `x` and `y`. Just like before you need to roll it one step at a time, not just jump it to the end. But this time, if the golfer gets the ball in the hole, you need to animate that final part too, moving the ball down into the hole after it's reached the right spot.
+The first change is that the `moveTo` function now has inputs for `x` and `y`. Just like before you need to roll it one step at a time, not just jump it to the end. But this time, if the golfer gets the ball in the hole, you need to animate that final part too, moving the ball down into the hole after it's reached the right spot.
 
 Then finally, **if the ball landed in the hole**, once it's rolled to the bottom, it's time to celebrate, so shoot of some fireworks using the `fireFireworks()` function.
 

--- a/curriculum/src/exercises/golf-shot-checker/llm-metadata.ts
+++ b/curriculum/src/exercises/golf-shot-checker/llm-metadata.ts
@@ -20,7 +20,7 @@ export const llmMetadata: LLMMetadata = {
         the shot lands in the hole. Suggest getting the horizontal movement working first.
 
         Watch for: combining the two range bounds into one condition, off-by-one errors in the
-        roll count, and forgetting to update x/y before each rollTo (jumping instead of stepping).
+        roll count, and forgetting to update x/y before each moveTo (jumping instead of stepping).
       `
     }
   }

--- a/curriculum/src/exercises/golf-shot-checker/solution.javascript
+++ b/curriculum/src/exercises/golf-shot-checker/solution.javascript
@@ -4,13 +4,13 @@ let shotLength = getShotLength()
 
 repeat(shotLength) {
   x = x + 1
-  rollTo(x, y)
+  moveTo(x, y)
 }
 
 if (shotLength >= 58 && shotLength <= 62) {
   repeat(9) {
     y = y + 1
-    rollTo(x, y)
+    moveTo(x, y)
   }
   fireFireworks()
 }

--- a/curriculum/src/exercises/golf-shot-checker/solution.jiki
+++ b/curriculum/src/exercises/golf-shot-checker/solution.jiki
@@ -4,13 +4,13 @@ set shot_length to get_shot_length()
 
 repeat shot_length times do
   change x to x + 1
-  roll_to(x, y)
+  move_to(x, y)
 end
 
 if shot_length >= 58 and shot_length <= 62 do
   repeat 9 times do
     change y to y + 1
-    roll_to(x, y)
+    move_to(x, y)
   end
   fire_fireworks()
 end

--- a/curriculum/src/exercises/golf-shot-checker/solution.py
+++ b/curriculum/src/exercises/golf-shot-checker/solution.py
@@ -4,10 +4,10 @@ shot_length = get_shot_length()
 
 repeat(shot_length):
     x = x + 1
-    roll_to(x, y)
+    move_to(x, y)
 
 if shot_length >= 58 and shot_length <= 62:
     repeat(9):
         y = y + 1
-        roll_to(x, y)
+        move_to(x, y)
     fire_fireworks()


### PR DESCRIPTION
The `golf-scenarios` and `golf-shot-checker` exercises ask students to move the ball one step at a time via a positional function. This renames that function from `rollTo` to `moveTo` (and the shared `GolfExercise` method), sweeping solutions, instructions, and llm-metadata to match.

The relative `roll()` in `golf-rolling-ball-loop` is unchanged (it's a no-arg relative step, not a `rollTo`), and `golf-rolling-ball-state` already used `moveTo`.

Typecheck clean; all 674 curriculum tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)