### PR TITLE
Patch react-modal scopeTab to survive null shadow-root activeElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
   "pnpm": {
     "overrides": {
       "@lezer/javascript": "npm:@jiki.io/lezer-javascript@^1.5.4"
+    },
+    "patchedDependencies": {
+      "react-modal@3.16.3": "patches/react-modal@3.16.3.patch"
     }
   }
 }

--- a/patches/react-modal@3.16.3.patch
+++ b/patches/react-modal@3.16.3.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/helpers/scopeTab.js b/lib/helpers/scopeTab.js
+index c8fa5a6b83c2680d6f434429f2c8bdd241380911..4e218e797a151fe83c8434922b867585535f3f04 100644
+--- a/lib/helpers/scopeTab.js
++++ b/lib/helpers/scopeTab.js
+@@ -14,7 +14,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
+ function getActiveElement() {
+   var el = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : document;
+ 
+-  return el.activeElement.shadowRoot ? getActiveElement(el.activeElement.shadowRoot) : el.activeElement;
++  // Patched (Jiki): a shadow root's activeElement can be null (e.g. shadow DOM
++  // injected by extensions like Grammarly/password managers), which crashed the
++  // Tab-key focus trap. Guard before recursing.
++  return el.activeElement && el.activeElement.shadowRoot ? getActiveElement(el.activeElement.shadowRoot) : el.activeElement;
+ }
+ 
+ function scopeTab(node, event) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   '@lezer/javascript': npm:@jiki.io/lezer-javascript@^1.5.4
 
+patchedDependencies:
+  react-modal@3.16.3:
+    hash: 5859843818013d7b18057e102d8339a3d293f8f3db01041ed3debc6e16f2e6d0
+    path: patches/react-modal@3.16.3.patch
+
 importers:
 
   .:
@@ -167,7 +172,7 @@ importers:
         version: 2.1.0(react@19.2.3)
       react-modal:
         specifier: ^3.16.3
-        version: 3.16.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 3.16.3(patch_hash=5859843818013d7b18057e102d8339a3d293f8f3db01041ed3debc6e16f2e6d0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-youtube:
         specifier: ^10.1.0
         version: 10.1.0(react@19.2.3)
@@ -16136,7 +16141,7 @@ snapshots:
       react: 19.2.3
       rfdc: 1.4.1
 
-  react-modal@3.16.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-modal@3.16.3(patch_hash=5859843818013d7b18057e102d8339a3d293f8f3db01041ed3debc6e16f2e6d0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       exenv: 1.2.2
       prop-types: 15.8.1


### PR DESCRIPTION
## Summary

Fixes [JIKI-FRONT-END-2Z](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-2Z) (`TypeError: Cannot read properties of null (reading 'shadowRoot')` in react-modal's `scopeTab` helper).

react-modal 3.16.3's `getActiveElement` recurses with `el.activeElement.shadowRoot ? ... : el.activeElement` and never checks that `activeElement` exists. When an extension (Grammarly, password managers) injects shadow DOM whose shadow root reports a null `activeElement`, pressing Tab inside any of our modals (`lib/modal/BaseModal.tsx`) crashed the keyboard focus trap.

### Fix

A pnpm patch (`patches/react-modal@3.16.3.patch`) adding the null guard before recursing. A null return is safe downstream: `scopeTab` only compares `activeElement` (`===`, `indexOf`), never dereferences it. Upstream react-modal is barely maintained, so a patch beats waiting on a release.

Includes the `pnpm.patchedDependencies` entry in the root `package.json` and the corresponding lockfile update.

## Test plan

- [x] `pnpm typecheck` passes
- [x] Modal unit tests pass (22 tests); full suite in pre-commit
- Note: this PR touches `pnpm-lock.yaml` — if CI hits the known git-dep build-allowlist failure for the codemirror fork, that's pre-existing, not from this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)