### PR TITLE
Use copy-then-sort instead of toSorted in sortBadges

### DIFF
--- a/app/app/(app)/achievements/lib/badgeUtils.ts
+++ b/app/app/(app)/achievements/lib/badgeUtils.ts
@@ -41,7 +41,9 @@ export function getBadgeColor(badge: BadgeData): "blue" | "gold" {
 }
 
 export function sortBadges(badges: BadgeData[]): BadgeData[] {
-  return badges.toSorted((a, b) => {
+  // Not toSorted(): it needs Chrome 110+/Safari 16.4+ and crashes the dashboard
+  // render on older browsers (JIKI-FRONT-END-14). Copy-then-sort is equivalent.
+  return [...badges].sort((a, b) => {
     // Priority: 1=unrevealed, 2=new (recently revealed or less than a week old), 3=revealed, 4=locked
     const getCategory = (badge: BadgeData): number => {
       if (badge.state === "unrevealed") {


### PR DESCRIPTION
## Summary

Fixes [JIKI-FRONT-END-14](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-14) (`TypeError: e.toSorted is not a function`, 237 events / 23 users).

`Array.prototype.toSorted` needs Chrome 110+ / Safari 16.4+. There's no `.browserslistrc` and Next/SWC transpiles syntax but doesn't polyfill instance methods, so `sortBadges` crashed the dashboard sidebar render (via `UserProfile/Badges.tsx`) for anyone on an older browser (sample event: Chrome Mobile 103 on Android 12).

`[...badges].sort()` is semantically identical — fresh array, input not mutated. This was the only `toSorted`/`toReversed`/`toSpliced` usage in the app.

## Test plan

- [x] `pnpm typecheck` passes
- [x] Full unit suite passes in pre-commit (1996 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)