### PR TITLE
JavaScript: exerciseFinished() halts execution at end of current statement

### DIFF
--- a/curriculum/src/exercises/index.ts
+++ b/curriculum/src/exercises/index.ts
@@ -98,7 +98,12 @@ export const exercises = {
   "tic-tac-toe": () => import("./tic-tac-toe"),
   leap: () => import("./leap"),
   "look-around": () => import("./look-around"),
-  "emoji-collector": () => import("./emoji-collector"),
+  // emoji-collector is unregistered for now: its design relies on student code
+  // running after exerciseFinished() (announceEmojis after the maze walk), which
+  // conflicts with exerciseFinished halting execution. It is unpublished (a
+  // challenge unlocked from the Dictionaries level, past the publish cutoff)
+  // and needs a redesign before it can be re-enabled.
+  // "emoji-collector": () => import("./emoji-collector"),
   "boundaried-ball": () => import("./boundaried-ball"),
   "smashing-blocks": () => import("./smashing-blocks"),
   "maze-solve-walk": () => import("./maze-solve-walk"),

--- a/curriculum/src/llm-metadata.ts
+++ b/curriculum/src/llm-metadata.ts
@@ -104,7 +104,6 @@ import { llmMetadata as spotifyLLM } from "./exercises/spotify/llm-metadata";
 import { llmMetadata as llmResponseLLM } from "./exercises/llm-response/llm-metadata";
 import { llmMetadata as leapLLM } from "./exercises/leap/llm-metadata";
 import { llmMetadata as lookAroundLLM } from "./exercises/look-around/llm-metadata";
-import { llmMetadata as emojiCollectorLLM } from "./exercises/emoji-collector/llm-metadata";
 import { llmMetadata as boundarieBallLLM } from "./exercises/boundaried-ball/llm-metadata";
 import { llmMetadata as smashingBlocksLLM } from "./exercises/smashing-blocks/llm-metadata";
 import { llmMetadata as mazeSolveWalkLLM } from "./exercises/maze-solve-walk/llm-metadata";
@@ -218,7 +217,6 @@ const llmMetadataRegistry = {
   "llm-response": llmResponseLLM,
   leap: leapLLM,
   "look-around": lookAroundLLM,
-  "emoji-collector": emojiCollectorLLM,
   "boundaried-ball": boundarieBallLLM,
   "smashing-blocks": smashingBlocksLLM,
   "maze-solve-walk": mazeSolveWalkLLM,

--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -1,5 +1,18 @@
 # JavaScript Interpreter Evolution
 
+## 2026-07-12: `exerciseFinished()` halts execution at the end of the current statement
+
+Previously `exerciseFinished()` (called by exercises when the goal is reached, e.g. the maze character landing on the target) only broke **no-argument** `repeat()` loops. Counted repeats, `while`, `for`, `for-of` and `for-in` ignored it, so a student who wrote `repeat(50)` instead of the bare `repeat()` watched their character reach the maze target and then keep executing the remaining iterations - wandering off the target square and failing the scenario's final-position check despite visibly finishing.
+
+Now the flag halts execution entirely, at the end of the statement that triggered it:
+
+- `executeStatement` early-returns when `_exerciseFinished` is set, so every subsequent statement (rest of the loop body, rest of a function body, statements after the loop, remaining top-level statements) becomes a no-op.
+- Every loop construct (`repeat` counted and uncounted, `while`, `for`, `for-of`, `for-in`) breaks after the iteration in which the flag was set, so loop machinery stops generating condition/iteration frames.
+
+**Semantic change:** the old behaviour was "finish the current _iteration_, then break the no-arg repeat" - remaining statements in the finishing iteration still ran. The new behaviour stops after the current _statement_: nothing in the program executes once the exercise has finished. The expression containing the triggering call still completes normally and generates its frame.
+
+Python and JikiScript retain the old semantics (only their no-arg repeat loops check the flag); aligning them is deliberately out of scope for now. The `ExecutionContext.exerciseFinished` doc comment in `shared/interfaces.ts` records the divergence.
+
 ## 2026-07-10: Loose equality (`==`/`!=`) rejected at parse time, with distinct messages
 
 Rejecting `==`/`!=` when `enforceStrictEquality` is on (the default) moved from a **runtime** check in `executeBinaryExpression` to a **parse-time** check in `parser.ts` (`equality()`). Rationale:

--- a/interpreters/src/javascript/executor.ts
+++ b/interpreters/src/javascript/executor.ts
@@ -499,6 +499,13 @@ export class Executor {
   }
 
   public executeStatement(statement: Statement): void {
+    // Once the exercise has signalled completion (via executionCtx.exerciseFinished()),
+    // execution halts at the end of the current statement: every subsequent statement
+    // - in loop bodies, function bodies, or after loops - becomes a no-op.
+    if (this._exerciseFinished) {
+      return;
+    }
+
     // Safety check: ensure this node type is allowed
     this.assertNodeAllowed(statement);
 

--- a/interpreters/src/javascript/executor/executeForInStatement.ts
+++ b/interpreters/src/javascript/executor/executeForInStatement.ts
@@ -75,6 +75,11 @@ export function executeForInStatement(executor: Executor, statement: ForInStatem
         executor.executeLoopIteration(() => {
           executor.executeStatement(statement.body);
         });
+
+        // Stop looping once the exercise signals completion
+        if (executor._exerciseFinished) {
+          break;
+        }
       }
     });
   } finally {

--- a/interpreters/src/javascript/executor/executeForOfStatement.ts
+++ b/interpreters/src/javascript/executor/executeForOfStatement.ts
@@ -77,6 +77,11 @@ export function executeForOfStatement(executor: Executor, statement: ForOfStatem
           executor.executeStatement(statement.body);
         });
 
