### PR TITLE
Guard document.body accesses in resize cleanup and visual-exercise views

### DIFF
--- a/app/components/coding-exercise/ui/test-results-view/visual/VisualInspectedView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/visual/VisualInspectedView.tsx
@@ -39,7 +39,9 @@ function VisualInspectedPreviewView() {
     return () => {
       const v = exerciseInstance.getView();
       v.style.display = "none";
-      document.body.appendChild(v);
+      // document.body can be null when this cleanup runs during page teardown
+      // (typed non-null but seen null in production - JIKI-FRONT-END-3E/3K).
+      (document.body as HTMLElement | null)?.appendChild(v);
     };
   }, [currentTestIdx, exercise.ExerciseClass, scenario]);
 

--- a/app/components/coding-exercise/useResize.tsx
+++ b/app/components/coding-exercise/useResize.tsx
@@ -38,6 +38,19 @@ function writeStoredSizes(update: StoredPanelSizes) {
   }
 }
 
+// document.body is typed non-null, but React can run these handlers/cleanups
+// during page teardown (or after something has wiped the DOM), where it is
+// genuinely null - seen in production as JIKI-FRONT-END-3E. Degrade silently:
+// there is no body left to style.
+function setBodyDragStyles(cursor: string, userSelect: string) {
+  const body = document.body as HTMLElement | null;
+  if (!body) {
+    return;
+  }
+  body.style.cursor = cursor;
+  body.style.userSelect = userSelect;
+}
+
 function applyVertical(container: HTMLDivElement, divider: HTMLButtonElement | null, percentage: number) {
   const leftFr = percentage / 50;
   const rightFr = (100 - percentage) / 50;
@@ -104,16 +117,14 @@ export function useResizablePanels() {
         document.removeEventListener("mouseup", listeners.horizontal.up);
       }
       // Reset cursor and user selection
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
+      setBodyDragStyles("", "");
     };
   }, []);
 
   const handleVerticalMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     isDraggingVertical.current = true;
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
+    setBodyDragStyles("col-resize", "none");
 
     const container = containerRef.current;
     const verticalDivider = verticalDividerRef.current;
@@ -137,8 +148,7 @@ export function useResizablePanels() {
     const handleMouseUp = () => {
       if (isDraggingVertical.current) {
         isDraggingVertical.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
+        setBodyDragStyles("", "");
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
         activeListenersRef.current.vertical = undefined;
@@ -158,8 +168,7 @@ export function useResizablePanels() {
   const handleHorizontalMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     isDraggingHorizontal.current = true;
-    document.body.style.cursor = "row-resize";
-    document.body.style.userSelect = "none";
+    setBodyDragStyles("row-resize", "none");
 
     const container = containerRef.current;
     const horizontalDivider = horizontalDividerRef.current;
@@ -185,8 +194,7 @@ export function useResizablePanels() {
     const handleMouseUp = () => {
       if (isDraggingHorizontal.current) {
         isDraggingHorizontal.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
+        setBodyDragStyles("", "");
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
         activeListenersRef.current.horizontal = undefined;

--- a/curriculum/src/VisualExercise.ts
+++ b/curriculum/src/VisualExercise.ts
@@ -38,7 +38,10 @@ export abstract class VisualExercise extends Exercise {
     this.view.id = `${cssClass}-${Math.random().toString(36).substr(2, 9)}`;
     this.view.classList.add(cssClass);
     this.view.style.display = "none";
-    document.body.appendChild(this.view);
+    // The body is only a hidden holding spot until the canvas re-parents the
+    // view, and it can genuinely be null during page teardown (typed non-null
+    // but seen null in production - JIKI-FRONT-END-3K), so skip it safely.
+    (document.body as HTMLElement | null)?.appendChild(this.view);
   }
 
   protected populateView() {}


### PR DESCRIPTION
## Summary

Fixes [JIKI-FRONT-END-3E](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-3E) and [JIKI-FRONT-END-3K](https://thalamus-ai.sentry.io/issues/JIKI-FRONT-END-3K).

Both issues came from the same production session (same user, same trace ID, same second): `document.body` was null while React ran passive-effect setup/teardown — mid-navigation teardown or an extension wiping the DOM. That crashed:

- `useResize`'s unmount cleanup (`document.body.style.cursor = ""`)
- `VisualExercise.createView()` in the curriculum package (`document.body.appendChild(this.view)` — the body is only a hidden holding spot until `VisualTestCanvas` re-parents the view)

### Fix

- `useResize.tsx`: all body cursor/userSelect writes go through a null-guarded `setBodyDragStyles` helper (the writes are cosmetic drag styling, so skipping them when the body is gone is harmless)
- `curriculum/src/VisualExercise.ts` and the matching cleanup in `VisualInspectedView.tsx`: optional-chain the `appendChild`

## Test plan

- [x] `pnpm typecheck` passes
- [x] Curriculum suite passes (672 tests; one rainbow-splodges run flaked on its random-colour assertion, passes consistently on re-run — pre-existing randomness, unrelated)
- [x] App coding-exercise suites pass (852 tests; full suite in pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)