### PR TITLE
Add locale machinery for es-ES/es-419/pt-PT/pt-BR content locales

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -129,27 +129,56 @@ These render English regardless of locale and are intentionally out of the chrom
 
 ## Locale Configuration
 
-Supported locales are defined in `lib/locales.ts`:
+Locales are defined in `lib/locales.ts`:
 
-```typescript
-export const SUPPORTED_LOCALES = ["en", "hu"] as const;
-export type Locale = (typeof SUPPORTED_LOCALES)[number];
-export const DEFAULT_LOCALE: Locale = "en";
-```
+- `ALL_LOCALES` — every locale the codebase knows about; the `Locale` type and message
+  catalogs (`messages/*.json`) are authored against this set.
+- `SUPPORTED_LOCALES` — the locales actually served in this environment. Production ships
+  `en` only; `next dev` serves the full set.
+- `DEFAULT_LOCALE` — `en`.
 
 ## URL Structure
 
 - **Default locale (English)**: Served at naked URLs (`/blog`, `/articles`)
 - **Non-default locales**: Served at locale-prefixed URLs (`/hu/blog`, `/hu/articles`)
 - **English locale prefix**: Redirects to naked URLs (`/en/blog` → `/blog`)
+- **Miscased locale segments**: 308 to the canonical casing (`/HU/blog` → `/hu/blog`,
+  `/pt-br/x` → `/pt-BR/x`). URL paths are case-sensitive, so the canonical BCP-47-cased slug
+  is the only URL that serves content; `resolveLocaleRouting` normalizes known locale
+  segments only (never a blanket lowercase). A miscased default-locale prefix goes straight
+  to the naked URL in a single hop (`/EN/blog` → `/blog`).
+- **Region suffixes**: a slug carries a region suffix only when the language has more than
+  one live content variant (`/es-ES/`, `/es-419/`, `/pt-PT/`, `/pt-BR/`); single-variant
+  languages stay bare (`/hu/`).
+
+## Multi-Variant Languages (Spanish, Portuguese)
+
+Some languages ship more than one content variant. The canonical ids (matching the API's
+`I18n::SUPPORTED_LOCALES`) are `es-ES` (Peninsular), `es-419` (neutral Latin American),
+`pt-PT` and `pt-BR`. These are not yet in `ALL_LOCALES` — the machinery below is already
+built and tested for them (`tests/unit/lib/i18n/futureLocales.test.ts` runs it against the
+future set), so going live is just the "Adding a New Locale" steps.
+
+- **Accept-Language negotiation** (`LANGUAGE_VARIANTS` in `lib/i18n/localeBanner.ts`):
+  Chromium sends `es-419` directly but Firefox/Safari send country codes (`es-CL`, `es-AR`),
+  so each tag resolves exact-first, then collapses by region (bare `es` → `es-419`, region
+  `ES` → `es-ES`, any other region → `es-419`; bare `pt` → `pt-BR`, unlisted pt regions →
+  `pt-PT`). This mirrors the API's `User::DetermineLocale` — keep the two tables in sync.
+  The same resolution drives the locale banner and the anonymous cache bucket.
+- **hreflang** (`hreflangLocale` in `lib/seo/alternates.ts`): Google only accepts
+  ISO-3166-1 alpha-2 regions, so `es-419` (a UN M.49 code) collapses to generic `es` in
+  hreflang keys. URLs, `<html lang>` and everything else keep the full internal id. Page
+  metadata and the sitemap share `alternateLanguages`, so the mapping lives in one place.
 
 ## Adding a New Locale
 
 When adding a new locale, you must:
 
-1. Add the locale code to `SUPPORTED_LOCALES` in `lib/locales.ts`
-2. Add translated content markdown files in the content package
-3. **Generate a search index for the new locale** - The content generation script automatically creates search indexes per locale at `public/static/search/articles-{locale}.json`. Run `pnpm run content:generate` after adding content.
+1. Add the locale code to `ALL_LOCALES` in `lib/locales.ts` (canonical BCP-47 casing, e.g.
+   `pt-BR`)
+2. Add its message catalog `messages/{locale}.json` (structurally identical to `en.json`)
+3. Add translated content markdown files in the content package
+4. **Generate a search index for the new locale** - The content generation script automatically creates search indexes per locale at `public/static/search/articles-{locale}.json`. Run `pnpm run content:generate` after adding content.
 
 ## Search Indexes
 

