### PR TITLE
Slim down dev process tree and remove bin/dev-claude

### DIFF
--- a/app/.context/commands.md
+++ b/app/.context/commands.md
@@ -2,7 +2,7 @@
 
 ## Core Commands
 
-- `./bin/dev-claude` - Start development server on port 3071 (for AI assistants)
+- `./bin/dev` - Start development server on port 3061
 - `pnpm typecheck` - Check TypeScript types (run from monorepo root)
 - `pnpm run lint` - Run ESLint for code quality checks
 - `pnpm run format` - Format code with Prettier
@@ -53,8 +53,6 @@ The dev server runs on port 3061 by default:
 - URL: http://localhost:3061
 - Uses webpack (Turbopack disabled due to pnpm workspace compatibility issues)
 - Hot module replacement enabled
-
-**For AI assistants**: The `./bin/dev-claude` script runs on port 3071
 
 ### Important Notes
 

--- a/app/.context/i18n-ui-strings-plan.md
+++ b/app/.context/i18n-ui-strings-plan.md
@@ -197,7 +197,7 @@ Order by ROI (small/high-visibility first, hardest last):
 4. Replace literals with `t("...")` / `t.rich(...)` per §2. Make server components `async` as needed.
 5. Typecheck (key typing will catch typos): `cd app && npx tsc --noEmit`.
 6. Lint touched files: `cd app && npx eslint <files>`.
-7. Spot-check in the dev server (`./bin/dev-claude`, port 3071) that the area renders.
+7. Spot-check in the dev server (`./bin/dev`, port 3061) that the area renders.
 8. Commit per-area (only if the user has asked for commits — default is leave in working tree).
 
 ### Tests

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -57,10 +57,10 @@ When working on the coding exercise component, also read from `.context/coding-e
 ### Development
 
 ```bash
