### PR TITLE
Filter injected-script and environment noise out of Sentry

### DIFF
--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -16,46 +16,60 @@ if (process.env.NODE_ENV === "production") {
       // error, so it slips past the frame-based beforeSend filter below.
       // https://github.com/getsentry/sentry-javascript/issues/3440
       "Object Not Found Matching Id",
+
       // WebExtension messaging errors: a content script talking to an unloaded
       // background page, or a Safari extension losing its tab. These bubble into
       // the page with no stack, so only a message filter can catch them.
       "Could not establish connection. Receiving end does not exist.",
       "Invalid call to runtime.sendMessage(). Tab not found.",
+
       // Crypto-wallet extensions erroring in their own injected page-context code.
       "Failed to connect to MetaMask",
       "MetaMask extension not found",
       /trap returned falsish for property 'tronlinkParams'/,
+
       // Instagram's Android in-app webview loses the Java bridge for its own
       // navigation-performance logger.
       /Java object is gone/,
+
       // Mux Data analytics beacons blocked by adblockers; mux-embed re-queues
       // internally, so a failed beacon flush is never actionable.
       /Failed to fetch \((?:[a-z0-9-]+\.)?litix\.io\)/,
+
       // Google Translate (and similar DOM-rewriting tools) replaces text nodes out
       // from under React, so the commit phase can no longer find its children. The
       // stacks are 100% react-dom internals with no app frames.
       /Failed to execute 'removeChild' on 'Node'/,
       /Failed to execute 'insertBefore' on 'Node'/,
+
       // The RSC flight stream was cut mid-read: the user navigated away, closed
       // the tab, or dropped network during a soft navigation.
       "Connection closed.",
+
       // A script download truncated by a dropped connection.
       "Unexpected end of script",
+
       // Injected document-level touch handlers; no first-party code reads .touches
       // (the scrubber uses pointer/mouse events).
       "Cannot read properties of undefined (reading 'touches')",
+
       // Chrome-on-iOS injected code rejects with two-letter minified messages
       // ("Aa", "he"). No real app error has a two-character message.
       /^[A-Za-z]{2}$/,
+
       // Autoplay being denied by the browser is expected behaviour, not a bug.
       /play method is not allowed by the user agent/,
+
       // media-chrome touching an extension-injected cross-origin stylesheet.
       /Not allowed to access cross-origin stylesheet/,
+
       // Firefox (Gecko) internal error in media-chrome's scrubber preview thumbnail.
       /^NS_ERROR_NOT_AVAILABLE/,
+
       // Our CSP correctly blocking injected/extension scripts from eval'ing.
       // First-party code never evals, so this can only come from foreign scripts.
       "violates the following Content Security Policy directive",
+
       // Canonical benign browser warning: the observer needed another pass within
       // one frame; the browser recovers and nothing is broken.
       "ResizeObserver loop limit exceeded",

--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -15,11 +15,53 @@ if (process.env.NODE_ENV === "production") {
       // non-Error promise rejection with this value. It has no stack trace and is not a real
       // error, so it slips past the frame-based beforeSend filter below.
       // https://github.com/getsentry/sentry-javascript/issues/3440
-      "Object Not Found Matching Id"
+      "Object Not Found Matching Id",
+      // WebExtension messaging errors: a content script talking to an unloaded
+      // background page, or a Safari extension losing its tab. These bubble into
+      // the page with no stack, so only a message filter can catch them.
+      "Could not establish connection. Receiving end does not exist.",
+      "Invalid call to runtime.sendMessage(). Tab not found.",
+      // Crypto-wallet extensions erroring in their own injected page-context code.
+      "Failed to connect to MetaMask",
+      "MetaMask extension not found",
+      /trap returned falsish for property 'tronlinkParams'/,
+      // Instagram's Android in-app webview loses the Java bridge for its own
+      // navigation-performance logger.
+      /Java object is gone/,
+      // Mux Data analytics beacons blocked by adblockers; mux-embed re-queues
+      // internally, so a failed beacon flush is never actionable.
+      /Failed to fetch \((?:[a-z0-9-]+\.)?litix\.io\)/,
+      // Google Translate (and similar DOM-rewriting tools) replaces text nodes out
+      // from under React, so the commit phase can no longer find its children. The
+      // stacks are 100% react-dom internals with no app frames.
+      /Failed to execute 'removeChild' on 'Node'/,
+      /Failed to execute 'insertBefore' on 'Node'/,
+      // The RSC flight stream was cut mid-read: the user navigated away, closed
+      // the tab, or dropped network during a soft navigation.
+      "Connection closed.",
+      // A script download truncated by a dropped connection.
+      "Unexpected end of script",
+      // Injected document-level touch handlers; no first-party code reads .touches
+      // (the scrubber uses pointer/mouse events).
+      "Cannot read properties of undefined (reading 'touches')",
+      // Chrome-on-iOS injected code rejects with two-letter minified messages
+      // ("Aa", "he"). No real app error has a two-character message.
+      /^[A-Za-z]{2}$/,
+      // Autoplay being denied by the browser is expected behaviour, not a bug.
+      /play method is not allowed by the user agent/,
+      // media-chrome touching an extension-injected cross-origin stylesheet.
+      /Not allowed to access cross-origin stylesheet/,
+      // Firefox (Gecko) internal error in media-chrome's scrubber preview thumbnail.
+      /^NS_ERROR_NOT_AVAILABLE/,
+      // Our CSP correctly blocking injected/extension scripts from eval'ing.
+      // First-party code never evals, so this can only come from foreign scripts.
+      "violates the following Content Security Policy directive",
+      // Canonical benign browser warning: the observer needed another pass within
+      // one frame; the browser recovers and nothing is broken.
+      "ResizeObserver loop limit exceeded",
+      "ResizeObserver loop completed with undelivered notifications."
     ],
     beforeSend(event) {
-      // Drop aborted-request errors - these happen when the user navigates away
-      // while a fetch is still in flight, which is expected, not a bug.
       const exception = event.exception?.values?.[0];
       // Opaque DOM resource-load rejections. A failed <img>/<audio>/<video> load
       // (or a media player that wraps loading in a promise) rejects with a raw
@@ -27,9 +69,18 @@ if (process.env.NODE_ENV === "production") {
       // the useless "Event `Event` (type=error) captured as promise rejection".
       // We re-capture these as a real Error with the failing resource URL in the
       // unhandledrejection listener below, so drop the stackless originals here.
-      if (exception?.type === "Event" && (exception.value?.includes("(type=error)") ?? false)) {
+      // Extensions also re-dispatch synthetic CustomEvents that Sentry captures
+      // the same way; any raw DOM Event captured as a rejection reason is
+      // non-actionable by construction.
+      if (
+        (exception?.type === "Event" || exception?.type === "CustomEvent") &&
+        ((exception.value?.includes("(type=error)") ?? false) ||
+          (exception.value?.includes("captured as promise rejection") ?? false))
+      ) {
         return null;
       }
+      // Drop aborted-request errors - these happen when the user navigates away
+      // while a fetch is still in flight, which is expected, not a bug.
       if (
         exception?.type === "RequestAbortedError" ||
         exception?.type === "AbortError" ||
@@ -38,17 +89,49 @@ if (process.env.NODE_ENV === "production") {
       ) {
         return null;
       }
+      // Wallet extensions (MetaMask et al) reject with a plain object rather than
+      // an Error, so the event has no exception stack; the extension's own stack
+      // and error code only exist inside the serialized rejection reason.
+      const serialized = event.extra?.__serialized__ as { code?: number; message?: string; stack?: string } | undefined;
+      if (
+        serialized?.code === 4900 ||
+        (serialized?.message?.includes("provider is disconnected from all chains") ?? false) ||
+        (serialized?.stack?.includes("chrome-extension://") ?? false)
+      ) {
+        return null;
+      }
 
       const frames = exception?.stacktrace?.frames;
       if (!frames || frames.length === 0) return event;
-      const isExtensionFrame = (url: string) =>
-        url.startsWith("chrome-extension://") ||
-        url.startsWith("moz-extension://") ||
-        url.startsWith("safari-web-extension://");
-      const hasAppFrame = frames.some((f) => {
-        const url = f.filename ?? "";
-        return url !== "" && url !== "<anonymous>" && !isExtensionFrame(url);
-      });
+
+      // Page-context injected scripts (adware/extension fetch wrappers) re-wrap
+      // window.fetch and leave a dangling promise copy, so fetch failures our code
+      // (or Mux, or Next's router prefetch) already handles resurface as unhandled
+      // rejections. Real Next.js frames can sit above the wrapper frame, so this
+      // must be an any-frame check, and the Google Search iOS in-app browser
+      // injects a page-inspection script (at the document's own URL, so it looks
+      // like an app frame) that recurses to stack overflow.
+      const INJECTED_FILE_PATTERNS = [/\/frame_ant\/frame_ant\.js/, /injectScriptAdjust\.js/, /\bactiveContent\.js/];
+      const INJECTED_FUNCTIONS = new Set(["findTopmostVisibleElement", "checkForImage", "isOpaqueElement"]);
+      if (
+        frames.some(
+          (f) =>
+            INJECTED_FILE_PATTERNS.some((p) => p.test(f.filename ?? "")) || INJECTED_FUNCTIONS.has(f.function ?? "")
+        )
+      ) {
+        return null;
+      }
+
+      // Keep an event only if some frame is genuinely our code. In the browser our
+      // frames are always chunk/static URLs (https://jiki.io/_next/... or
+      // https://assets.jiki.io/_next/...). Extension content scripts injected into
+      // the page context show up as bare sourceURL names ("inpage.js",
+      // "extensionServiceWorker.js", "content/foo.js"), the document URL itself,
+      // "undefined", or <anonymous> - none of which are our bundle. webpack:// is
+      // kept for any environment that reports pre-symbolicated frames.
+      const isAppFrame = (url: string) =>
+        url.includes("/_next/") || url.includes("jiki.io/static/") || url.startsWith("webpack://");
+      const hasAppFrame = frames.some((f) => isAppFrame(f.filename ?? ""));
       return hasAppFrame ? event : null;
     }
   });

--- a/app/lib/hooks/useExternalPremiumPrices.ts
+++ b/app/lib/hooks/useExternalPremiumPrices.ts
@@ -28,10 +28,12 @@ export function useExternalPremiumPrices({ enabled = true }: { enabled?: boolean
       })
       .catch((error: unknown) => {
         // A rejected fetch (blocked by an extension, dropped connection, or the
-        // visitor navigating away) throws a TypeError. That's expected ambient
-        // noise and the fallback already covers it, so don't report it.
+        // visitor navigating away) throws a TypeError. A captive portal or ISP
+        // block page returning 200 with HTML makes response.json() throw a
+        // SyntaxError. Both are expected ambient noise and the fallback already
+        // covers them, so don't report them.
         // A bad HTTP status throws a plain Error and is worth surfacing.
-        if (error instanceof TypeError) {
+        if (error instanceof TypeError || error instanceof SyntaxError) {
           return;
         }
         reportError(error);


### PR DESCRIPTION
## Summary

An evaluation of all 88 unresolved front-end Sentry issues found ~35 of them are noise from browser extensions, in-app browsers, and user environments rather than app bugs. This PR filters them client-side so they stop being reported.

### Why the old filter missed them

The existing `beforeSend` dropped events only when every frame was a `chrome-extension://`-style URL. But extensions inject scripts into the *page* context, where their frames show up as bare sourceURL names (`inpage.js`, `extensionServiceWorker.js`, `content/neweggagent.js`), the document's own URL, or `undefined` — all of which counted as app frames.

### Changes to `instrumentation-client.ts`

- **App-frame allowlist**: an event is now kept only if some frame comes from `/_next/`, `jiki.io/static/`, or `webpack://` — everything we ship lives there.
- **Any-frame drops** for known fetch-wrapping injected scripts (`frame_ant.js`, `injectScriptAdjust.js`, `activeContent.js`) whose dangling promise copies resurface handled fetch failures as unhandled rejections, and for the Google Search iOS in-app browser's page-inspection recursion (`findTopmostVisibleElement` etc., which runs at the document URL so it looks like an app frame).
- **Wallet object rejections**: MetaMask-style rejections are plain objects with no exception stack; drop on serialized `code: 4900` / `chrome-extension://` stacks.
- **CustomEvent rejections** join the existing stackless-Event drop.
- **~15 `ignoreErrors` entries**: WebExtension messaging errors, MetaMask/TronLink noise, Google Translate `removeChild`/`insertBefore` breakage, cut RSC streams ("Connection closed."), truncated scripts, Mux Data (litix.io) beacon failures, blocked autoplay, media-chrome cross-origin stylesheet / `NS_ERROR_NOT_AVAILABLE`, CSP-blocked injected eval, ResizeObserver warnings, injected `.touches` handlers, and Chrome-iOS two-letter minified errors.

### `useExternalPremiumPrices.ts`

Also suppress `SyntaxError` (captive portal / ISP block page returning 200 HTML to the pricing fetch), matching the existing `TypeError` rule — covers JIKI-FRONT-END-2H.

### Sentry issues covered

JIKI-FRONT-END-4, -7, -K, -N, -P, -Q, -R, -X, -Z, -10, -12, -1C, -1F, -1V, -1W, -1X, -24, -25, -26, -27, -28, -2C, -2D, -2E, -2H, -2K, -2M, -2N, -2R, -2S, -2T, -2V, -2X, -31, -32, -34, -36, -3C, -3D, -3H, -3J, -3N

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm run lint` passes
- [x] All 1996 app unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)