--- a/app/lib/i18n/config.ts
+++ b/app/lib/i18n/config.ts
@@ -62,6 +62,17 @@ export function isSupportedLocale(value: string | undefined | null): value is Lo
   return value != null && (SUPPORTED_LOCALES as readonly string[]).includes(value);
 }
 
+/**
+ * The canonically-cased supported locale matching `value` case-insensitively
+ * (e.g. "pt-br" -> "pt-BR"), or undefined when it isn't a locale at all. URL
+ * paths are case-sensitive (RFC 3986), so a miscased locale segment isn't a
+ * page of its own; middleware uses this to 308 it to the canonical casing.
+ */
+export function matchLocaleIgnoringCase(value: string): Locale | undefined {
+  const lower = value.toLowerCase();
+  return SUPPORTED_LOCALES.find((locale) => locale.toLowerCase() === lower);
+}
+
 export function normalizeLocale(value: string | undefined | null): Locale {
   return isSupportedLocale(value) ? value : DEFAULT_LOCALE;
 }

--- a/app/lib/i18n/localeBanner.ts
+++ b/app/lib/i18n/localeBanner.ts
@@ -84,7 +84,10 @@ export function localeCacheBucket(acceptLanguage: string | null): string {
 
 /**
  * First supported locale in an Accept-Language header, honouring its ordering.
- * Tries an exact match then the base language (e.g. "pt-BR" -> "pt").
+ * Each tag is fully resolved (an exact case-normalized match, else its
+ * region-collapsed content variant / base language) before moving on, so a later
+ * exact match never leapfrogs an earlier tag that already collapses to something
+ * supported.
  */
 export function firstSupportedLanguage(acceptLanguage: string): Locale | undefined {
   const tags = acceptLanguage
@@ -99,13 +102,79 @@ export function firstSupportedLanguage(acceptLanguage: string): Locale | undefin
     .sort((a, b) => b.quality - a.quality);
 
   for (const { tag } of tags) {
-    if (isSupportedLocale(tag)) {
-      return tag;
-    }
-    const base = tag.split("-")[0];
-    if (isSupportedLocale(base)) {
-      return base;
+    const resolved = resolveTag(tag);
+    if (resolved != null) {
+      return resolved;
     }
   }
   return undefined;
+}
+
+/**
+ * Some languages ship more than one content variant, and which one a browser
+ * gets depends on the region in its tag. Maps each such language to:
+ * - `bare`: the variant for a region-less tag (e.g. "pt" -> pt-BR)
+ * - `regions`: explicit region -> variant overrides
+ * - `fallback`: the variant for any region not listed above
+ *
+ * Chromium sends "es-419" directly, but Firefox and Safari send country codes
+ * ("es-CL", "es-AR"), so every non-ES region must collapse to the Latin American
+ * variant. A language absent here simply collapses to its base language.
+ *
+ * Mirrors the API's User::DetermineLocale LANGUAGE_VARIANTS — keep them in sync.
+ */
+const LANGUAGE_VARIANTS: Record<
+  string,
+  { bare: string; regions: Record<string, string>; fallback: string } | undefined
+> = {
+  pt: { bare: "pt-BR", regions: { BR: "pt-BR" }, fallback: "pt-PT" },
+  es: { bare: "es-419", regions: { ES: "es-ES" }, fallback: "es-419" }
+};
+
+/** Resolve one Accept-Language tag to a supported locale, or undefined. */
+function resolveTag(tag: string): Locale | undefined {
+  const parsed = parseTag(tag);
+  if (parsed == null) {
+    return undefined;
+  }
+  if (isSupportedLocale(parsed.canonical)) {
+    return parsed.canonical;
+  }
+  const collapsed = collapseTag(parsed.language, parsed.region);
+  if (isSupportedLocale(collapsed)) {
+    return collapsed;
+  }
+  return undefined;
+}
+
+/** The content variant (or bare base language) a language+region collapses to. */
+function collapseTag(language: string, region: string | undefined): string {
+  const variants = LANGUAGE_VARIANTS[language];
+  if (variants == null) {
+    return language;
+  }
+  if (region == null) {
+    return variants.bare;
+  }
+  return variants.regions[region] ?? variants.fallback;
+}
+
+/**
+ * Split a tag into language/region/canonical, normalizing case since
+ * Accept-Language isn't case-stable ("pt-br", "ES"): language lowercased, region
+ * uppercased. Region is the first 2-alpha or 3-digit subtag, so script subtags
+ * (the "Latn" in "es-Latn-MX") are skipped. Undefined for a language-less tag.
+ */
+function parseTag(tag: string): { language: string; region: string | undefined; canonical: string } | undefined {
+  const parts = tag.split("-");
+  const language = parts[0]?.toLowerCase();
+  if (!language) {
+    return undefined;
+  }
+  const region = parts
+    .slice(1)
+    .find((part) => /^([A-Za-z]{2}|\d{3})$/.test(part))
+    ?.toUpperCase();
+  const canonical = region != null ? `${language}-${region}` : language;
+  return { language, region, canonical };
 }

--- a/app/lib/i18n/localeRouting.ts
+++ b/app/lib/i18n/localeRouting.ts
@@ -1,4 +1,10 @@
-import { DEFAULT_LOCALE, isLocalizableBase, isSupportedLocale, stripLocalePrefix } from "./config";
+import {
+  DEFAULT_LOCALE,
+  isLocalizableBase,
+  isSupportedLocale,
+  matchLocaleIgnoringCase,
+  stripLocalePrefix
+} from "./config";
 
 /**
  * - `rewrite`: serve `target` internally while keeping the visible URL naked (the
@@ -22,6 +28,20 @@ export type LocaleRouting =
 export function resolveLocaleRouting(pathname: string): LocaleRouting {
   const segments = pathname.split("/");
   const first = segments[1];
+
+  // A miscased locale segment (/HU, /pt-br) is not a page of its own: 308 it to
+  // its canonical form so mistyped inbound links neither 404 nor mint duplicate
+  // URLs. Resolving the corrected path again collapses double hops (e.g. /EN/blog
+  // goes straight to /blog, not via /en/blog). Bounded to known locale segments;
+  // nothing else is case-normalized.
+  if (first && !isSupportedLocale(first)) {
+    const canonical = matchLocaleIgnoringCase(first);
+    if (canonical != null) {
+      const normalized = ["", canonical, ...segments.slice(2)].join("/");
+      const rerouted = resolveLocaleRouting(normalized);
+      return { action: "redirect", target: rerouted.action === "redirect" ? rerouted.target : normalized };
+    }
+  }
 
   if (isSupportedLocale(first)) {
     const base = stripLocalePrefix(pathname);

--- a/app/lib/seo/alternates.ts
+++ b/app/lib/seo/alternates.ts
@@ -27,16 +27,28 @@ export function buildAlternates(localelessPath: string, currentLocale: Locale): 
 /**
  * The reciprocal hreflang map for a locale-less path: one absolute URL per
  * supported locale plus `x-default` (the default-locale URL). Shared by page
- * metadata and the sitemap so the two never drift.
+ * metadata and the sitemap so the two never drift. Keys are hreflang values
+ * (see `hreflangLocale`); URL paths always carry the full internal locale id.
  */
 export function alternateLanguages(localelessPath: string): Record<string, string> {
   const absolute = (locale: Locale) => `${SITE_URL}${swapLocaleInPath(localelessPath, locale)}`;
 
   const languages: Record<string, string> = { "x-default": absolute(DEFAULT_LOCALE) };
   for (const locale of SUPPORTED_LOCALES) {
-    languages[locale] = absolute(locale);
+    languages[hreflangLocale(locale)] = absolute(locale);
   }
   return languages;
+}
+
+// Google's hreflang accepts only ISO-639-1 language + ISO-3166-1 alpha-2 region
+// subtags; UN M.49 bloc codes like the 419 in es-419 are silently ignored. Ids
+// without a valid hreflang form collapse to the nearest valid one here. Only the
+// hreflang key collapses — URLs and <html lang> keep the full internal id.
+const HREFLANG_OVERRIDES: Record<string, string> = { "es-419": "es" };
+
+/** The Google-valid hreflang value for an internal locale id. */
+export function hreflangLocale(locale: Locale): string {
+  return HREFLANG_OVERRIDES[locale] ?? locale;
 }
 
 /**

--- a/app/tests/unit/lib/i18n/futureLocales.test.ts
+++ b/app/tests/unit/lib/i18n/futureLocales.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The es/pt content locales (es-ES, es-419, pt-PT, pt-BR) aren't served yet —
+ * lib/locales.ts still ships en/hu — but the locale machinery (routing, hreflang,
+ * Accept-Language negotiation) must already be correct for them so going live is
+ * just adding the locale + its catalog. These tests run that machinery against
+ * the future set by mocking the locale config.
+ *
+ * The negotiation cases mirror the API's User::DetermineLocale acceptance oracle
+ * (jiki-education/api test/commands/user/determine_locale_test.rb) — keep them in
+ * sync.
+ */
+jest.mock("@/lib/locales", () => {
+  const ALL_LOCALES = ["en", "hu", "es-ES", "es-419", "pt-PT", "pt-BR"] as const;
+  return { ALL_LOCALES, DEFAULT_LOCALE: "en", SUPPORTED_LOCALES: ALL_LOCALES };
+});
+
+import { resolveLocaleRouting } from "@/lib/i18n/localeRouting";
+import { firstSupportedLanguage, localeCacheBucket, resolveBannerOffer } from "@/lib/i18n/localeBanner";
+import { alternateLanguages, hreflangLocale } from "@/lib/seo/alternates";
+
+const SITE = "https://jiki.io";
+
+describe("routing for region-suffixed locales", () => {
+  it("passes canonical-cased locale paths through to [locale]", () => {
+    expect(resolveLocaleRouting("/es-419/blog")).toEqual({ action: "none" });
+    expect(resolveLocaleRouting("/es-ES/blog/my-post")).toEqual({ action: "none" });
+    expect(resolveLocaleRouting("/pt-BR")).toEqual({ action: "none" });
+    expect(resolveLocaleRouting("/pt-PT/premium")).toEqual({ action: "none" });
+  });
+
+  it("308s miscased locale segments to the canonical BCP-47 casing", () => {
+    expect(resolveLocaleRouting("/es-es/blog")).toEqual({ action: "redirect", target: "/es-ES/blog" });
+    expect(resolveLocaleRouting("/ES-419/blog")).toEqual({ action: "redirect", target: "/es-419/blog" });
+    expect(resolveLocaleRouting("/pt-br/blog/my-post")).toEqual({ action: "redirect", target: "/pt-BR/blog/my-post" });
+    expect(resolveLocaleRouting("/Pt-Br")).toEqual({ action: "redirect", target: "/pt-BR" });
+  });
+
+  it("leaves unknown region variants alone (not a supported locale in any casing)", () => {
+    expect(resolveLocaleRouting("/es-mx/blog")).toEqual({ action: "none" });
+    expect(resolveLocaleRouting("/es/blog")).toEqual({ action: "none" });
+  });
+});
+
+describe("hreflang emission", () => {
+  it("collapses es-419 to generic es (Google rejects UN M.49 region codes)", () => {
+    expect(hreflangLocale("es-419" as never)).toBe("es");
+  });
+
+  it("passes ISO-valid ids through untouched", () => {
+    expect(hreflangLocale("es-ES" as never)).toBe("es-ES");
+    expect(hreflangLocale("pt-PT" as never)).toBe("pt-PT");
+    expect(hreflangLocale("pt-BR" as never)).toBe("pt-BR");
+    expect(hreflangLocale("en")).toBe("en");
+  });
+
+  it("keys the alternates map by hreflang value while URLs keep the internal id", () => {
+    expect(alternateLanguages("/blog/hello")).toEqual({
+      "x-default": `${SITE}/blog/hello`,
+      en: `${SITE}/blog/hello`,
+      hu: `${SITE}/hu/blog/hello`,
+      "es-ES": `${SITE}/es-ES/blog/hello`,
+      es: `${SITE}/es-419/blog/hello`,
+      "pt-PT": `${SITE}/pt-PT/blog/hello`,
+      "pt-BR": `${SITE}/pt-BR/blog/hello`
+    });
+  });
+
+  it("never emits es-419 as an hreflang key", () => {
+    expect(Object.keys(alternateLanguages("/premium"))).not.toContain("es-419");
+  });
+});
+
+describe("Accept-Language negotiation (API acceptance oracle)", () => {
+  it.each([
+    ["pt-BR", "pt-BR"], // exact
+    ["pt-PT", "pt-PT"], // exact
+    ["pt", "pt-BR"], // bare pt -> Brazilian (CLDR)
+    ["pt-MZ", "pt-PT"], // unlisted pt region -> European fallback
+    ["es-ES, en", "es-ES"], // Spain -> Peninsular (exact match)
+    ["es", "es-419"], // bare es -> Latin American (larger audience)
+    ["es-MX, es-419, en", "es-419"], // es-MX collapses straight to es-419
+    ["es-AR, en", "es-419"], // Latin American region
+    ["es-CL, en", "es-419"], // Firefox/Safari send country codes, not es-419
+    ["es-PE, en", "es-419"], // ditto
+    ["es-419", "es-419"], // exact (Chromium sends this directly)
+    ["es-ES, es-MX", "es-ES"], // first tag resolves exactly and wins
+    ["es-es", "es-ES"], // case-normalized before matching
+    ["ES-419", "es-419"], // ditto
+    ["es-Latn-MX", "es-419"], // script subtag skipped, region still found
+    ["it-IT, hu, en", "hu"], // it unsupported, next preference
+    ["es-CL;q=0.9, es-ES;q=0.8", "es-419"] // q-ordering respected before resolving
+  ])("%s -> %s", (header, expected) => {
+    expect(firstSupportedLanguage(header)).toBe(expected);
+  });
+
+  it("returns undefined when nothing matches (caller applies the default)", () => {
+    expect(firstSupportedLanguage("xx-YY")).toBeUndefined();
+  });
+});
+
+describe("banner offer and cache bucket for variant locales", () => {
+  it("offers es-419 (with its URL) to a LatAm country-code browser on an English page", () => {
+    expect(resolveBannerOffer({ pathname: "/blog/x", isAuthed: false, acceptLanguage: "es-CL,es;q=0.9" })).toEqual({
+      offered: "es-419",
+      current: "en",
+      href: "/es-419/blog/x"
+    });
+  });
+
+  it("buckets the anonymous cache by the resolved variant", () => {
+    expect(localeCacheBucket("es-CL,en;q=0.8")).toBe("es-419");
+    expect(localeCacheBucket("pt")).toBe("pt-BR");
+  });
+});

--- a/app/tests/unit/lib/i18n/localeBanner.test.ts
+++ b/app/tests/unit/lib/i18n/localeBanner.test.ts
@@ -68,6 +68,11 @@ describe("firstSupportedLanguage", () => {
     expect(firstSupportedLanguage("hu-HU,en;q=0.9")).toBe("hu");
   });
 
+  it("normalizes tag casing (Accept-Language isn't case-stable)", () => {
+    expect(firstSupportedLanguage("HU")).toBe("hu");
+    expect(firstSupportedLanguage("hu-hu")).toBe("hu");
+  });
+
   it("returns undefined when nothing is supported", () => {
     expect(firstSupportedLanguage("de,fr,pt-BR")).toBeUndefined();
   });

--- a/app/tests/unit/lib/i18n/localeRouting.test.ts
+++ b/app/tests/unit/lib/i18n/localeRouting.test.ts
@@ -116,6 +116,34 @@ describe("resolveLocaleRouting", () => {
     });
   });
 
