### PR TITLE
Stop modelling per-op 5dp rounding in stock-market expectations

### DIFF
--- a/curriculum/src/exercises/stock-market/scenarios.ts
+++ b/curriculum/src/exercises/stock-market/scenarios.ts
@@ -25,15 +25,17 @@ function generateGrowthRates(startYear: number): Record<number, number> {
   return rates;
 }
 
-// Match the interpreter's 5dp rounding on every arithmetic operation
-function round5(v: number): number {
-  return Math.round(v * 100000) / 100000;
-}
-
+// Plain float arithmetic in the same order as the reference solution
+// (money = money * (100 + rate) / 100). The interpreter no longer rounds
+// each operation to 5dp, so the model must not either: per-op rounding
+// error compounds over 20 years and can cross a cent boundary for some
+// rate sequences, falsely failing correct solutions. The toFixed(2)
+// comparison in the expectations provides the tolerance for students
+// whose operation order differs slightly.
 function getExpectedBalance(startYear: number, rates: Record<number, number>): number {
   let money = 10;
   for (let year = startYear; year < startYear + 20; year++) {
-    money = round5(round5(money * round5(100 + rates[year])) / 100);
+    money = (money * (100 + rates[year])) / 100;
   }
   return money;
 }
@@ -42,7 +44,7 @@ function getExpectedTaxReports(startYear: number, rates: Record<number, number>)
   const reports: { year: number; balance: number }[] = [];
   let money = 10;
   for (let year = startYear; year < startYear + 20; year++) {
-    money = round5(round5(money * round5(100 + rates[year])) / 100);
+    money = (money * (100 + rates[year])) / 100;
     reports.push({ year, balance: money });
   }
   return reports;


### PR DESCRIPTION
## Summary

The interpreter no longer rounds every arithmetic operation to 5dp, but stock-market's `getExpectedBalance`/`getExpectedTaxReports` still emulated that (`round5` on every multiply/divide). The injected per-op error (up to 5e-6) compounds across 20 years of up-to-40% growth, so for some random rate sequences the model drifts more than half a cent from the interpreter's full-precision result and the `toFixed(2)` comparison fails a **correct** solution.

This is what flaked the `twenty-years` scenario in CI solution validation — and since `expectations()` runs in the browser with fresh random rates per run, it falsely failed real students at the same probability.

### Fix

Compute the expected values with plain float arithmetic in the same order as the reference solution (`money = money * (100 + rate) / 100`). The existing `toFixed(2)` comparison stays as the tolerance for students whose operation order differs slightly.

Not in scope (per Jeremy): the hardcoded `let year = 2026` in the solution (breaks in 2027 — to be dealt with separately), and the equivalent stale `round5` helpers in checkerboard/structured-house (geometry, no compounding, much lower risk).

## Test plan

- [x] stock-market solution validation passes 5/5 consecutive runs
- [x] Full curriculum suite passes (672 tests)
- [x] `pnpm typecheck` and app coding-exercise tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)