+        // Stop looping once the exercise signals completion
+        if (executor._exerciseFinished) {
+          break;
+        }
+
         // Remove the loop variable before the next iteration
         // (it will be redefined in the next iteration)
       }

--- a/interpreters/src/javascript/executor/executeForStatement.ts
+++ b/interpreters/src/javascript/executor/executeForStatement.ts
@@ -47,6 +47,11 @@ export function executeForStatement(executor: Executor, statement: ForStatement)
           executor.executeStatement(statement.body);
         });
 
+        // Stop looping once the exercise signals completion
+        if (executor._exerciseFinished) {
+          break;
+        }
+
         // Delay repeat for things like animations
         executor.time += (executor.languageFeatures.repeatDelay ?? 0) * TIME_SCALE_FACTOR;
 

--- a/interpreters/src/javascript/executor/executeRepeatStatement.ts
+++ b/interpreters/src/javascript/executor/executeRepeatStatement.ts
@@ -10,6 +10,7 @@ export function executeRepeatStatement(executor: Executor, statement: RepeatStat
   // bounded only by the infinite-loop guard. Passing a null count makes the loop rely on
   // guardInfiniteLoop to stop it, so hitting maxTotalLoopIterations raises MaxIterationsReached
   // rather than silently exiting one iteration before the guard would fire.
+  // (Counted repeats also stop early when the exercise signals completion - see executeLoop.)
   if (statement.count === null) {
     executeLoop(executor, statement, null, null);
     return;
@@ -87,7 +88,8 @@ function executeLoop(
           executor.executeStatement(statement.body);
         });
 
-        if (countResult == null && executor._exerciseFinished) {
+        // Stop looping once the exercise signals completion (counted or not).
+        if (executor._exerciseFinished) {
           break;
         }
 

--- a/interpreters/src/javascript/executor/executeWhileStatement.ts
+++ b/interpreters/src/javascript/executor/executeWhileStatement.ts
@@ -37,6 +37,11 @@ export function executeWhileStatement(executor: Executor, statement: WhileStatem
           executor.executeStatement(statement.body);
         });
 
+        // Stop looping once the exercise signals completion
+        if (executor._exerciseFinished) {
+          break;
+        }
+
         // Delay repeat for things like animations
         executor.time += (executor.languageFeatures.repeatDelay ?? 0) * TIME_SCALE_FACTOR;
       }