-./bin/dev-claude
+./bin/dev
 ```
 
-Starts the development server on http://localhost:3071
+Starts the development server on http://localhost:3061. Never start or stop the dev server yourself — ask the human to run it.
 
 ### Build, TypeScript & Lint
 

--- a/app/bin/dev
+++ b/app/bin/dev
@@ -13,8 +13,8 @@ CURRICULUM_PID=$!
 pnpm run icons:watch &
 ICONS_PID=$!
 
-# Start Next.js dev server
-pnpm dev
-
 # Kill background processes when this script exits
 trap "kill $INTERPRETERS_PID $CURRICULUM_PID $ICONS_PID 2>/dev/null" EXIT
+
+# Start Next.js dev server
+pnpm dev

--- a/app/bin/dev-claude
+++ b/app/bin/dev-claude
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-pnpm install
-pnpm dev --port 3071

--- a/app/lib/subscriptions/checkout.ts
+++ b/app/lib/subscriptions/checkout.ts
@@ -15,7 +15,7 @@
  *
  * @example
  * createCheckoutReturnUrl("/subscribe")
- * // Returns: "http://localhost:3071/subscribe?session_id={CHECKOUT_SESSION_ID}"
+ * // Returns: "http://localhost:3061/subscribe?session_id={CHECKOUT_SESSION_ID}"
  */
 export function createCheckoutReturnUrl(pathname: string, origin?: string): string {
   const baseOrigin = origin || (typeof window !== "undefined" ? window.location.origin : "");

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "npm-run-all icons:generate icon-cache:generate css-hashes:generate content:generate exercise-cache:generate concept-cache:generate --parallel dev:next content:watch exercise-cache:watch concept-cache:watch icon-cache:watch css-hashes:watch",
+    "dev": "npm-run-all icons:generate icon-cache:generate css-hashes:generate content:generate exercise-cache:generate concept-cache:generate && pnpm run --parallel \"/^(dev:next|content:watch|exercise-cache:watch|concept-cache:watch|icon-cache:watch|css-hashes:watch)$/\"",
     "css-hashes:generate": "node scripts/generate-css-asset-hashes.js",
     "css-hashes:watch": "onchange 'app/**/*.css' 'components/**/*.css' 'lib/**/*.css' '../curriculum/src/**/*.css' 'public/static/images/**' 'public/static/fonts/**' 'icons/**/*.svg' -- node scripts/generate-css-asset-hashes.js",
     "dev:next": "next dev --port 3061 --turbo",
@@ -21,7 +21,7 @@
     "concept-cache:watch": "onchange '../curriculum/src/concepts/**' -- node scripts/generate-concept-cache.js",
     "seed-language": "node scripts/seed-language.js",
     "icons:generate": "node scripts/generate-icon-types.js",
-    "icons:watch": "pnpm run icons:generate && onchange 'icons/**/*.svg' -- pnpm run icons:generate",
+    "icons:watch": "node scripts/generate-icon-types.js && onchange 'icons/**/*.svg' -- node scripts/generate-icon-types.js",
     "icon-cache:generate": "node scripts/generate-icon-cache.js",
     "icon-cache:watch": "onchange 'icons/lessons/**/*.svg' 'icons/badges/**/*.svg' 'icons/challenges/**/*.svg' -- node scripts/generate-icon-cache.js",
     "test": "pnpm run icons:generate && pnpm run icon-cache:generate && jest",

--- a/app/tests/unit/lib/subscriptions/checkout.test.ts
+++ b/app/tests/unit/lib/subscriptions/checkout.test.ts
@@ -23,8 +23,8 @@ describe("createCheckoutReturnUrl", () => {
   });
 
   it("preserves origin with port", () => {
-    const url = createCheckoutReturnUrl("/subscribe", "http://localhost:3071");
-    expect(url).toBe("http://localhost:3071/subscribe?checkout_return=true&checkout_session_id={CHECKOUT_SESSION_ID}");
+    const url = createCheckoutReturnUrl("/subscribe", "http://localhost:3061");
+    expect(url).toBe("http://localhost:3061/subscribe?checkout_return=true&checkout_session_id={CHECKOUT_SESSION_ID}");
   });
 
   it("handles nested paths", () => {

--- a/interpreters/package.json
+++ b/interpreters/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json && node build.mjs",
-    "dev": "npm-run-all --parallel dev:tsc dev:bundle",
+    "dev": "pnpm run --parallel \"/^dev:(tsc|bundle)$/\"",
     "dev:tsc": "tsc --watch",
     "dev:bundle": "node build.mjs --watch",
     "test": "vitest --exclude '**/benchmark*.test.ts'",


### PR DESCRIPTION
## What

Reduces the number of persistent processes spawned by `bin/dev` and fixes its cleanup trap, and removes the unused `bin/dev-claude` script (port 3071) entirely.

## Changes

- **Fewer pnpm wrappers**: the app's `dev` script now runs its six parallel watchers via pnpm's regex script runner (`pnpm run --parallel "/^(...)$/"`) inside a single pnpm process, instead of npm-run-all spawning a ~130MB pnpm wrapper per watcher. Same for the interpreters' `dev:tsc`/`dev:bundle`. Saves roughly 8 persistent node processes / ~1GB RSS.
- **`icons:watch`** invokes `node scripts/generate-icon-types.js` directly instead of spawning a pnpm wrapper on every SVG change.
- **Trap fix**: `bin/dev` now registers its cleanup `trap` before the blocking `pnpm dev`, so background watchers are reliably killed when the script exits early.
- **Removed `bin/dev-claude`** and all references to port 3071 (AGENTS.md, .context docs, checkout.ts doc comment and test). AGENTS.md now instructs agents to ask the human to start/stop the dev server.

## Test plan

- [x] Verified pnpm's regex parallel runner runs the exact intended scripts concurrently in a sandbox package
- [x] `pnpm exec jest tests/unit/lib/subscriptions/checkout.test.ts` passes
- [x] Pre-commit hooks (build, lint, typecheck, tests) pass
- [ ] Restart `./bin/dev` and confirm all watchers and the dev server come up (not run here to avoid disturbing the live dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)