### PR TITLE
Fall back to symbol when narrowSymbol is unsupported

### DIFF
--- a/app/lib/formatCurrency.ts
+++ b/app/lib/formatCurrency.ts
@@ -31,6 +31,18 @@ function minorUnitExponent(currency: string): number {
   return currencyFractionDigits(currency);
 }
 
+// Intl.NumberFormat in currency style with "narrowSymbol", falling back to
+// "symbol" on engines that reject narrowSymbol (older/niche browsers throw a
+// RangeError, which would otherwise take down the whole page render since we
+// format prices during render).
+export function currencyNumberFormat(options: Intl.NumberFormatOptions): Intl.NumberFormat {
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currencyDisplay: "narrowSymbol", ...options });
+  } catch {
+    return new Intl.NumberFormat(undefined, { style: "currency", currencyDisplay: "symbol", ...options });
+  }
+}
+
 function disambiguate(currency: string, formatted: string): string {
   const prefix = DOLLAR_PREFIX[currency];
   if (!prefix) return formatted;
@@ -50,10 +62,8 @@ export function formatCurrency(
 ): string {
   const currencyUpper = currency.toUpperCase();
   const amount = amountInMinorUnits / Math.pow(10, minorUnitExponent(currencyUpper));
-  const formatted = new Intl.NumberFormat(undefined, {
-    style: "currency",
+  const formatted = currencyNumberFormat({
     currency: currencyUpper,
-    currencyDisplay: "narrowSymbol",
     ...options
   }).format(amount);
   return disambiguate(currencyUpper, formatted);

--- a/app/lib/pricing.ts
+++ b/app/lib/pricing.ts
@@ -3,6 +3,8 @@
  * Defines subscription tiers, pricing, and features
  */
 
+import { currencyNumberFormat } from "./formatCurrency";
+
 export type MembershipTier = "standard" | "premium";
 
 export type BillingInterval = "monthly" | "annual";
@@ -28,10 +30,8 @@ export function formatMonthlyPrice(prices: PremiumPrices): string {
   const currency = prices.currency.toUpperCase();
   const amount = prices.monthly / Math.pow(10, currencyFractionDigits(currency));
 
-  return new Intl.NumberFormat(undefined, {
-    style: "currency",
+  return currencyNumberFormat({
     currency,
-    currencyDisplay: "narrowSymbol",
     minimumFractionDigits: 0,
     maximumFractionDigits: 2
   }).format(amount);


### PR DESCRIPTION
## Summary

Fixes [JIKI-FRONT-END-1J](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-1J) (`RangeError: invalid value narrowSymbol for option currencyDisplay`).

`Intl.NumberFormat` with `currencyDisplay: "narrowSymbol"` throws a `RangeError` on engines that don't support it (the reporting user was on Pale Moon 34 / Goanna). Both `formatCurrency` and `formatMonthlyPrice` format prices during render of the landing/pricing pages, so the error boundary took down the whole page — on the revenue path.

### Fix

New shared `currencyNumberFormat` helper in `lib/formatCurrency.ts` that constructs the formatter with `narrowSymbol` inside a try/catch and falls back to `currencyDisplay: "symbol"`. Both call sites (`formatCurrency`, `pricing.ts`'s `formatMonthlyPrice`) now use it. The existing dollar-prefix disambiguation logic is unchanged.

## Test plan

- [x] `pnpm typecheck` passes
- [x] formatCurrency + pricing unit tests pass (25 tests); full suite in pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)