### PR TITLE
Fingerprint Mux player errors per code; catch autoplay denial

### DIFF
--- a/app/components/choose-language/ui/VideoStep.tsx
+++ b/app/components/choose-language/ui/VideoStep.tsx
@@ -54,7 +54,11 @@ export function VideoStep({ lessonData, onReady, onProceedToSelector, hasVisited
   const autoplay = () => {
     if (!hasAutoPlayedRef.current && playerRef.current?.currentTime === 0) {
       hasAutoPlayedRef.current = true;
-      void playerRef.current.play();
+      // Autoplay denial (NotAllowedError) is expected when the browser blocks
+      // unmuted playback; don't let it surface as an unhandled rejection.
+      playerRef.current.play().catch(() => {
+        setIsVideoVisible(true);
+      });
     }
   };
 

--- a/app/components/ui/JikiMuxPlayer.tsx
+++ b/app/components/ui/JikiMuxPlayer.tsx
@@ -47,7 +47,13 @@ function defaultOnError(event: Event) {
     return;
   }
 
-  reportError(error);
+  // Every variant funnels through this same stack frame, so without an explicit
+  // fingerprint Sentry lumps decode failures, unsupported formats, and unknown
+  // errors into one issue. Group per code/muxCode so each class is triaged on
+  // its own volume.
+  reportError(error, {
+    fingerprint: ["muxplayer-error", String(code ?? "none"), String(muxCode ?? "none")]
+  });
 }
 
 const JikiMuxPlayer = forwardRef<MuxPlayerRefAttributes, MuxPlayerProps>(function JikiMuxPlayer(props, ref) {

--- a/app/lib/reportError.ts
+++ b/app/lib/reportError.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
-export function reportError(error: unknown): void {
+export function reportError(error: unknown, captureContext?: { fingerprint?: string[] }): void {
   console.error(error);
   if (process.env.NODE_ENV !== "production") return;
-  Sentry.captureException(error);
+  Sentry.captureException(error, captureContext);
 }


### PR DESCRIPTION
## Summary

Two related media-player reporting fixes:

**[JIKI-FRONT-END-1T](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-1T)** (`Error: MuxPlayer error`, 257 events / 96 users, assigned to Aron): since PR #760 the error message includes the Mux `code`/`muxCode`, but Sentry groups by stack trace and every variant funnels through the same `defaultOnError` frame — so decode failures (code 3), unsupported formats (code 4), and no-code errors all pile into one issue titled by whichever event is newest. `defaultOnError` now passes an explicit fingerprint (`["muxplayer-error", code, muxCode]`) so each class groups separately and can be triaged on its own volume (e.g. deciding later whether code 3/4 should join code 2 as console-only). `reportError` gains an optional capture-context parameter to support this.

**[JIKI-FRONT-END-C](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-C)** (`NotAllowedError: play method is not allowed...`): the choose-language `autoplay()` retry was the one `.play()` call site without a `.catch`, so browsers blocking unmuted autoplay produced an unhandled rejection. It now mirrors the mount-time autoplay handling and reveals the video controls. (The remaining stackless variants of C come from mux-player internals and are covered by the `ignoreErrors` entry in #866.)

## Test plan

- [x] `pnpm typecheck` passes
- [x] VideoStep unit tests pass; full suite in pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)