### PR TITLE
Clarify gold-panning instructions and add running-total hint

### DIFF
--- a/curriculum/src/exercises/gold-panning/instructions/en.md
+++ b/curriculum/src/exercises/gold-panning/instructions/en.md
@@ -7,8 +7,10 @@ Before California was the home of tech, it was the home of gold! Over 300,000 pe
 
 In this exercise, you're building a robot that's going out to pan for gold.
 
-You have a `pan()` function that returns the amount of nuggets you find each time. And you have a `sell(numberOfNuggets)` function that you can use to sell the total number of nuggets you find.
+You have a `pan()` function, which you can use to pan some gold out of the water. The function returns the amount of nuggets you find.
 
-Your robot follows the same pattern each time. It heads to the river, pans **5 times** and then sells the total number of nuggets it finds in these 5 pans at the end.
+You also have a `sell(numberOfNuggets)` function that you can use to sell the total number of nuggets you find.
+
+Your robot has enough capacity to pan a few times before selling. You need to write code so that it heads to the river, pans **5 times**, keeping track of how much gold it's collected as it goes, and then sells the total number of nuggets it has found (across all 5 pans at the end).
 
 Solve the puzzle in **5 lines of code** (or less)!

--- a/curriculum/src/exercises/gold-panning/metadata.json
+++ b/curriculum/src/exercises/gold-panning/metadata.json
@@ -7,6 +7,10 @@
       "answer": "You need to sell ALL the gold you find in the 5 pans in one go at the end, not selling after each pan."
     },
     {
+      "question": "I am using pan multiple times but I don't know how to keep track of how much I have.",
+      "answer": "Think about what you've learned in recent video lessons. You need to use a variable to keep track of the **total** amount of gold that you have collected across **all** the pans together."
+    },
+    {
       "question": "I've got it working, but I can't get down to 5 lines.",
       "answer": "Do you have repetitive code in your solution? If so, what can we use to reduce that repetitiveness?"
     },


### PR DESCRIPTION
## What

Two content-only tweaks to the `gold-panning` exercise:

- **Instructions**: reworded so students are explicitly guided to keep a running total across all 5 pans, then sell once at the end (rather than just being told the robot "follows the same pattern").
- **Hint**: added a new hint for students who are calling `pan()` multiple times but don't know how to track their accumulated haul, pointing them at the variable/accumulator concept.

## Notes

Swept the sibling files (`llm-metadata.ts`, `scenarios.ts`, `solution.*`, existing hints) — all already describe the running-total-then-sell framing, so no further changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)