### PR TITLE
Restore height:auto for images in external-page reset

### DIFF
--- a/app/app/styles/base.css
+++ b/app/app/styles/base.css
@@ -95,6 +95,15 @@
         max-width: 100%;
     }
 
+    /* Preserve intrinsic aspect ratio when width is overridden (e.g. a CSS
+       module sets width but the element still carries width/height attrs, as
+       Next.js <Image> does). Scoped to img/video like Tailwind's preflight,
+       so SVG/canvas that rely on attribute height are unaffected. */
+    img,
+    video {
+        height: auto;
+    }
+
     table {
         border-collapse: collapse;
     }


### PR DESCRIPTION
## Problem

Images and videos on the external/landing pages (rhodri photo, WelcomeSection game videos, BootcampSection level videos, part1/part2 images, certificate) render stretched, with broken aspect ratios.

## Root cause

`app/styles/base.css` is a hand-written reset that deliberately **replaces Tailwind's Preflight** on external/hybrid pages (Tailwind is intentionally not loaded there). When mirroring Preflight it kept `max-width: 100%` on images but dropped the companion `height: auto`.

Next.js `<Image>` and our `<video>` emit fixed `width`/`height` HTML attributes. When a CSS module overrides the width, with no CSS height the browser falls back to the fixed pixel `height` attribute and the aspect ratio breaks.

## Fix

Add `height: auto` back to the reset, scoped to `img, video` exactly as Tailwind's Preflight does (so `svg`/`canvas` that rely on attribute height are unaffected). One central change fixes every affected element across all external pages.

## Test plan

- [ ] Visually confirm the landing page (jiki.io) images/videos render at correct aspect ratio
- [x] `pnpm test` (app) passes — 1921 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)