### PR TITLE
Fix scrubber drag listener leak and null-timeline seek crash

### DIFF
--- a/app/components/coding-exercise/lib/AnimationTimeline.ts
+++ b/app/components/coding-exercise/lib/AnimationTimeline.ts
@@ -10,7 +10,10 @@ import {
 } from "animejs";
 
 export class AnimationTimeline {
-  private animationTimeline: Timeline;
+  // Null after destroy(): callers can outlive the timeline (e.g. a document-level
+  // drag listener still firing while the exercise tears down), so playback
+  // methods no-op once destroyed instead of dereferencing null.
+  private animationTimeline: Timeline | null;
   private updateCallbacks: ((anim: Timeline) => void)[] = [];
   private completeCallbacks: ((anim: Timeline) => void)[] = [];
   public hasPlayedOrScrubbed = false;
@@ -32,8 +35,7 @@ export class AnimationTimeline {
   }
 
   public destroy() {
-    this.animationTimeline.pause();
-    // @ts-expect-error - Intentionally setting to null for cleanup
+    this.animationTimeline?.pause();
     this.animationTimeline = null;
   }
 
@@ -54,6 +56,10 @@ export class AnimationTimeline {
   }
 
   public populateTimeline(animations: CurriculumAnimation[], frames: Frame[] = []): this {
+    if (!this.animationTimeline) {
+      return this;
+    }
+    const timeline = this.animationTimeline;
     animations.forEach((animation) => {
       const { targets, offset, transformations, duration, easing, modifier } = animation;
 
@@ -65,7 +71,7 @@ export class AnimationTimeline {
         ...(modifier !== undefined && { modifier })
       };
 
-      this.animationTimeline.add(targets as TargetsParam, params, offset as TimelinePosition);
+      timeline.add(targets as TargetsParam, params, offset as TimelinePosition);
     });
 
     /*
@@ -82,19 +88,19 @@ export class AnimationTimeline {
      On the other hand ensure the full duration of the last animation is present. hence the max function.
     */
 
-    const animationDurationAfterAnimations = this.animationTimeline.duration;
+    const animationDurationAfterAnimations = timeline.duration;
     const lastFrame = frames[frames.length - 1];
 
     // ESLint doesn't realize lastFrame can be undefined when frames array is empty
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const lastFrameTime = lastFrame ? lastFrame.timeInMs : 0;
-    this.animationTimeline.duration = Math.max(animationDurationAfterAnimations, lastFrameTime);
+    timeline.duration = Math.max(animationDurationAfterAnimations, lastFrameTime);
     return this;
   }
 
   public get duration() {
     // Translate this back to microseconds
-    return this.animationTimeline.duration * TIME_SCALE_FACTOR;
+    return (this.animationTimeline?.duration ?? 0) * TIME_SCALE_FACTOR;
   }
 
   // public seekEndOfTimeline() {
@@ -107,28 +113,28 @@ export class AnimationTimeline {
     // collapse sub-millisecond frame times to 0 and skip past animations
     // whose offsets fall inside that range (e.g. exercises like digital-clock
     // that operate at microsecond granularity).
-    this.animationTimeline.seek(time / TIME_SCALE_FACTOR, muteCallbacks);
+    this.animationTimeline?.seek(time / TIME_SCALE_FACTOR, muteCallbacks);
   }
 
   public play(cb?: () => void) {
     if (cb) {
       cb();
     }
-    this.animationTimeline.play();
+    this.animationTimeline?.play();
   }
 
   public pause(cb?: () => void) {
-    this.animationTimeline.pause();
+    this.animationTimeline?.pause();
     if (cb) {
       cb();
     }
   }
 
   public get paused(): boolean {
-    return this.animationTimeline.paused;
+    return this.animationTimeline?.paused ?? true;
   }
 
   public get completed(): boolean {
-    return this.animationTimeline.completed;
+    return this.animationTimeline?.completed ?? false;
   }
 }

