### PR TITLE
Fix unhandled rejection and non-retry on Turnstile script load failure

### DIFF
--- a/app/lib/turnstile/useTurnstile.ts
+++ b/app/lib/turnstile/useTurnstile.ts
@@ -48,7 +48,12 @@ function loadTurnstileScript(): Promise<void> {
     script.async = true;
     script.defer = true;
     script.onload = () => resolve();
-    script.onerror = () => reject(new Error("Failed to load Turnstile script"));
+    script.onerror = () => {
+      // Clear the cached promise so a future attempt (remount, retry) re-tries
+      // the network load instead of getting this rejection back forever.
+      window.__turnstileScriptPromise = undefined;
+      reject(new Error("Failed to load Turnstile script"));
+    };
     document.head.appendChild(script);
   });
   return window.__turnstileScriptPromise;
@@ -170,6 +175,10 @@ export function useTurnstile(): UseTurnstileResult {
       });
       widgetIdRef.current = localWidgetId;
     });
+    // Mark the ready promise as handled so a script-load failure (ad blockers,
+    // network blips) doesn't surface as an unhandled rejection. execute() still
+    // receives the rejection via its own await and shows the captcha error UI.
+    readyRef.current.catch(() => {});
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
Fixes jiki-education/front-end#598 (`Error: Failed to load Turnstile script`).

## Root cause

The Sentry error is not a CSP problem — `middleware.ts` correctly whitelists `challenges.cloudflare.com` in `script-src`. The script fails to load for external reasons: ad blockers / privacy extensions (Cloudflare's challenge script is a common block target), network blips, or corporate proxies.

The defect is in how `lib/turnstile/useTurnstile.ts` handles that failure:

1. **Unhandled promise rejection (what Sentry catches).** The effect assigns `readyRef.current = loadTurnstileScript().then(...)` with no `.catch`. On a load failure the ready promise rejects with no handler attached during the microtask, so the browser fires `unhandledrejection` and Sentry reports it — even when the user never submits the form. The `try/catch` in `LoginForm.handleSubmit` already handles the submit path gracefully, so many of these reports are pure noise.
2. **Rejected promise cached forever.** `loadTurnstileScript` memoizes on `window.__turnstileScriptPromise` but never clears it on failure, so once loading fails every later attempt (remount, retry, second submit) gets the cached rejection back instantly and never re-attempts the network load.

## Fix

- Clear `window.__turnstileScriptPromise` in `script.onerror` so a future attempt actually retries the load.
- Attach a no-op `.catch` to the effect's ready promise so the failure is marked handled (no more unhandled-rejection noise) while `execute()` still receives the rejection via its own `await` and shows the existing `captchaError` UI.

## Testing

- `pnpm typecheck` passes.
- Full app test suite passes (1867 tests) via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)