--- a/interpreters/src/shared/interfaces.ts
+++ b/interpreters/src/shared/interfaces.ts
@@ -35,7 +35,7 @@ export interface ExecutionContext {
   getCurrentTimeInMs: () => number;
   random: () => number; // Returns a float in [0, 1). Seeded if randomSeed was provided.
   logicError: (message: string) => never; // For custom functions to throw educational errors
-  exerciseFinished: () => void; // Signal that the exercise is complete; no-arg repeat loops will break
+  exerciseFinished: () => void; // Signal that the exercise is complete. JavaScript: halts execution at the end of the current statement. Python/JikiScript: no-arg repeat loops break.
   languageFeatures?: JSLanguageFeatures | PythonLanguageFeatures | JikiScriptLanguageFeatures;
 }
 

--- a/interpreters/tests/javascript/concepts/repeat.test.ts
+++ b/interpreters/tests/javascript/concepts/repeat.test.ts
@@ -241,7 +241,7 @@ describe("JavaScript repeat loops", () => {
       expect(echos).toEqual(["a", "a", "a"]);
     });
 
-    test("breaks at end of iteration, not mid-iteration", () => {
+    test("halts at end of the finishing statement, not mid-statement", () => {
       const echos: string[] = [];
       let callCount = 0;
       const { frames, error } = interpret(
@@ -268,7 +268,9 @@ describe("JavaScript repeat loops", () => {
         }
       );
       expect(error).toBeNull();
-      expect(echos).toEqual(["before", "after"]);
+      // The echo("before") statement completes, then execution halts:
+      // echo("after") never runs.
+      expect(echos).toEqual(["before"]);
     });
 
     test("works with break", () => {

--- a/interpreters/tests/javascript/exercise-finished.test.ts
+++ b/interpreters/tests/javascript/exercise-finished.test.ts
@@ -1,0 +1,159 @@
+import { interpret } from "@javascript/interpreter";
+
+// exerciseFinished() (called by exercises when the goal is reached, e.g. the
+// maze character lands on the target) halts execution at the end of the
+// current statement. Nothing else runs: no further loop iterations of any
+// loop type, no statements later in the block, no statements after the loop.
+
+function finishingEcho(echos: string[], finishOn: string) {
+  return {
+    externalFunctions: [
+      {
+        name: "echo",
+        func: (ctx: any, n: any) => {
+          const value = n.value.toString();
+          echos.push(value);
+          if (value === finishOn) {
+            ctx.exerciseFinished();
+          }
+        },
+        description: "",
+      },
+    ],
+  };
+}
+
+describe("exerciseFinished halts execution", () => {
+  test("counted repeat stops before its remaining iterations", () => {
+    const echos: string[] = [];
+    const { error } = interpret(
+      `
+      repeat(50) {
+        echo("step")
+      }
+      `,
+      finishingEcho(echos, "step")
+    );
+    expect(error).toBeNull();
+    expect(echos).toEqual(["step"]);
+  });
+
+  test("counted repeat: remaining statements in the finishing iteration are skipped", () => {
+    const echos: string[] = [];
+    const { error } = interpret(
+      `
+      repeat(3) {
+        echo("finish")
+        echo("skipped")
+      }
+      `,
+      finishingEcho(echos, "finish")
+    );
+    expect(error).toBeNull();
+    expect(echos).toEqual(["finish"]);
+  });
+
+  test("while loop stops", () => {
+    const echos: string[] = [];
+    const { error } = interpret(
+      `
+      let i = 0
+      while (i < 50) {
+        i = i + 1
+        echo("step")
+      }
+      `,
+      finishingEcho(echos, "step")
+    );
+    expect(error).toBeNull();
+    expect(echos).toEqual(["step"]);
+  });
+
+  test("for loop stops", () => {
+    const echos: string[] = [];
+    const { error } = interpret(
+      `
+      for (let i = 0; i < 50; i++) {
+        echo("step")
+      }
+      `,
+      finishingEcho(echos, "step")
+    );
+    expect(error).toBeNull();
+    expect(echos).toEqual(["step"]);
+  });
+
+  test("for-of loop stops", () => {
+    const echos: string[] = [];
+    const { error } = interpret(
+      `
+      for (const x of ["a", "b", "c"]) {
+        echo(x)
+      }
+      `,
+      finishingEcho(echos, "b")
+    );
+    expect(error).toBeNull();
+    expect(echos).toEqual(["a", "b"]);
+  });
+
+  test("statements after the loop do not run", () => {
+    const echos: string[] = [];
+    const { error } = interpret(
+      `
+      repeat(5) {
+        echo("step")
+      }
+      echo("after-loop")
+      `,
+      finishingEcho(echos, "step")
+    );
+    expect(error).toBeNull();
+    expect(echos).toEqual(["step"]);
+  });
+
+  test("remaining statements in a function body do not run", () => {
+    const echos: string[] = [];
+    const { error } = interpret(
+      `
+      function doSteps() {
+        echo("finish")
+        echo("skipped-in-function")
+      }
+      doSteps()
+      echo("after-call")
+      `,
+      finishingEcho(echos, "finish")
+    );
+    expect(error).toBeNull();
+    expect(echos).toEqual(["finish"]);
+  });
+
+  test("no further frames are generated after the finishing statement", () => {
+    const echos: string[] = [];
+    const { frames: finishedFrames, error } = interpret(
+      `
+      repeat(50) {
+        echo("step")
+      }
+      `,
+      finishingEcho(echos, "step")
+    );
+    expect(error).toBeNull();
+
+    const { frames: fullFrames } = interpret(
+      `
+      repeat(50) {
+        echo("step")
+      }
+      `,
+      {
+        externalFunctions: [{ name: "echo", func: (_ctx: any, _n: any) => {}, description: "" }],
+      }
+    );
+
+    // The finished run stops after the first iteration; the unfinished run
+    // executes all 50 iterations and so produces far more frames.
+    expect(finishedFrames.length).toBeLessThan(fullFrames.length / 10);
+  });
+});


### PR DESCRIPTION
## Problem

A student [reported on the forum](https://jiki.io/r/forum) that in the look-around maze, writing `repeat(50)` instead of the bare `repeat()` meant their character reached the target square and then "kept running until 50 repeats are completed" - wandering off the target and failing the scenario's final-position check despite visibly completing the maze.

Cause: `exerciseFinished()` (fired by maze exercises when the character lands on the target) only broke **no-argument** `repeat()` loops. Counted repeats, `while`, `for`, `for-of` and `for-in` all ignored it.

## Change (JavaScript interpreter only)

`exerciseFinished()` now halts execution at the end of the statement that triggered it:

- `executeStatement` early-returns once the flag is set, so every subsequent statement (rest of the loop body, function bodies, statements after the loop) is a no-op.
- Every loop construct breaks after the finishing iteration, so loop machinery stops generating condition/iteration frames.

**Semantic change:** the previous behaviour was "finish the current iteration, then break the no-arg repeat". The existing test encoding that (`breaks at end of iteration, not mid-iteration`) now asserts the halt. New `exercise-finished.test.ts` covers all loop types, post-loop statements, function bodies, and frame generation.

Python and JikiScript keep the old semantics for now; the divergence is documented in `shared/interfaces.ts` and the JS evolution doc (which has a new entry for this change).

## emoji-collector unregistered

Its design relies on student code running after `exerciseFinished()` (`announceEmojis(emojis)` after the maze walk), which this change deliberately prevents. It is unpublished (a challenge unlocked from the Dictionaries level, well past the `make-your-own-functions` publish cutoff), so it's removed from the exercise registry with a comment explaining why, pending a redesign.

## Testing

- Interpreters: 3536 passed (including full JS suite and new coverage)
- Curriculum: 672 passed (all remaining exercise solutions pass all non-bonus scenarios)
- App: 1921 unit tests + coding-exercise e2e suite (97) pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)