### PR TITLE
Add Shift+Arrow breakpoint stepping to the scrubber

### DIFF
--- a/app/.context/coding-exercise/scrubber-implementation.md
+++ b/app/.context/coding-exercise/scrubber-implementation.md
@@ -88,6 +88,8 @@ Handled in `ScrubberInput` (the focused slider), routed to orchestrator navigati
 
 - **Arrow Left**: Previous frame (`goToPrevFrame`)
 - **Arrow Right**: Next frame (`goToNextFrame`)
+- **Shift + Arrow Left**: Previous breakpoint (`goToPrevBreakpoint`)
+- **Shift + Arrow Right**: Next breakpoint (`goToNextBreakpoint`)
 - **Arrow Down**: First frame (`goToFirstFrame`)
 - **Arrow Up**: Last frame (`goToLastFrame`)
 - **Spacebar**: Play/pause (`play`/`pause`)

--- a/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
+++ b/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
@@ -133,12 +133,21 @@ function handleOnKeyDown(event: React.KeyboardEvent, orchestrator: Orchestrator,
       // Preventing default stops the range input from also nudging itself,
       // which would fight the frame we're snapping to.
       event.preventDefault();
-      orchestrator.goToPrevFrame();
+      // Holding Shift steps between breakpoints instead of individual frames.
+      if (event.shiftKey) {
+        orchestrator.goToPrevBreakpoint();
+      } else {
+        orchestrator.goToPrevFrame();
+      }
       break;
 
     case "ArrowRight":
       event.preventDefault();
-      orchestrator.goToNextFrame();
+      if (event.shiftKey) {
+        orchestrator.goToNextBreakpoint();
+      } else {
+        orchestrator.goToNextFrame();
+      }
       break;
 
     case "ArrowDown":

--- a/app/tests/unit/components/coding-exercise/scrubber/ScrubberInput.test.tsx
+++ b/app/tests/unit/components/coding-exercise/scrubber/ScrubberInput.test.tsx
@@ -43,6 +43,8 @@ function createMockOrchestrator(): Orchestrator {
     goToNextFrame: jest.fn(),
     goToFirstFrame: jest.fn(),
     goToLastFrame: jest.fn(),
+    goToPrevBreakpoint: jest.fn(),
+    goToNextBreakpoint: jest.fn(),
     snapToNearestFrame: jest.fn()
   } as unknown as Orchestrator;
 }
@@ -392,6 +394,26 @@ describe("ScrubberInput Component", () => {
       fireEvent.keyDown(input, { key: "ArrowRight" });
 
       expect(mockOrchestrator.goToNextFrame).toHaveBeenCalledTimes(1);
+    });
+
+    it("Shift+ArrowLeft goes to the previous breakpoint", () => {
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
+
+      fireEvent.keyDown(input, { key: "ArrowLeft", shiftKey: true });
+
+      expect(mockOrchestrator.goToPrevBreakpoint).toHaveBeenCalledTimes(1);
+      expect(mockOrchestrator.goToPrevFrame).not.toHaveBeenCalled();
+    });
+
+    it("Shift+ArrowRight goes to the next breakpoint", () => {
+      const mockOrchestrator = createMockOrchestrator();
+      const input = renderScrubber(mockOrchestrator);
+
+      fireEvent.keyDown(input, { key: "ArrowRight", shiftKey: true });
+
+      expect(mockOrchestrator.goToNextBreakpoint).toHaveBeenCalledTimes(1);
+      expect(mockOrchestrator.goToNextFrame).not.toHaveBeenCalled();
     });
 
     it("ArrowDown goes to the first frame", () => {


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts for breakpoint stepping on the scrubber, matching the existing frame-stepping arrow keys:

- **Shift + Arrow Left** → previous breakpoint (`goToPrevBreakpoint`)
- **Shift + Arrow Right** → next breakpoint (`goToNextBreakpoint`)

Plain arrows are unchanged (frame-by-frame stepping). Shift always means breakpoint, with no fallback to frame stepping. When there's no breakpoint in the pressed direction the existing `moveToFrame(undefined)` behaviour applies (pause + show info widget, no seek), which mirrors how the `‹`/`›` breakpoint stepper buttons already behave.

The breakpoint navigation logic already existed on the orchestrator and backed the `BreakpointStepperButtons`; this PR only wires it to the keyboard.

## Changes

- `ScrubberInput.tsx` — branch on `event.shiftKey` in the `ArrowLeft`/`ArrowRight` cases of `handleOnKeyDown`.
- `ScrubberInput.test.tsx` — two new tests asserting Shift+Arrow routes to the breakpoint methods (and not the frame ones); added the methods to the mock orchestrator.
- `scrubber-implementation.md` — documented the new shortcuts.

## Testing

- `ScrubberInput` unit tests pass (23).
- Full app suite passes (1867) via pre-commit.
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)