--- a/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
+++ b/app/components/coding-exercise/ui/scrubber/ScrubberInput.tsx
@@ -18,6 +18,13 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
     const orchestrator = useOrchestrator();
     const { isPlaying } = useOrchestratorStore(orchestrator);
     const isDraggingRef = useRef(false);
+    // The document-level listeners actually attached in handleMouseDown. The
+    // handler callbacks are recreated every render (their deps include the
+    // current time), so cleanup must remove the exact functions that were
+    // attached, not whichever identity the current render holds - otherwise a
+    // drag that outlives the component leaks a mousemove listener that keeps
+    // driving the (destroyed) timeline forever.
+    const activeListenersRef = useRef<{ move: (event: MouseEvent) => void; up: () => void } | null>(null);
 
     const min = calculateMinInputValue(frames);
     // IO tests have no animationTimeline, so fall back to the last frame's time
@@ -43,6 +50,15 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
       [min, max, currentValue, ref]
     );
 
+    const removeActiveListeners = useCallback(() => {
+      if (!activeListenersRef.current) {
+        return;
+      }
+      document.removeEventListener("mousemove", activeListenersRef.current.move);
+      document.removeEventListener("mouseup", activeListenersRef.current.up);
+      activeListenersRef.current = null;
+    }, []);
+
     const handleMouseDown = useCallback(
       (event: React.MouseEvent) => {
         if (!enabled) {
@@ -60,11 +76,13 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
         // its content tracks the highlighted line as the drag continues.
         orchestrator.showInformationWidget();
 
+        removeActiveListeners();
+        activeListenersRef.current = { move: handleMouseMove, up: handleMouseUp };
         document.addEventListener("mousemove", handleMouseMove);
         document.addEventListener("mouseup", handleMouseUp);
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [enabled, getValueFromMousePosition, orchestrator]
+      [enabled, getValueFromMousePosition, orchestrator, removeActiveListeners]
     );
 
     const handleMouseMove = useCallback(
@@ -83,10 +101,8 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
       isDraggingRef.current = false;
       orchestrator.snapToNearestFrame();
 
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [orchestrator]);
+      removeActiveListeners();
+    }, [orchestrator, removeActiveListeners]);
 
     const handleKeyDown = useCallback(
       (event: React.KeyboardEvent) => {
@@ -101,11 +117,10 @@ const ScrubberInput = forwardRef<HTMLDivElement, ScrubberInputProps>(
     // Cleanup event listeners on unmount
     useEffect(() => {
       return () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
+        isDraggingRef.current = false;
+        removeActiveListeners();
       };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [removeActiveListeners]);
 
     return (
       <div


### PR DESCRIPTION
## Summary

Fixes [JIKI-FRONT-END-22](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-22) (`TypeError: Cannot read properties of null (reading 'seek')`, 2,761 events from 2 users — one stuck session spams an event per mouse move).

### Root cause

Dragging the scrubber attaches document-level `mousemove`/`mouseup` listeners in `handleMouseDown`. The handlers are recreated every render (their deps include the current time, which changes as you drag), but the unmount cleanup effect had empty deps, so it captured only the **first** render's handler identities and its `removeEventListener` calls were no-ops for the actually-attached functions. If the exercise unmounted mid-drag (error boundary, navigation — the Sentry events show mousemoves over the error page), the leaked `mousemove` handler kept calling `orchestrator.setCurrentTestTime()` → `AnimationTimeline.seek()` against a timeline that `Orchestrator.cleanup()` had already destroyed (which nulls the inner anime.js timeline), crashing on every mouse move forever.

### Fix (two layers)

- **`ScrubberInput.tsx`**: store the exact attached handlers in `activeListenersRef` at `addEventListener` time; `mouseup` and the unmount cleanup remove precisely those, so listeners can no longer outlive the component.
- **`AnimationTimeline.ts`**: the inner timeline is now typed as nullable (it already became null in `destroy()` via a `@ts-expect-error`); playback methods no-op and getters return inert values (`duration` 0, `paused` true, `completed` false) after destruction, so any other stale caller degrades silently instead of throwing.

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 852 coding-exercise unit tests pass (full suite runs in pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)