+  describe("miscased locale segments (308 to the canonical casing)", () => {
+    it("redirects a miscased non-default locale to its canonical casing", () => {
+      expect(resolveLocaleRouting("/HU/blog")).toEqual({ action: "redirect", target: "/hu/blog" });
+      expect(resolveLocaleRouting("/Hu/articles/my-article")).toEqual({
+        action: "redirect",
+        target: "/hu/articles/my-article"
+      });
+    });
+
+    it("redirects the miscased localized home to its canonical casing", () => {
+      expect(resolveLocaleRouting("/HU")).toEqual({ action: "redirect", target: "/hu" });
+    });
+
+    it("redirects a miscased default-locale prefix straight to the naked URL (single hop)", () => {
+      expect(resolveLocaleRouting("/EN/blog")).toEqual({ action: "redirect", target: "/blog" });
+      expect(resolveLocaleRouting("/EN")).toEqual({ action: "redirect", target: "/" });
+    });
+
+    it("normalizes the casing even for non-localizable paths", () => {
+      expect(resolveLocaleRouting("/HU/dashboard")).toEqual({ action: "redirect", target: "/hu/dashboard" });
+    });
+
+    it("leaves segments that aren't a locale in any casing alone", () => {
+      expect(resolveLocaleRouting("/XX/blog")).toEqual({ action: "none" });
+      expect(resolveLocaleRouting("/HUNGARY/blog")).toEqual({ action: "none" });
+    });
+  });
+
   describe("non-localizable paths (untouched)", () => {
     it("leaves app routes alone", () => {
       expect(resolveLocaleRouting("/dashboard")).toEqual({ action: "none" });


### PR DESCRIPTION
## What

Front-end counterpart to [jiki-education/api#522](https://github.com/jiki-education/api/pull/522). Builds all the locale *machinery* for the multi-variant Spanish/Portuguese content locales (`es-ES`, `es-419`, `pt-PT`, `pt-BR`) while **en/hu stay the only served locales** — `lib/locales.ts` is untouched and no message catalogs are added. When the locales go live, the remaining steps are just: add the id to `ALL_LOCALES`, add its catalog, add content.

## Changes

- **308 case normalization** (`lib/i18n/localeRouting.ts`, new `matchLocaleIgnoringCase` in `lib/i18n/config.ts`): a miscased locale segment (`/HU/blog`, `/pt-br/x`) 308s to its canonical BCP-47 casing. Bounded to known locale segments (never a blanket lowercase), and double hops collapse — `/EN/blog` goes straight to `/blog`, not via `/en/blog`. Works today for en/hu (previously `/HU/blog` 404ed).
- **hreflang collapse** (`hreflangLocale` in `lib/seo/alternates.ts`): `es-419` is a UN M.49 bloc code, which Google's hreflang silently rejects, so it collapses to generic `es` in hreflang keys. URLs and `<html lang>` keep the full internal id. Page metadata and the sitemap already share `alternateLanguages`, so the mapping lives in exactly one place.
- **Accept-Language negotiation** (`lib/i18n/localeBanner.ts`): `firstSupportedLanguage` now mirrors the API's `User::DetermineLocale` — exact case-normalized match first, then region collapse via the same `LANGUAGE_VARIANTS` table (bare `es` → `es-419`, `ES` → `es-ES`, other regions → `es-419`; bare `pt` → `pt-BR`, unlisted pt regions → `pt-PT`). This covers the Firefox/Safari country-code case (`es-CL`, `es-AR`) the API PR flags as most likely to regress, and drives both the locale banner and the anonymous cache bucket. Also fixes tag matching being case-sensitive (`Accept-Language: HU` previously matched nothing).
- **Future-locale test suite** (`tests/unit/lib/i18n/futureLocales.test.ts`): mocks the locale config to the full future set and ports the API's acceptance oracle row-for-row, plus routing/casing/hreflang coverage, so the machinery is proven against locales that aren't live yet.
- **Docs**: `.context/i18n.md` gains a Multi-Variant Languages section; the stale locale-config snippet now matches the real `ALL_LOCALES`/`SUPPORTED_LOCALES` split.

## Testing

- Full unit suite passes (1900 tests, 154 suites); `tsc --noEmit` and ESLint clean.
- Verified live against the dev server: `/HU/blog` → 308 `/hu/blog`, `/EN/blog` → 308 `/blog` (single hop), canonical paths 200, unknown segments (`/XX/blog`, `/hu-Hu/blog`) still 404, and `/hu/blog` hreflang link tags unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)