### PR TITLE
i18n catalog cleanup: password minimums, shared strings, ICU messages

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -149,6 +149,11 @@ Top-level namespaces in `messages/en.json` (and `hu.json`, which is structurally
 `misc`. `seo.*` backs page `generateMetadata` (titles/descriptions); `toasts.*` covers the
 component/hook-reachable toast messages.
 
+### Never localized (by design)
+
+- **`/dev` and `/test` routes** and the components that exist only for them: development-only
+  tooling, never shown to students. Do not extract their strings into the catalog.
+
 ### Not yet localized (deferred)
 
 These render English regardless of locale and are intentionally out of the chrome sweep:

--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -7,8 +7,13 @@ This file covers two layers:
 2. **Content localization** (blog posts, articles) — per-locale markdown + generated indexes.
    Covered from [URL Structure](#url-structure) onward.
 
-All app-chrome UI strings have been extracted into the message catalog. The original
-area-by-area sweep is documented in `.context/i18n-ui-strings-plan.md` (the runbook).
+The external/marketing surface (landing, auth, settings, premium, modals, toasts, SEO metadata)
+is extracted into the message catalog. Several app-internal feature areas are **not yet
+extracted** and still hardcode English: `components/coding-exercise/`, `lesson/`, `quiz-card/`,
+`challenge/`, `dashboard/`, `projects/`, `guides/`, `build/`, `unsubscribe/`, `video-exercise/`,
+and the achievements/challenges page components under `app/(app)/`. When extracting these,
+follow the conventions below. The original area-by-area sweep is documented in
+`.context/i18n-ui-strings-plan.md` (the runbook).
 
 ## UI String Translation
 

--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -108,7 +108,9 @@ fragile. Use a single ICU message:
 - Values: `{name}` interpolation; counts: ICU `{count, plural, one {...} other {...}}` (never a
   hand-rolled `count === 1 ? t("singular") : t("plural")`).
 
-(Some older fragment keys still exist and are being migrated to this pattern.)
+`tests/unit/messages.test.ts` guards the catalogs: every message must parse as valid ICU, the
+`en`/`hu` key trees must be identical, and no message may have leading/trailing whitespace
+(whitespace-padded fragments are how concatenation bugs sneak back in).
 
 ### Building locale-aware links
 

--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -77,6 +77,39 @@ Reference implementation: `components/layout/ExternalFooter.tsx`.
 Key-naming convention: namespace = feature folder; dot-nested to mirror the component tree;
 camelCase leaf keys describing the role (not the English text). Shared strings live under `common.*`.
 
+### Shared vs duplicated strings
+
+Two strings with the same English text are **not** automatically the same message — context can
+change the translation. The rule:
+
+- **Share** (one key under `common.*`) when the string has one meaning everywhere regardless of
+  surrounding UI: progress states (`common.processing`, `common.verifying`, `common.sending`,
+  `common.loading`), generic dialog buttons (`common.continue`, `common.close`, `common.cancel`,
+  `common.confirm`, `common.reloadPage`), the price unit (`common.perMonth`), and form validation
+  messages (`common.validation.*`). The Premium benefit title/description pairs shared by the
+  settings upsell and benefits views live under `premium.benefits.*`; strings shared by the two
+  2FA forms live under `auth.twoFactor.*`.
+- **Duplicate deliberately** when the same English text plays different roles: e.g.
+  `settings.cancelSectionPanel.cancel` ("Cancel" = cancel the subscription) is a different message
+  from `common.cancel` ("Cancel" = dismiss the dialog); nav labels, headings, and page titles stay
+  per-feature even when they coincide with a button label.
+
+When merging or adding shared keys, keep `en.json` and `hu.json` structurally identical.
+
+### ICU, not string concatenation
+
+Never split a sentence across multiple keys (`fooPrefix` + `fooSuffix`) to inject markup, links,
+or dynamic values — word order differs across languages and whitespace-padded fragments are
+fragile. Use a single ICU message:
+
+- Inline markup/styling: `t.rich("key", { highlight: (c) => <span className={...}>{c}</span> })`
+- Links: `t.rich("key", { link: (c) => <Link href={...}>{c}</Link> })`
+- Embedded components (e.g. live prices): self-closing tags — `t.rich("key", { price: () => <PremiumPrice /> })`
+- Values: `{name}` interpolation; counts: ICU `{count, plural, one {...} other {...}}` (never a
+  hand-rolled `count === 1 ? t("singular") : t("plural")`).
+
+(Some older fragment keys still exist and are being migrated to this pattern.)
+
 ### Building locale-aware links
 
 Never hardcode internal navigation paths (`href="/auth/login"`, `router.push("/blog")`). They
@@ -119,7 +152,6 @@ These render English regardless of locale and are intentionally out of the chrom
   `lib/settings/settingsStore.ts` (Zustand store toasts),
   `components/coding-exercise/lib/orchestrator/TestSuiteManager.ts` (class). Localizing these needs
   the pass-in pattern (translate at the call site and pass the string down) or a follow-up.
-- **`SubscriptionErrorBoundary`** — a class component; `useTranslations` can't run in its render.
 - **`app/global-error.tsx`** — replaces the entire HTML tree (no `NextIntlClientProvider` in scope),
   so it keeps hardcoded English.
 - **Content** (out of scope by design): blog/article/concept bodies, exercise/curriculum text,

--- a/app/.context/testing.md
+++ b/app/.context/testing.md
@@ -409,6 +409,20 @@ const element = array[0]!; // Assert element exists
 const result = object.method!(); // Assert method exists
 ```
 
+### Translations in Tests (next-intl)
+
+`jest.setup.js` globally mocks next-intl: components using `useTranslations` render the real
+English strings from `messages/en.json` (no provider needed per test). The mock supports
+namespaces, dotted keys, `{var}` interpolation, simple ICU plurals
+(`{count, plural, one {...} other {...}}`), and `t.rich` with nested tags. Consequences:
+
+- Assert on the real English text (`screen.getByText(/Jiki Premium/)`), not on message keys.
+- `t.rich` markup is split across elements, so exact-string matchers may need regex or a
+  function matcher when a sentence contains inline tags.
+- The mock is a simplification, not the real ICU engine. `tests/unit/messages.test.ts`
+  validates every catalog message against the real parser (`intl-messageformat`), so invalid
+  ICU fails there even though the mock would tolerate it.
+
 ### Centralized Mock Utilities
 
 The project provides centralized mock utilities in `tests/mocks/`:

--- a/app/components/auth/AuthErrorCard.tsx
+++ b/app/components/auth/AuthErrorCard.tsx
@@ -36,10 +36,13 @@ export function AuthErrorCard({ title, message, ctaHref, ctaText }: AuthErrorCar
               {ctaText}
             </Link>
             <p className={styles.confirmationCardFooter}>
-              {t("needHelpPrefix")}
-              <Link href={routes.article("support")} className="ui-link">
-                {t("contactSupport")}
-              </Link>
+              {t.rich("needHelp", {
+                link: (chunks) => (
+                  <Link href={routes.article("support")} className="ui-link">
+                    {chunks}
+                  </Link>
+                )
+              })}
             </p>
           </div>
         </div>

--- a/app/components/auth/CheckInboxMessage.tsx
+++ b/app/components/auth/CheckInboxMessage.tsx
@@ -23,10 +23,16 @@ export function CheckInboxMessage({ email }: CheckInboxMessageProps) {
             <p className={styles.confirmationText}>{t("sentTo")}</p>
             <p className={styles.confirmationEmail}>{email}</p>
             <p className={styles.confirmationHint}>
-              {t("hintPrefix")}
-              <Link href={`${routes.authResendConfirmation()}?email=${encodeURIComponent(email)}`} className="ui-link">
-                {t("resendLink")}
-              </Link>
+              {t.rich("hint", {
+                link: (chunks) => (
+                  <Link
+                    href={`${routes.authResendConfirmation()}?email=${encodeURIComponent(email)}`}
+                    className="ui-link"
+                  >
+                    {chunks}
+                  </Link>
+                )
+              })}
             </p>
           </div>
         </div>

--- a/app/components/auth/ForgotPasswordForm.tsx
+++ b/app/components/auth/ForgotPasswordForm.tsx
@@ -130,10 +130,13 @@ export function ForgotPasswordForm() {
 
           <div className={styles.footerLinks}>
             <p>
-              {t("rememberedPrompt")}
-              <Link href={routes.authLogin()} className="ui-link">
-                {t("loginLink")}
-              </Link>
+              {t.rich("remembered", {
+                link: (chunks) => (
+                  <Link href={routes.authLogin()} className="ui-link">
+                    {chunks}
+                  </Link>
+                )
+              })}
             </p>
           </div>
         </form>

--- a/app/components/auth/ForgotPasswordForm.tsx
+++ b/app/components/auth/ForgotPasswordForm.tsx
@@ -14,6 +14,7 @@ import styles from "./AuthForm.module.css";
 export function ForgotPasswordForm() {
   const t = useTranslations("auth.forgotPassword");
   const tc = useTranslations("auth");
+  const tCommon = useTranslations("common");
   const routes = useLocaleRoutes();
   const { requestPasswordReset, isLoading } = useAuthStore();
   const turnstile = useTurnstile();
@@ -30,7 +31,7 @@ export function ForgotPasswordForm() {
     if (!email) {
       errors.email = tc("fields.emailRequired");
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      errors.email = tc("fields.emailInvalidAddress");
+      errors.email = tCommon("validation.emailInvalid");
     }
 
     setValidationErrors(errors);
@@ -124,7 +125,7 @@ export function ForgotPasswordForm() {
             style={{ width: "100%" }}
             disabled={isLoading || verifying}
           >
-            {isLoading ? t("submitting") : verifying ? t("verifying") : t("submit")}
+            {isLoading ? tCommon("sending") : verifying ? tCommon("verifying") : t("submit")}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/LoginForm.tsx
+++ b/app/components/auth/LoginForm.tsx
@@ -19,6 +19,7 @@ import { GoogleAuthButton } from "./GoogleAuthButton";
 export function LoginForm() {
   const t = useTranslations("auth.login");
   const tc = useTranslations("auth");
+  const tCommon = useTranslations("common");
   const routes = useLocaleRoutes();
   const { login, isLoading } = useAuthStore();
   const { handleAuthResponse, handleGoogleSuccess, googleAuthError, returnTo, TwoFactorForm } = useAuth();
@@ -38,13 +39,13 @@ export function LoginForm() {
     if (!email) {
       errors.email = tc("fields.emailRequired");
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      errors.email = tc("fields.emailInvalid");
+      errors.email = tCommon("validation.emailInvalid");
     }
 
     if (!password) {
-      errors.password = tc("fields.passwordRequired");
+      errors.password = tCommon("validation.passwordRequired");
     } else if (password.length < 6) {
-      errors.password = tc("fields.passwordMinLength");
+      errors.password = tCommon("validation.passwordMinLength");
     }
 
     setValidationErrors(errors);
@@ -232,7 +233,7 @@ export function LoginForm() {
             style={{ width: "100%" }}
             disabled={isLoading || verifying}
           >
-            {isLoading ? t("submitting") : verifying ? t("verifying") : t("submit")}
+            {isLoading ? t("submitting") : verifying ? tCommon("verifying") : t("submit")}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/LoginForm.tsx
+++ b/app/components/auth/LoginForm.tsx
@@ -111,10 +111,13 @@ export function LoginForm() {
         <header>
           <h1>{t("title")}</h1>
           <p>
-            {t("noAccountPrefix")}
-            <Link href={buildUrlWithReturnTo(routes.authSignup(), returnTo)} className="ui-link">
-              {t("signUpLink")}
-            </Link>
+            {t.rich("noAccount", {
+              link: (chunks) => (
+                <Link href={buildUrlWithReturnTo(routes.authSignup(), returnTo)} className="ui-link">
+                  {chunks}
+                </Link>
+              )
+            })}
           </p>
         </header>
 
@@ -201,13 +204,16 @@ export function LoginForm() {
               )}
               {unconfirmedEmail && (
                 <div className="ui-form-field-error-message" style={{ display: "block" }}>
-                  {t("unconfirmedPrefix")}
-                  <Link
-                    href={`${routes.authResendConfirmation()}?email=${encodeURIComponent(unconfirmedEmail)}`}
-                    className="ui-link"
-                  >
-                    {t("resendConfirmationLink")}
-                  </Link>
+                  {t.rich("unconfirmed", {
+                    link: (chunks) => (
+                      <Link
+                        href={`${routes.authResendConfirmation()}?email=${encodeURIComponent(unconfirmedEmail)}`}
+                        className="ui-link"
+                      >
+                        {chunks}
+                      </Link>
+                    )
+                  })}
                 </div>
               )}
               {googleAuthError && (
@@ -238,10 +244,13 @@ export function LoginForm() {
 
           <div className={styles.footerLinks}>
             <p>
-              {t("resendPrompt")}
-              <Link href={routes.authResendConfirmation()} className="ui-link">
-                {t("resendLink")}
-              </Link>
+              {t.rich("resend", {
+                link: (chunks) => (
+                  <Link href={routes.authResendConfirmation()} className="ui-link">
+                    {chunks}
+                  </Link>
+                )
+              })}
             </p>
           </div>
         </form>

--- a/app/components/auth/ResendConfirmationForm.tsx
+++ b/app/components/auth/ResendConfirmationForm.tsx
@@ -13,6 +13,7 @@ import styles from "./AuthForm.module.css";
 export function ResendConfirmationForm() {
   const t = useTranslations("auth.resendConfirmation");
   const tc = useTranslations("auth");
+  const tCommon = useTranslations("common");
   const routes = useLocaleRoutes();
   const { resendConfirmation, isLoading, error, clearError } = useAuthStore();
   const searchParams = useSearchParams();
@@ -27,7 +28,7 @@ export function ResendConfirmationForm() {
     if (!email) {
       errors.email = tc("fields.emailRequired");
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      errors.email = t("emailInvalid");
+      errors.email = tCommon("validation.emailInvalid");
     }
 
     setValidationErrors(errors);
@@ -105,7 +106,7 @@ export function ResendConfirmationForm() {
             style={{ width: "100%" }}
             disabled={isLoading}
           >
-            {isLoading ? t("submitting") : t("submit")}
+            {isLoading ? tCommon("sending") : t("submit")}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/ResendConfirmationForm.tsx
+++ b/app/components/auth/ResendConfirmationForm.tsx
@@ -111,10 +111,13 @@ export function ResendConfirmationForm() {
 
           <div className={styles.footerLinks}>
             <p>
-              {t("confirmedPrompt")}
-              <Link href={routes.authLogin()} className="ui-link">
-                {t("loginLink")}
-              </Link>
+              {t.rich("confirmed", {
+                link: (chunks) => (
+                  <Link href={routes.authLogin()} className="ui-link">
+                    {chunks}
+                  </Link>
+                )
+              })}
             </p>
           </div>
         </form>

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -12,6 +12,7 @@ import styles from "./AuthForm.module.css";
 
 export function ResetPasswordForm() {
   const t = useTranslations("auth.resetPassword");
+  const tCommon = useTranslations("common");
   const routes = useLocaleRoutes();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -31,15 +32,15 @@ export function ResetPasswordForm() {
     }
 
     if (!password) {
-      errors.password = t("passwordRequired");
+      errors.password = tCommon("validation.passwordRequired");
     } else if (password.length < 6) {
-      errors.password = t("passwordMinLength");
+      errors.password = tCommon("validation.passwordMinLength");
     }
 
     if (!passwordConfirmation) {
       errors.passwordConfirmation = t("confirmationRequired");
     } else if (password !== passwordConfirmation) {
-      errors.passwordConfirmation = t("passwordsDontMatch");
+      errors.passwordConfirmation = tCommon("validation.passwordsNoMatch");
     }
 
     setValidationErrors(errors);

--- a/app/components/auth/ResetPasswordForm.tsx
+++ b/app/components/auth/ResetPasswordForm.tsx
@@ -178,10 +178,13 @@ export function ResetPasswordForm() {
 
           <div className={styles.footerLinks}>
             <p>
-              {t("rememberedPrefix")}
-              <Link href={routes.authLogin()} className="ui-link">
-                {t("signInLink")}
-              </Link>
+              {t.rich("remembered", {
+                link: (chunks) => (
+                  <Link href={routes.authLogin()} className="ui-link">
+                    {chunks}
+                  </Link>
+                )
+              })}
             </p>
           </div>
         </form>

--- a/app/components/auth/SignupForm.tsx
+++ b/app/components/auth/SignupForm.tsx
@@ -22,6 +22,7 @@ import { GoogleAuthButton } from "./GoogleAuthButton";
 export function SignupForm() {
   const t = useTranslations("auth.signup");
   const tc = useTranslations("auth");
+  const tCommon = useTranslations("common");
   const activeLocale = useLocale();
   const routes = useLocaleRoutes();
   const { signup, isLoading } = useAuthStore();
@@ -43,13 +44,13 @@ export function SignupForm() {
     if (!email) {
       errors.email = tc("fields.emailRequired");
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      errors.email = tc("fields.emailInvalid");
+      errors.email = tCommon("validation.emailInvalid");
     }
 
     if (!password) {
-      errors.password = tc("fields.passwordRequired");
+      errors.password = tCommon("validation.passwordRequired");
     } else if (password.length < 6) {
-      errors.password = tc("fields.passwordMinLength");
+      errors.password = tCommon("validation.passwordMinLength");
     }
 
     setValidationErrors(errors);
@@ -233,7 +234,7 @@ export function SignupForm() {
             style={{ width: "100%" }}
             disabled={isLoading || verifying}
           >
-            {isLoading ? t("submitting") : verifying ? t("verifying") : t("submit")}
+            {isLoading ? t("submitting") : verifying ? tCommon("verifying") : t("submit")}
           </button>
 
           <div className={styles.footerLinks}>

--- a/app/components/auth/SignupForm.tsx
+++ b/app/components/auth/SignupForm.tsx
@@ -135,11 +135,13 @@ export function SignupForm() {
         <header>
           <h1>{t("title")}</h1>
           <p>
-            {t("haveAccountPrefix")}
-            <Link href={buildUrlWithReturnTo(routes.authLogin(), returnTo)} className="ui-link">
-              {t("loginLink")}
-            </Link>
-            .
+            {t.rich("haveAccount", {
+              link: (chunks) => (
+                <Link href={buildUrlWithReturnTo(routes.authLogin(), returnTo)} className="ui-link">
+                  {chunks}
+                </Link>
+              )
+            })}
           </p>
         </header>
 
@@ -239,10 +241,13 @@ export function SignupForm() {
 
           <div className={styles.footerLinks}>
             <p>
-              {t("resendPrompt")}
-              <Link href={routes.authResendConfirmation()} className="ui-link">
-                {t("resendLink")}
-              </Link>
+              {t.rich("resend", {
+                link: (chunks) => (
+                  <Link href={routes.authResendConfirmation()} className="ui-link">
+                    {chunks}
+                  </Link>
+                )
+              })}
             </p>
           </div>
         </form>

--- a/app/components/auth/TwoFactorSetupForm.tsx
+++ b/app/components/auth/TwoFactorSetupForm.tsx
@@ -23,6 +23,8 @@ export function TwoFactorSetupForm({
   onSessionExpired
 }: TwoFactorSetupFormProps) {
   const t = useTranslations("auth.twoFactorSetup");
+  const tCommon = useTranslations("common");
+  const tShared = useTranslations("auth.twoFactor");
   const { setup2FA, isLoading } = useAuthStore();
   const [otpCode, setOtpCode] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -44,9 +46,9 @@ export function TwoFactorSetupForm({
           onSessionExpired();
           return;
         }
-        setError(errorData?.error?.message || t("invalidCode"));
+        setError(errorData?.error?.message || tShared("invalidCode"));
       } else {
-        setError(t("verificationFailed"));
+        setError(tShared("verificationFailed"));
       }
       setOtpCode("");
     }
@@ -82,7 +84,7 @@ export function TwoFactorSetupForm({
               <OTPInput value={otpCode} onChange={handleOtpChange} disabled={isLoading} hasError={!!error} autoFocus />
             </div>
 
-            {isLoading && <p className={styles.verifyingText}>{t("verifying")}</p>}
+            {isLoading && <p className={styles.verifyingText}>{tCommon("verifying")}</p>}
 
             <div className={styles.actions}>
               <button
@@ -92,7 +94,7 @@ export function TwoFactorSetupForm({
                 style={{ width: "100%" }}
                 disabled={isLoading}
               >
-                {t("cancel")}
+                {tShared("cancel")}
               </button>
             </div>
           </div>

--- a/app/components/auth/TwoFactorVerifyForm.tsx
+++ b/app/components/auth/TwoFactorVerifyForm.tsx
@@ -16,6 +16,8 @@ interface TwoFactorVerifyFormProps {
 
 export function TwoFactorVerifyForm({ onSuccess, onCancel, onSessionExpired }: TwoFactorVerifyFormProps) {
   const t = useTranslations("auth.twoFactorVerify");
+  const tCommon = useTranslations("common");
+  const tShared = useTranslations("auth.twoFactor");
   const { verify2FA, isLoading } = useAuthStore();
   const [otpCode, setOtpCode] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -37,9 +39,9 @@ export function TwoFactorVerifyForm({ onSuccess, onCancel, onSessionExpired }: T
           onSessionExpired();
           return;
         }
-        setError(errorData?.error?.message || t("invalidCode"));
+        setError(errorData?.error?.message || tShared("invalidCode"));
       } else {
-        setError(t("verificationFailed"));
+        setError(tShared("verificationFailed"));
       }
       setOtpCode("");
     }
@@ -69,7 +71,7 @@ export function TwoFactorVerifyForm({ onSuccess, onCancel, onSessionExpired }: T
               <OTPInput value={otpCode} onChange={handleOtpChange} disabled={isLoading} hasError={!!error} autoFocus />
             </div>
 
-            {isLoading && <p className={styles.verifyingText}>{t("verifying")}</p>}
+            {isLoading && <p className={styles.verifyingText}>{tCommon("verifying")}</p>}
 
             <div className={styles.actions}>
               <button
@@ -79,7 +81,7 @@ export function TwoFactorVerifyForm({ onSuccess, onCancel, onSessionExpired }: T
                 style={{ width: "100%" }}
                 disabled={isLoading}
               >
-                {t("cancel")}
+                {tShared("cancel")}
               </button>
             </div>
           </div>

--- a/app/components/choose-language/ui/VideoStep.tsx
+++ b/app/components/choose-language/ui/VideoStep.tsx
@@ -98,10 +98,13 @@ export function VideoStep({ lessonData, onReady, onProceedToSelector, hasVisited
 
       {!hasVisitedSelector && (
         <p className={styles.videoInstruction}>
-          {t("videoInstructionPrefix")}
-          <button className={styles.skipButton} onClick={handleSkip}>
-            {t("skipVideo")}
-          </button>
+          {t.rich("videoInstruction", {
+            skip: (chunks) => (
+              <button className={styles.skipButton} onClick={handleSkip}>
+                {chunks}
+              </button>
+            )
+          })}
         </p>
       )}
     </>

--- a/app/components/landing-page/BootcampSection.tsx
+++ b/app/components/landing-page/BootcampSection.tsx
@@ -45,8 +45,7 @@ export function BootcampSection() {
               <div className={styles.row}>
                 <div className={styles.lhs}>
                   <h3 className={styles.subHeading}>
-                    {t("part1Heading")}
-                    <span className="ui-emoji">🧑‍🔬</span>
+                    {t("part1Heading")} <span className="ui-emoji">🧑‍🔬</span>
                     <div className={styles.bubble}>{t("part1Bubble")}</div>
                   </h3>
                   <div className={styles["part-intro"]}>{t.rich("part1Intro", { highlight })}</div>
@@ -54,11 +53,14 @@ export function BootcampSection() {
                     <li>
                       <UnderstandingIcon width={20} height={20} />
                       <div className={styles.text}>
-                        {t.rich("part1Item1Prefix", { strong })}
-                        <Link href={routes.concepts()} className={styles.underline}>
-                          {t("part1Item1Link")}
-                        </Link>
-                        {t("part1Item1Suffix")}
+                        {t.rich("part1Item1", {
+                          strong,
+                          link: (chunks) => (
+                            <Link href={routes.concepts()} className={styles.underline}>
+                              {chunks}
+                            </Link>
+                          )
+                        })}
                       </div>
                     </li>
                     <li>

--- a/app/components/landing-page/FAQs.tsx
+++ b/app/components/landing-page/FAQs.tsx
@@ -12,19 +12,21 @@ export function FAQs() {
       <div className={styles.container}>
         <h2>{t("heading")}</h2>
         <p className={styles.intro}>
-          {t("introPrefix")}
-          <a href="mailto:hello@jiki.io">{t("introLink")}</a>
+          {t.rich("intro", { link: (chunks) => <a href="mailto:hello@jiki.io">{chunks}</a> })}
         </p>
         <div className={styles.faq}>
           <h4>{t("q1")}</h4>
           <p>{t.rich("q1a1", { strong })}</p>
           <p>
-            {t.rich("q1a2Prefix", { strong })}
-            <strong>
-              <MonthlyPrice />
-              {tCommon("perMonth")}
-            </strong>
-            {t("q1a2Suffix")}
+            {t.rich("q1a2", {
+              strong,
+              price: () => (
+                <strong>
+                  <MonthlyPrice />
+                  {tCommon("perMonth")}
+                </strong>
+              )
+            })}
           </p>
           <ul>
             <li>{t.rich("q1Item1", { strong })}</li>

--- a/app/components/landing-page/FAQs.tsx
+++ b/app/components/landing-page/FAQs.tsx
@@ -4,6 +4,7 @@ import styles from "./FAQs.module.css";
 
 export function FAQs() {
   const t = useTranslations("landing.faqs");
+  const tCommon = useTranslations("common");
   const strong = (chunks: React.ReactNode) => <strong>{chunks}</strong>;
   return (
     <section className={styles.faqs}>
@@ -21,7 +22,7 @@ export function FAQs() {
             {t.rich("q1a2Prefix", { strong })}
             <strong>
               <MonthlyPrice />
-              {t("q1PerMonth")}
+              {tCommon("perMonth")}
             </strong>
             {t("q1a2Suffix")}
           </p>

--- a/app/components/landing-page/Hero.tsx
+++ b/app/components/landing-page/Hero.tsx
@@ -110,11 +110,13 @@ export function Hero() {
       <div className={[styles["container"], shared["lg-container"]].join(" ")}>
         <div className={styles["hero-lhs"]}>
           <h1 ref={headlineRef} className={styles["rock-solid"]} data-rock-solid>
-            {t("headlinePart1")}
-            <span data-anim="highlight-headline" className={styles.headlineHighlight}>
-              {t("headlineHighlight")}
-            </span>
-            {t("headlinePart2")}
+            {t.rich("headline", {
+              highlight: (chunks) => (
+                <span data-anim="highlight-headline" className={styles.headlineHighlight}>
+                  {chunks}
+                </span>
+              )
+            })}
           </h1>
           <p ref={taglineRef} className={`${styles.tagline}`} data-tagline>
             {t.rich("tagline", {
@@ -123,19 +125,13 @@ export function Hero() {
             })}
           </p>
           <p ref={audienceRef} className={`${styles.tagline} `}>
-            {t("audiencePrefix")}
-            <span data-anim="highlight-audience" className={styles.highlightWhite}>
-              {t("audience1")}
-            </span>
-            {t("audienceMiddle")}
-            <span data-anim="highlight-audience" className={styles.highlightWhite}>
-              {t("audience2")}
-            </span>
-            {t("audienceAfter2")}
-            <span data-anim="highlight-audience" className={styles.highlightWhite}>
-              {t("audience3")}
-            </span>
-            {t("audienceSuffix")}
+            {t.rich("audience", {
+              highlight: (chunks) => (
+                <span data-anim="highlight-audience" className={styles.highlightWhite}>
+                  {chunks}
+                </span>
+              )
+            })}
           </p>
           <div className={styles["cta-wrapper"]}>
             <SignupButton />

--- a/app/components/landing-page/LatestNewsSection.tsx
+++ b/app/components/landing-page/LatestNewsSection.tsx
@@ -21,10 +21,13 @@ export function LatestNewsSection({ posts }: LatestNewsSectionProps) {
       <div className={styles.inner}>
         <h2 className={styles.heading}>{t("heading")}</h2>
         <p className={styles.subheading}>
-          {t("subheadingPrefix")}
-          <Link href={routes.blog()} className={styles.blogLink}>
-            {t("subheadingLink")}
-          </Link>
+          {t.rich("subheading", {
+            link: (chunks) => (
+              <Link href={routes.blog()} className={styles.blogLink}>
+                {chunks}
+              </Link>
+            )
+          })}
           .
         </p>
         <div className={styles.grid}>

--- a/app/components/landing-page/LatestNewsSection.tsx
+++ b/app/components/landing-page/LatestNewsSection.tsx
@@ -28,7 +28,6 @@ export function LatestNewsSection({ posts }: LatestNewsSectionProps) {
               </Link>
             )
           })}
-          .
         </p>
         <div className={styles.grid}>
           {posts.map((post) => (

--- a/app/components/landing-page/SignupButton.tsx
+++ b/app/components/landing-page/SignupButton.tsx
@@ -24,8 +24,9 @@ export function SignupButton({ className = "" }: SignupButtonProps) {
       onClick={ctaLaunch.handleClick}
     >
       <span>
-        {t("signUp")}
-        <span className={styles.free}>{t("free")}</span>
+        {t.rich("label", {
+          free: (chunks) => <span className={styles.free}>{chunks}</span>
+        })}
       </span>
       <span
         className={`${rocket.rocketWrapper} ${rocket.rocketWrapperLg} ${ctaLaunch.launching ? rocket.launching : ""}`}

--- a/app/components/landing-page/SignupSection.tsx
+++ b/app/components/landing-page/SignupSection.tsx
@@ -13,10 +13,7 @@ export function SignupSection() {
       <div className={styles["lhs-bg"]}></div>
       <div className={styles["rhs-bg"]}></div>
       <div className={`${shared["lg-container"]} ${styles.inner}`}>
-        <h2 className={styles.heading}>
-          {t("headingPrefix")}
-          {strong(t("headingHighlight"))}
-        </h2>
+        <h2 className={styles.heading}>{t.rich("heading", { strong })}</h2>
         <p className={styles.intro}>{t.rich("intro", { strong })}</p>
         <Link href={routes.authSignup()} className="ui-btn ui-btn-xlarge ui-btn-primary">
           {t("button")}

--- a/app/components/landing-page/TestimonialsSection.tsx
+++ b/app/components/landing-page/TestimonialsSection.tsx
@@ -66,10 +66,13 @@ export function TestimonialsSection() {
       <div className={shared["lg-container"]}>
         <h2>{t("heading")}</h2>
         <p className={styles.subheading}>
-          {t("subheadingPrefix")}
-          <Link className={styles.subheadingLink} href={routes.testimonials()}>
-            {t("subheadingLink")}
-          </Link>
+          {t.rich("subheading", {
+            link: (chunks) => (
+              <Link className={styles.subheadingLink} href={routes.testimonials()}>
+                {chunks}
+              </Link>
+            )
+          })}
         </p>
         <div className={styles["primary-quote"]}>
           <div className={styles.words}>

--- a/app/components/landing-page/WelcomeSection.tsx
+++ b/app/components/landing-page/WelcomeSection.tsx
@@ -19,6 +19,7 @@ import { SignupButton } from "./SignupButton";
 
 export function WelcomeSection() {
   const t = useTranslations("landing.welcome");
+  const tCommon = useTranslations("common");
   const routes = useLocaleRoutes();
   const annotationsRef = useRoughAnnotations();
   const wavingHandRef = useWavingHand();
@@ -170,7 +171,7 @@ export function WelcomeSection() {
           {t.rich("para16Prefix", { strong })}
           <strong>
             <MonthlyPrice />
-            {t("para16PerMonth")}
+            {tCommon("perMonth")}
           </strong>
           {t("para16Suffix")}
         </p>

--- a/app/components/landing-page/WelcomeSection.tsx
+++ b/app/components/landing-page/WelcomeSection.tsx
@@ -38,10 +38,11 @@ export function WelcomeSection() {
         <div className={styles.introBlock}>
           <div className={styles.introInner}>
             <h2>
-              <span className={`${styles.headingHighlight} intro-aspiring-coder rough-highlight`}>
-                {t("headingHighlight")}
-              </span>
-              {t("headingRest")}
+              {t.rich("heading", {
+                highlight: (chunks) => (
+                  <span className={`${styles.headingHighlight} intro-aspiring-coder rough-highlight`}>{chunks}</span>
+                )
+              })}
             </h2>
             <p>{t.rich("para1", { strong })}</p>
             <p>{t.rich("para2", { strong, highlight })}</p>
@@ -101,14 +102,19 @@ export function WelcomeSection() {
           </div>
         </div>
         <p className={styles.paraSpaced}>
-          {t("para10Prefix")}
-          <span className={styles.eventuallyShort}>{t("para10Eventually")}</span>
-          <span className={styles.eventuallyLong}>
-            <span className={`rough-underline ${styles.nowrap}`} id="eventually-underline">
-              {t("para10Eventually")}
-            </span>
-            <span className={styles["rhodri-arrow"]} ref={rhodriRef}></span>
-          </span>
+          {t.rich("para10", {
+            eventually: (chunks) => (
+              <>
+                <span className={styles.eventuallyShort}>{chunks}</span>
+                <span className={styles.eventuallyLong}>
+                  <span className={`rough-underline ${styles.nowrap}`} id="eventually-underline">
+                    {chunks}
+                  </span>
+                  <span className={styles["rhodri-arrow"]} ref={rhodriRef}></span>
+                </span>
+              </>
+            )
+          })}
         </p>
         <p>{t("para11")}</p>
         <p>{t.rich("para12", { strong })}</p>
@@ -168,18 +174,24 @@ export function WelcomeSection() {
         <h3 className={styles.sectionHeading}>{t("heading5")}</h3>
         <p>{t.rich("para15", { highlight: strongHighlight })}</p>
         <p>
-          {t.rich("para16Prefix", { strong })}
-          <strong>
-            <MonthlyPrice />
-            {tCommon("perMonth")}
-          </strong>
-          {t("para16Suffix")}
+          {t.rich("para16", {
+            strong,
+            price: () => (
+              <strong>
+                <MonthlyPrice />
+                {tCommon("perMonth")}
+              </strong>
+            )
+          })}
         </p>
         <p>
-          {t("para17Prefix")}
-          <Link href={routes.authSignup()} className={styles.inlineLink}>
-            {t("para17Link")}
-          </Link>
+          {t.rich("para17", {
+            link: (chunks) => (
+              <Link href={routes.authSignup()} className={styles.inlineLink}>
+                {chunks}
+              </Link>
+            )
+          })}
         </p>
         <div className={styles.ctaRow}>
           <span className={`${styles.ctaPointer} ${styles.ctaPointerRight}`} aria-hidden="true">
@@ -190,7 +202,7 @@ export function WelcomeSection() {
             className={`ui-btn ui-btn-xlarge ui-btn-primary ${rocket.bounceOnHover}`}
             onClick={ctaLaunch.handleClick}
           >
-            {t("ctaButton")}
+            {t("ctaButton")}{" "}
             <span
               className={`${rocket.rocketWrapper} ${rocket.rocketWrapperLg} ${ctaLaunch.launching ? rocket.launching : ""}`}
             >

--- a/app/components/premium/FaqSection.tsx
+++ b/app/components/premium/FaqSection.tsx
@@ -19,17 +19,9 @@ export default function FaqSection() {
                 <summary>{question}</summary>
                 <div className={styles["faq-answer"]}>
                   <p>
-                    {item.answerLinkKeyPrefix ? (
-                      <>
-                        {t(`${item.answerLinkKeyPrefix}Prefix` as Parameters<typeof t>[0])}
-                        <Link href={routes.article("support")}>
-                          {t(`${item.answerLinkKeyPrefix}Link` as Parameters<typeof t>[0])}
-                        </Link>
-                        {t(`${item.answerLinkKeyPrefix}Suffix` as Parameters<typeof t>[0])}
-                      </>
-                    ) : (
-                      t(item.answerKey as Parameters<typeof t>[0])
-                    )}
+                    {t.rich(item.answerKey as Parameters<typeof t.rich>[0], {
+                      link: (chunks) => <Link href={routes.article("support")}>{chunks}</Link>
+                    })}
                   </p>
                 </div>
               </details>

--- a/app/components/premium/pricing.data.ts
+++ b/app/components/premium/pricing.data.ts
@@ -98,6 +98,6 @@ export const FAQ_ITEMS: FaqItemData[] = [
   { questionKey: "q1", answerKey: "a1" },
   { questionKey: "q2", answerKey: "a2" },
   { questionKey: "q3", answerKey: "a3" },
-  { questionKey: "q4", answerLinkKeyPrefix: "a4" },
+  { questionKey: "q4", answerKey: "a4" },
   { questionKey: "q5", answerKey: "a5" }
 ];

--- a/app/components/premium/pricing.types.ts
+++ b/app/components/premium/pricing.types.ts
@@ -1,8 +1,6 @@
 export interface FaqItemData {
   questionKey: string;
-  answerKey?: string;
-  // When set, the answer is rendered with an embedded support link (a4Prefix/a4Link/a4Suffix).
-  answerLinkKeyPrefix?: string;
+  answerKey: string;
 }
 
 export interface FeatureRowData {

--- a/app/components/settings/modals/AvatarEditModal.tsx
+++ b/app/components/settings/modals/AvatarEditModal.tsx
@@ -24,6 +24,7 @@ const MAX_ZOOM = 3;
 export function AvatarEditModal() {
   const t = useTranslations("toasts.avatar");
   const ts = useTranslations("settings.avatarEdit");
+  const tCommon = useTranslations("common");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const user = useAuthStore((state) => state.user);
@@ -172,7 +173,7 @@ export function AvatarEditModal() {
 
       <div className={styles.buttons}>
         <button type="button" onClick={hideModal} className="ui-btn ui-btn-default ui-btn-tertiary">
-          {ts("cancel")}
+          {tCommon("cancel")}
         </button>
       </div>
 

--- a/app/components/settings/modals/ChangeEmailModal.tsx
+++ b/app/components/settings/modals/ChangeEmailModal.tsx
@@ -12,6 +12,7 @@ interface ChangeEmailModalProps {
 
 export function ChangeEmailModal({ currentEmail, onSave }: ChangeEmailModalProps) {
   const t = useTranslations("settings.changeEmail");
+  const tCommon = useTranslations("common");
   const [newEmail, setNewEmail] = useState("");
   const [currentPassword, setCurrentPassword] = useState("");
   const [isSaving, setIsSaving] = useState(false);
@@ -33,7 +34,7 @@ export function ChangeEmailModal({ currentEmail, onSave }: ChangeEmailModalProps
     }
 
     if (!validateEmail(newEmail)) {
-      setError(t("emailInvalid"));
+      setError(tCommon("validation.emailInvalid"));
       return;
     }
 
@@ -43,7 +44,7 @@ export function ChangeEmailModal({ currentEmail, onSave }: ChangeEmailModalProps
     }
 
     if (!currentPassword) {
-      setError(t("passwordRequired"));
+      setError(tCommon("validation.currentPasswordRequired"));
       return;
     }
 
@@ -116,7 +117,7 @@ export function ChangeEmailModal({ currentEmail, onSave }: ChangeEmailModalProps
             disabled={isSaving}
             className="ui-btn ui-btn-small ui-btn-secondary flex-1"
           >
-            {t("cancel")}
+            {tCommon("cancel")}
           </button>
         </div>
       </form>

--- a/app/components/settings/modals/ChangePasswordModal.tsx
+++ b/app/components/settings/modals/ChangePasswordModal.tsx
@@ -11,6 +11,7 @@ interface ChangePasswordModalProps {
 
 export function ChangePasswordModal({ onSave }: ChangePasswordModalProps) {
   const t = useTranslations("settings.changePassword");
+  const tCommon = useTranslations("common");
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -23,22 +24,22 @@ export function ChangePasswordModal({ onSave }: ChangePasswordModalProps) {
 
     // Validation
     if (!currentPassword) {
-      setError(t("currentRequired"));
+      setError(tCommon("validation.currentPasswordRequired"));
       return;
     }
 
     if (!newPassword) {
-      setError(t("newRequired"));
+      setError(tCommon("validation.newPasswordRequired"));
       return;
     }
 
-    if (newPassword.length < 8) {
-      setError(t("minLength"));
+    if (newPassword.length < 6) {
+      setError(tCommon("validation.passwordMinLength"));
       return;
     }
 
     if (newPassword !== confirmPassword) {
-      setError(t("noMatch"));
+      setError(tCommon("validation.passwordsNoMatch"));
       return;
     }
 
@@ -120,7 +121,7 @@ export function ChangePasswordModal({ onSave }: ChangePasswordModalProps) {
             disabled={isSaving}
             className="ui-btn ui-btn-secondary ui-btn-small flex-1"
           >
-            {t("cancel")}
+            {tCommon("cancel")}
           </button>
         </div>
       </form>

--- a/app/components/settings/modals/DeleteAccountModal.tsx
+++ b/app/components/settings/modals/DeleteAccountModal.tsx
@@ -43,6 +43,7 @@ function ConfirmStep({
   error: string | null;
 }) {
   const t = useTranslations("settings.deleteAccount");
+  const tCommon = useTranslations("common");
   return (
     <div className={styles.content}>
       <h3 className={styles.title}>{t("confirmTitle")}</h3>
@@ -50,10 +51,10 @@ function ConfirmStep({
       {error && <p className={styles.error}>{error}</p>}
       <div className={styles.buttons}>
         <button className="ui-btn ui-btn-small ui-btn-primary" onClick={hideModal} disabled={isLoading}>
-          {t("cancel")}
+          {tCommon("cancel")}
         </button>
         <button className="ui-btn ui-btn-default ui-btn-danger" onClick={onConfirm} disabled={isLoading}>
-          {isLoading ? t("submitting") : t("submit")}
+          {isLoading ? tCommon("sending") : t("submit")}
         </button>
       </div>
     </div>

--- a/app/components/settings/sections/ProfileSection.tsx
+++ b/app/components/settings/sections/ProfileSection.tsx
@@ -15,6 +15,7 @@ interface ProfileSectionProps {
 
 export default function ProfileSection({ settings, updateName, updateHandle, updateEmail }: ProfileSectionProps) {
   const t = useTranslations("settings.profile");
+  const tCommon = useTranslations("common");
 
   // Validation functions
   const validateName = (value: string): string | null => {
@@ -48,7 +49,7 @@ export default function ProfileSection({ settings, updateName, updateHandle, upd
       return t("emailEmpty");
     }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
-      return t("emailInvalid");
+      return tCommon("validation.emailInvalid");
     }
     return null;
   };

--- a/app/components/settings/sections/ProfileSection.tsx
+++ b/app/components/settings/sections/ProfileSection.tsx
@@ -91,8 +91,10 @@ export default function ProfileSection({ settings, updateName, updateHandle, upd
         {settings.unconfirmed_email && (
           <StatusNotification variant="info">
             <p>
-              {t("confirmationPendingPrefix")}
-              <strong>{settings.unconfirmed_email}</strong>
+              {t.rich("confirmationPending", {
+                email: settings.unconfirmed_email,
+                strong: (chunks) => <strong>{chunks}</strong>
+              })}
             </p>
             <p className="text-xs mt-4">{t("confirmationPendingHint")}</p>
           </StatusNotification>

--- a/app/components/settings/subscription/BenefitSection.tsx
+++ b/app/components/settings/subscription/BenefitSection.tsx
@@ -68,6 +68,7 @@ function CancellingBenefitSection({
   className?: string;
 }) {
   const t = useTranslations("settings.benefits");
+  const tCommon = useTranslations("common");
   return (
     <div className={`${styles.benefitsSection} ${className}`}>
       <div className={styles.benefitsHeader}>
@@ -88,7 +89,7 @@ function CancellingBenefitSection({
             {t("resubscribePrefix")}
             <span className={styles.price}>
               <PremiumPrice interval="monthly" />
-              {t("resubscribePerMonth")}
+              {tCommon("perMonth")}
             </span>
             {t("resubscribeSuffix")}
           </p>
@@ -105,14 +106,14 @@ function CancellingBenefitSection({
 }
 
 function BenefitsList() {
-  const t = useTranslations("settings.benefits");
+  const tBenefits = useTranslations("premium.benefits");
   const benefits = [
-    { title: t("unlimitedAiTitle"), description: t("unlimitedAiDescription") },
-    { title: t("unlimitedContentTitle"), description: t("unlimitedContentDescription") },
-    { title: t("certificatesTitle"), description: t("certificatesDescription") },
-    { title: t("adFreeTitle"), description: t("adFreeDescription") },
-    { title: t("prioritySupportTitle"), description: t("prioritySupportDescription") },
-    { title: t("earlyAccessTitle"), description: t("earlyAccessDescription") }
+    { title: tBenefits("unlimitedAiTitle"), description: tBenefits("unlimitedAiDescription") },
+    { title: tBenefits("unlimitedContentTitle"), description: tBenefits("unlimitedContentDescription") },
+    { title: tBenefits("certificatesTitle"), description: tBenefits("certificatesDescription") },
+    { title: tBenefits("adFreeTitle"), description: tBenefits("adFreeDescription") },
+    { title: tBenefits("prioritySupportTitle"), description: tBenefits("prioritySupportDescription") },
+    { title: tBenefits("earlyAccessTitle"), description: tBenefits("earlyAccessDescription") }
   ];
   return (
     <div className={styles.premiumBenefits}>

--- a/app/components/settings/subscription/BenefitSection.tsx
+++ b/app/components/settings/subscription/BenefitSection.tsx
@@ -34,9 +34,7 @@ function ActiveBenefitSection({ className = "" }: { className?: string }) {
           className={`${styles.splashDecoration} ${styles.splashLeft}`}
         />
         <h3>
-          {t("activeHeadingPrefix")}
-          <span className={styles.gradientText}>{t("premium")}</span>
-          {t("activeHeadingSuffix")}
+          {t.rich("activeHeading", { highlight: (chunks) => <span className={styles.gradientText}>{chunks}</span> })}
         </h3>
         <Image
           src="/static/images/misc/splash.png"
@@ -51,10 +49,10 @@ function ActiveBenefitSection({ className = "" }: { className?: string }) {
       <BenefitsList />
 
       <p className={styles.benefitsFooter}>
-        {t("footerPrefix")}
-        <Link href={routes.premium()}>{t("footerWhatsIncluded")}</Link>
-        {t("footerOr")}
-        <Link href={routes.article("support")}>{t("footerContactSupport")}</Link>.
+        {t.rich("footer", {
+          includedLink: (chunks) => <Link href={routes.premium()}>{chunks}</Link>,
+          supportLink: (chunks) => <Link href={routes.article("support")}>{chunks}</Link>
+        })}
       </p>
     </div>
   );
@@ -73,9 +71,9 @@ function CancellingBenefitSection({
     <div className={`${styles.benefitsSection} ${className}`}>
       <div className={styles.benefitsHeader}>
         <h3>
-          {t("cancellingHeadingPrefix")}
-          <span className={styles.gradientText}>{t("premium")}</span>
-          {t("cancellingHeadingSuffix")}
+          {t.rich("cancellingHeading", {
+            highlight: (chunks) => <span className={styles.gradientText}>{chunks}</span>
+          })}
         </h3>
       </div>
       <p className={styles.benefitsSubtitle}>{t("cancellingSubtitle")}</p>
@@ -86,12 +84,14 @@ function CancellingBenefitSection({
         <div className={styles.resubscribeCtaContent}>
           <h4>{t("resubscribeTitle")}</h4>
           <p>
-            {t("resubscribePrefix")}
-            <span className={styles.price}>
-              <PremiumPrice interval="monthly" />
-              {tCommon("perMonth")}
-            </span>
-            {t("resubscribeSuffix")}
+            {t.rich("resubscribe", {
+              price: () => (
+                <span className={styles.price}>
+                  <PremiumPrice interval="monthly" />
+                  {tCommon("perMonth")}
+                </span>
+              )
+            })}
           </p>
         </div>
         <button

--- a/app/components/settings/subscription/PremiumUpsell.tsx
+++ b/app/components/settings/subscription/PremiumUpsell.tsx
@@ -39,9 +39,7 @@ export default function PremiumUpsell({
   return (
     <div className={`${styles.premiumUpsell} ${className}`}>
       <h2 className={styles.premiumUpsellHeadline}>
-        {t("headlinePrefix")}
-        <span className={styles.highlight}>{t("headlineHighlight")}</span>
-        {t("headlineSuffix")}
+        {t.rich("headline", { highlight: (chunks) => <span className={styles.highlight}>{chunks}</span> })}
       </h2>
       <p className={styles.premiumUpsellSubtitle}>{t("subtitle")}</p>
 
@@ -67,9 +65,7 @@ export default function PremiumUpsell({
               <span className={styles.period}>{tCommon("perMonth")}</span>
             </div>
             <p className={styles.premiumUpsellNote}>
-              {t("dailyNotePrefix")}
-              <PremiumDailyPrice interval="monthly" />
-              {t("dailyNoteSuffix")}
+              {t.rich("dailyNote", { price: () => <PremiumDailyPrice interval="monthly" /> })}
             </p>
           </div>
         </div>

--- a/app/components/settings/subscription/PremiumUpsell.tsx
+++ b/app/components/settings/subscription/PremiumUpsell.tsx
@@ -16,11 +16,13 @@ export default function PremiumUpsell({
   className = ""
 }: PremiumUpsellProps) {
   const t = useTranslations("settings.premiumUpsell");
+  const tCommon = useTranslations("common");
+  const tBenefits = useTranslations("premium.benefits");
   const features = [
-    { title: t("unlimitedAiTitle"), description: t("unlimitedAiDescription") },
-    { title: t("unlimitedContentTitle"), description: t("unlimitedContentDescription") },
-    { title: t("certificatesTitle"), description: t("certificatesDescription") },
-    { title: t("adFreeTitle"), description: t("adFreeDescription") }
+    { title: tBenefits("unlimitedAiTitle"), description: tBenefits("unlimitedAiDescription") },
+    { title: tBenefits("unlimitedContentTitle"), description: tBenefits("unlimitedContentDescription") },
+    { title: tBenefits("certificatesTitle"), description: tBenefits("certificatesDescription") },
+    { title: tBenefits("adFreeTitle"), description: tBenefits("adFreeDescription") }
   ];
   const [internalLoading, setInternalLoading] = useState(false);
   const isLoading = externalLoading || internalLoading;
@@ -62,7 +64,7 @@ export default function PremiumUpsell({
               <span className={styles.amount}>
                 <PremiumPrice interval="monthly" />
               </span>
-              <span className={styles.period}>{t("perMonth")}</span>
+              <span className={styles.period}>{tCommon("perMonth")}</span>
             </div>
             <p className={styles.premiumUpsellNote}>
               {t("dailyNotePrefix")}
@@ -76,7 +78,7 @@ export default function PremiumUpsell({
           onClick={handleUpgrade}
           disabled={isLoading}
         >
-          {isLoading ? t("processing") : t("upgrade")}
+          {isLoading ? tCommon("processing") : t("upgrade")}
         </button>
       </div>
     </div>

--- a/app/components/settings/subscription/SubscriptionErrorBoundary.tsx
+++ b/app/components/settings/subscription/SubscriptionErrorBoundary.tsx
@@ -2,8 +2,18 @@
 
 import { Component, type ErrorInfo, type ReactNode } from "react";
 
+export interface SubscriptionErrorBoundaryMessages {
+  title: string;
+  messagePart1: string;
+  messagePart2: string;
+  refresh: string;
+  tryAgain: string;
+  detailsSummary: string;
+}
+
 interface SubscriptionErrorBoundaryProps {
   children: ReactNode;
+  messages: SubscriptionErrorBoundaryMessages;
   fallback?: ReactNode;
 }
 
@@ -35,19 +45,18 @@ export default class SubscriptionErrorBoundary extends Component<
         return this.props.fallback;
       }
 
+      const { messages } = this.props;
+
       return (
         <div className="bg-red-50 border border-red-200 rounded-lg p-6">
           <div className="flex items-center mb-4">
             <div className="w-12 h-12 bg-red-500 rounded-full mr-12"></div>
-            <h3 className="font-medium text-red-900">Subscription System Error</h3>
+            <h3 className="font-medium text-red-900">{messages.title}</h3>
           </div>
 
           <div className="text-red-800 text-sm mb-4">
-            <p className="mb-2">
-              We&apos;re experiencing issues loading your subscription information. This might be a temporary problem
-              with our payment system.
-            </p>
-            <p>Please try refreshing the page, or contact support if the issue persists.</p>
+            <p className="mb-2">{messages.messagePart1}</p>
+            <p>{messages.messagePart2}</p>
           </div>
 
           <div className="flex gap-12">
@@ -55,19 +64,19 @@ export default class SubscriptionErrorBoundary extends Component<
               onClick={() => window.location.reload()}
               className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition-colors focus-ring"
             >
-              Refresh Page
+              {messages.refresh}
             </button>
             <button
               onClick={() => this.setState({ hasError: false })}
               className="px-4 py-2 bg-red-100 text-red-700 border border-red-300 rounded hover:bg-red-200 transition-colors focus-ring"
             >
-              Try Again
+              {messages.tryAgain}
             </button>
           </div>
 
           {process.env.NODE_ENV === "development" && this.state.error && (
             <details className="mt-4 p-12 bg-red-100 border border-red-300 rounded text-xs">
-              <summary className="cursor-pointer font-medium text-red-900 mb-2">Error Details (Development)</summary>
+              <summary className="cursor-pointer font-medium text-red-900 mb-2">{messages.detailsSummary}</summary>
               <pre className="text-red-800 whitespace-pre-wrap break-words">
                 {this.state.error.message}
                 {"\n"}

--- a/app/components/settings/subscription/states/NeverSubscribedState.tsx
+++ b/app/components/settings/subscription/states/NeverSubscribedState.tsx
@@ -10,6 +10,7 @@ interface NeverSubscribedStateProps {
 
 export default function NeverSubscribedState({ onUpgradeToPremium, isLoading = false }: NeverSubscribedStateProps) {
   const t = useTranslations("settings.neverSubscribed");
+  const tCommon = useTranslations("common");
   const premiumTier = PRICING_TIERS.premium;
 
   return (
@@ -29,7 +30,7 @@ export default function NeverSubscribedState({ onUpgradeToPremium, isLoading = f
           </h4>
           <p className="text-2xl font-bold text-text-primary mb-4">
             <PremiumPrice interval="monthly" />
-            <span className="text-sm font-normal">{t("perMonth")}</span>
+            <span className="text-sm font-normal">{tCommon("perMonth")}</span>
           </p>
           <ul className="text-sm text-text-secondary space-y-4 mb-4" aria-label={t("featuresLabel")}>
             {premiumTier.features.map((feature: string, index: number) => (

--- a/app/components/settings/tabs/SubscriptionTab.tsx
+++ b/app/components/settings/tabs/SubscriptionTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { User } from "@/types/auth";
 import SubscriptionErrorBoundary from "../subscription/SubscriptionErrorBoundary";
 import SubscriptionSection from "../subscription/SubscriptionSection";
@@ -10,8 +11,18 @@ interface SubscriptionTabProps {
 }
 
 export default function SubscriptionTab({ user, refreshUser }: SubscriptionTabProps) {
+  const t = useTranslations("settings.errorBoundary");
   return (
-    <SubscriptionErrorBoundary>
+    <SubscriptionErrorBoundary
+      messages={{
+        title: t("title"),
+        messagePart1: t("messagePart1"),
+        messagePart2: t("messagePart2"),
+        refresh: t("refresh"),
+        tryAgain: t("tryAgain"),
+        detailsSummary: t("detailsSummary")
+      }}
+    >
       <SubscriptionSection user={user} refreshUser={refreshUser} />
     </SubscriptionErrorBoundary>
   );

--- a/app/components/settings/ui/EditableField.tsx
+++ b/app/components/settings/ui/EditableField.tsx
@@ -27,6 +27,7 @@ export default function EditableField({
   updateButtonText
 }: EditableFieldProps) {
   const t = useTranslations("settings.editableField");
+  const tCommon = useTranslations("common");
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(value);
   const [isSaving, setIsSaving] = useState(false);
@@ -100,7 +101,7 @@ export default function EditableField({
           </div>
           <div className={styles.buttonRow}>
             <button onClick={handleCancel} disabled={isSaving} className="ui-btn ui-btn-secondary ui-btn-small">
-              {t("cancel")}
+              {tCommon("cancel")}
             </button>
             <button
               onClick={handleSave}

--- a/app/components/settings/ui/PasswordField.tsx
+++ b/app/components/settings/ui/PasswordField.tsx
@@ -12,6 +12,7 @@ interface PasswordFieldProps {
 
 export default function PasswordField({ onSave, disabled = false }: PasswordFieldProps) {
   const t = useTranslations("settings.passwordField");
+  const tCommon = useTranslations("common");
   const [isEditing, setIsEditing] = useState(false);
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -29,19 +30,19 @@ export default function PasswordField({ onSave, disabled = false }: PasswordFiel
   const handleSave = async () => {
     // Validation
     if (!currentPassword) {
-      setError(t("currentRequired"));
+      setError(tCommon("validation.currentPasswordRequired"));
       return;
     }
     if (!newPassword) {
-      setError(t("newRequired"));
+      setError(tCommon("validation.newPasswordRequired"));
       return;
     }
-    if (newPassword.length < 8) {
-      setError(t("minLength"));
+    if (newPassword.length < 6) {
+      setError(tCommon("validation.passwordMinLength"));
       return;
     }
     if (newPassword !== confirmPassword) {
-      setError(t("noMatch"));
+      setError(tCommon("validation.passwordsNoMatch"));
       return;
     }
 
@@ -116,7 +117,7 @@ export default function PasswordField({ onSave, disabled = false }: PasswordFiel
           {error && <div className={styles.errorMessage}>{error}</div>}
           <div className={styles.buttonRow}>
             <button onClick={handleCancel} disabled={isSaving} className="ui-btn ui-btn-secondary ui-btn-small">
-              {t("cancel")}
+              {tCommon("cancel")}
             </button>
             <button onClick={handleSave} disabled={isSaving} className="ui-btn ui-btn-primary ui-btn-small">
               {isSaving ? <LoadingSpinner size="sm" /> : t("submit")}

--- a/app/components/settings/ui/SubscriptionButton.tsx
+++ b/app/components/settings/ui/SubscriptionButton.tsx
@@ -24,7 +24,7 @@ export default function SubscriptionButton({
   ariaLabel,
   ariaDescribedBy
 }: SubscriptionButtonProps) {
-  const t = useTranslations("settings.subscriptionButton");
+  const t = useTranslations("common");
   const baseClasses =
     "font-medium rounded transition-all duration-200 focus-ring disabled:opacity-50 disabled:cursor-not-allowed";
 

--- a/app/components/settings/ui/SubscriptionStatus.tsx
+++ b/app/components/settings/ui/SubscriptionStatus.tsx
@@ -69,20 +69,13 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
           <h3>{t("currentPlan")}</h3>
         </div>
         <p>
-          {t("activePrefix")}
-          <span className={styles.gradientText}>{t("activePlanName", { tier: tierDetails.name })}</span>
-          {t("activeMiddle")}
-          <strong>
-            <PremiumPrice interval="monthly" />
-            {tCommon("perMonth")}
-          </strong>
-          {nextBillingDate && (
-            <>
-              {t("activeNextBillingPrefix")}
-              <strong>{nextBillingDate}</strong>
-            </>
-          )}
-          .
+          {t.rich(nextBillingDate ? "activeWithBilling" : "active", {
+            tier: tierDetails.name,
+            date: nextBillingDate ?? "",
+            plan: (chunks) => <span className={styles.gradientText}>{chunks}</span>,
+            strong: (chunks) => <strong>{chunks}</strong>,
+            price: () => <PremiumPrice interval="monthly" />
+          })}
         </p>
       </div>
     );
@@ -99,17 +92,20 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
           {t("cancellingMessage")}
           {daysRemaining !== null && (
             <>
-              {t("cancellingRemainingPrefix")}
-              <strong>
-                {daysRemaining} {daysRemaining === 1 ? t("cancellingDay") : t("cancellingDays")}
-              </strong>
-              {t("cancellingRemainingSuffix")}
+              {" "}
+              {t.rich("cancellingRemaining", {
+                count: daysRemaining,
+                strong: (chunks) => <strong>{chunks}</strong>
+              })}
             </>
           )}
           {nextBillingDate && (
             <>
-              {t("cancellingEndsPrefix")}
-              <strong>{nextBillingDate}</strong>.
+              {" "}
+              {t.rich("cancellingEnds", {
+                date: nextBillingDate,
+                strong: (chunks) => <strong>{chunks}</strong>
+              })}
             </>
           )}
         </p>
@@ -122,11 +118,7 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
     return (
       <div className={`${styles.settingItem} ${className}`}>
         <h3>{t("currentPlan")}</h3>
-        <p style={{ marginBottom: 0 }}>
-          {t("freePrefix")}
-          <strong>{t("freePlanName")}</strong>
-          {t("freeSuffix")}
-        </p>
+        <p style={{ marginBottom: 0 }}>{t.rich("free", { strong: (chunks) => <strong>{chunks}</strong> })}</p>
       </div>
     );
   }
@@ -146,8 +138,7 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
             role="status"
             aria-label={t("currentPlanAriaLabel", { plan: tierDetails.name })}
           >
-            {tierDetails.name}
-            {t("planSuffix")}
+            {t("planLabel", { tier: tierDetails.name })}
           </div>
           <div
             className={`px-2 py-4 rounded text-xs font-medium ${statusInfo.bgColor} ${statusInfo.color}`}

--- a/app/components/settings/ui/SubscriptionStatus.tsx
+++ b/app/components/settings/ui/SubscriptionStatus.tsx
@@ -14,6 +14,7 @@ interface SubscriptionStatusProps {
 
 export default function SubscriptionStatus({ tier, status, nextBillingDate, className = "" }: SubscriptionStatusProps) {
   const t = useTranslations("settings.subscriptionStatus");
+  const tCommon = useTranslations("common");
   const tierDetails = PRICING_TIERS[tier];
   const isActiveSubscription = tier !== "standard" && status === "active";
   const isCancelling = tier !== "standard" && status === "cancelling";
@@ -73,7 +74,7 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
           {t("activeMiddle")}
           <strong>
             <PremiumPrice interval="monthly" />
-            {t("activePerMonth")}
+            {tCommon("perMonth")}
           </strong>
           {nextBillingDate && (
             <>
@@ -161,7 +162,7 @@ export default function SubscriptionStatus({ tier, status, nextBillingDate, clas
       <div className="text-text-secondary text-sm">
         <p>
           <PremiumPrice interval="monthly" />
-          {t("perMonth")}
+          {tCommon("perMonth")}
         </p>
 
         {/* Status-specific messages */}

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -89,13 +89,19 @@ jest.mock("next-intl", () => {
     return path.split(".").reduce((node, part) => (node == null ? undefined : node[part]), messages);
   };
 
+  // Plural bodies may contain simple {var} placeholders but no deeper nesting;
+  // tests/unit/messages.test.ts enforces that catalog messages stay within this
+  // subset so the mock can't silently diverge from the real ICU engine.
   const interpolate = (template, values = {}) =>
     String(template)
-      .replace(/\{(\w+), plural, one \{([^{}]*)\} other \{([^{}]*)\}\}/g, (match, name, one, other) => {
-        if (!(name in values)) return match;
-        const count = Number(values[name]);
-        return (count === 1 ? one : other).replace(/#/g, String(count));
-      })
+      .replace(
+        /\{(\w+), plural, one \{((?:[^{}]|\{\w+\})*)\} other \{((?:[^{}]|\{\w+\})*)\}\}/g,
+        (match, name, one, other) => {
+          if (!(name in values)) return match;
+          const count = Number(values[name]);
+          return (count === 1 ? one : other).replace(/#/g, String(count));
+        }
+      )
       .replace(/\{(\w+)\}/g, (match, name) => (name in values ? String(values[name]) : match));
 
   const createTranslator = (namespace) => {

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -79,7 +79,8 @@ if (typeof global.ResizeObserver === "undefined") {
 
 // Mock next-intl so components using translations render real English strings
 // (read from messages/en.json) without needing a NextIntlClientProvider in each
-// test. Supports namespaces, dotted keys, {var} interpolation, and t.rich.
+// test. Supports namespaces, dotted keys, {var} interpolation, simple ICU
+// plurals ({count, plural, one {...} other {...}}), and t.rich with nested tags.
 jest.mock("next-intl", () => {
   const messages = mockEnMessages;
 
@@ -89,31 +90,51 @@ jest.mock("next-intl", () => {
   };
 
   const interpolate = (template, values = {}) =>
-    String(template).replace(/\{(\w+)\}/g, (match, name) => (name in values ? String(values[name]) : match));
+    String(template)
+      .replace(/\{(\w+), plural, one \{([^{}]*)\} other \{([^{}]*)\}\}/g, (match, name, one, other) => {
+        if (!(name in values)) return match;
+        const count = Number(values[name]);
+        return (count === 1 ? one : other).replace(/#/g, String(count));
+      })
+      .replace(/\{(\w+)\}/g, (match, name) => (name in values ? String(values[name]) : match));
 
   const createTranslator = (namespace) => {
     const t = (key, values) => {
       const value = resolve(namespace, key);
       return typeof value === "string" ? interpolate(value, values) : key;
     };
-    // t.rich: strip the <tag>…</tag> markup down to the rendered chunks.
-    t.rich = (key, tags = {}) => {
+    // t.rich: render <tag>…</tag> markup via the passed handlers (functions),
+    // interpolating the remaining options as ICU values. Handles nested tags
+    // of different names (e.g. <strong><price></price>/month</strong>).
+    t.rich = (key, options = {}) => {
       const value = resolve(namespace, key);
       if (typeof value !== "string") {
         return key;
       }
-      const parts = [];
-      const regex = /<(\w+)>(.*?)<\/\1>|([^<]+)/g;
-      let match;
-      while ((match = regex.exec(value)) !== null) {
-        const [, tag, inner, text] = match;
-        if (tag && typeof tags[tag] === "function") {
-          parts.push(tags[tag](inner));
-        } else {
-          parts.push(tag ? inner : text);
-        }
+      const tags = {};
+      const values = {};
+      for (const [name, v] of Object.entries(options)) {
+        (typeof v === "function" ? tags : values)[name] = v;
       }
-      return parts;
+      const renderRich = (template) => {
+        const parts = [];
+        const regex = /<(\w+)>(.*?)<\/\1>|([^<]+)/g;
+        let match;
+        while ((match = regex.exec(template)) !== null) {
+          const [, tag, inner, text] = match;
+          if (tag) {
+            const chunks = renderRich(inner);
+            const content = chunks.length === 1 ? chunks[0] : chunks;
+            parts.push(typeof tags[tag] === "function" ? tags[tag](content) : content);
+          } else {
+            parts.push(interpolate(text, values));
+          }
+        }
+        return parts;
+      };
+      return renderRich(value).map((part, i) =>
+        React.isValidElement(part) ? React.cloneElement(part, { key: i }) : part
+      );
     };
     t.markup = (key, values) => t(key, values);
     t.raw = (key) => resolve(namespace, key);

--- a/app/lib/modal/modals/AuthErrorModal.tsx
+++ b/app/lib/modal/modals/AuthErrorModal.tsx
@@ -42,7 +42,6 @@ export function AuthErrorModal() {
             </Link>
           )
         })}
-        .
       </p>
     </div>
   );

--- a/app/lib/modal/modals/AuthErrorModal.tsx
+++ b/app/lib/modal/modals/AuthErrorModal.tsx
@@ -7,6 +7,7 @@ import styles from "./AuthErrorModal.module.css";
 
 export function AuthErrorModal() {
   const t = useTranslations("modals.authError");
+  const tCommon = useTranslations("common");
   const routes = useLocaleRoutes();
   const handleReload = () => {
     window.location.reload();
@@ -25,7 +26,7 @@ export function AuthErrorModal() {
 
       <button className={styles.reloadButton} onClick={handleReload}>
         <ReloadIcon />
-        {t("reload")}
+        {tCommon("reloadPage")}
       </button>
 
       <p className={styles.helpText}>

--- a/app/lib/modal/modals/AuthErrorModal.tsx
+++ b/app/lib/modal/modals/AuthErrorModal.tsx
@@ -30,14 +30,18 @@ export function AuthErrorModal() {
       </button>
 
       <p className={styles.helpText}>
-        {t("helpTextPrefix")}
-        <Link href={routes.article("how-to-clear-your-cookies")} className={styles.helpLink}>
-          {t("clearCookies")}
-        </Link>
-        {t("helpTextOr")}
-        <Link href={routes.article("support")} className={styles.helpLink}>
-          {t("contactSupport")}
-        </Link>
+        {t.rich("helpText", {
+          cookiesLink: (chunks) => (
+            <Link href={routes.article("how-to-clear-your-cookies")} className={styles.helpLink}>
+              {chunks}
+            </Link>
+          ),
+          supportLink: (chunks) => (
+            <Link href={routes.article("support")} className={styles.helpLink}>
+              {chunks}
+            </Link>
+          )
+        })}
         .
       </p>
     </div>

--- a/app/lib/modal/modals/ConfirmationModal.tsx
+++ b/app/lib/modal/modals/ConfirmationModal.tsx
@@ -29,6 +29,7 @@ export function ConfirmationModal({
   closeOnAction = true
 }: ConfirmationModalProps) {
   const t = useTranslations("modals.confirmation");
+  const tCommon = useTranslations("common");
   const handleConfirm = () => {
     onConfirm?.();
     if (closeOnAction) hideModal();
@@ -45,10 +46,10 @@ export function ConfirmationModal({
       <p className={styles.modalMessage}>{message ?? t("defaultMessage")}</p>
       <div className={styles.modalButtons}>
         <button onClick={handleCancel} className="ui-btn ui-btn-tertiary ui-btn-default whitespace-nowrap">
-          {cancelText ?? t("defaultCancel")}
+          {cancelText ?? tCommon("cancel")}
         </button>
         <button onClick={handleConfirm} className="ui-btn ui-btn-primary ui-btn-default whitespace-nowrap">
-          {confirmText ?? t("defaultConfirm")}
+          {confirmText ?? tCommon("confirm")}
         </button>
       </div>
     </>

--- a/app/lib/modal/modals/ConnectionErrorModal.tsx
+++ b/app/lib/modal/modals/ConnectionErrorModal.tsx
@@ -26,13 +26,19 @@ export function ConnectionErrorModal() {
       </div>
 
       <p className={styles.helpText}>
-        {t("helpTextPrefix")}
-        <br />
-        {t("helpTextPersists")}
-        <a href="https://jiki.instatus.com/" target="_blank" rel="noopener noreferrer" className={styles.statusLink}>
-          {t("checkStatusPage")}
-        </a>
-        .
+        {t.rich("helpText", {
+          br: () => <br />,
+          link: (chunks) => (
+            <a
+              href="https://jiki.instatus.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.statusLink}
+            >
+              {chunks}
+            </a>
+          )
+        })}
       </p>
     </div>
   );

--- a/app/lib/modal/modals/ExampleModal.tsx
+++ b/app/lib/modal/modals/ExampleModal.tsx
@@ -11,13 +11,14 @@ interface ExampleModalProps {
 
 export function ExampleModal({ title, message }: ExampleModalProps) {
   const t = useTranslations("modals.example");
+  const tCommon = useTranslations("common");
   return (
     <div className={styles.body}>
       <h2 className={styles.title}>{title ?? t("defaultTitle")}</h2>
       <p className={styles.message}>{message ?? t("defaultMessage")}</p>
       <div className={styles.buttonRow}>
         <button onClick={hideModal} className={styles.buttonSecondary}>
-          {t("cancel")}
+          {tCommon("cancel")}
         </button>
         <button
           onClick={() => {
@@ -26,7 +27,7 @@ export function ExampleModal({ title, message }: ExampleModalProps) {
           }}
           className={styles.buttonPrimary}
         >
-          {t("confirm")}
+          {tCommon("confirm")}
         </button>
       </div>
     </div>

--- a/app/lib/modal/modals/ExerciseSuccessModal.tsx
+++ b/app/lib/modal/modals/ExerciseSuccessModal.tsx
@@ -11,6 +11,7 @@ interface ExerciseSuccessModalProps {
 
 export function ExerciseSuccessModal({ title, message, buttonText }: ExerciseSuccessModalProps) {
   const t = useTranslations("modals.exerciseSuccess");
+  const tCommon = useTranslations("common");
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold text-green-700">{title ?? t("defaultTitle")}</h2>
@@ -22,7 +23,7 @@ export function ExerciseSuccessModal({ title, message, buttonText }: ExerciseSuc
           onClick={hideModal}
           className="px-6 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
         >
-          {buttonText ?? t("defaultButton")}
+          {buttonText ?? tCommon("continue")}
         </button>
       </div>
     </div>

--- a/app/lib/modal/modals/PaymentVerificationFailedModal.tsx
+++ b/app/lib/modal/modals/PaymentVerificationFailedModal.tsx
@@ -10,6 +10,7 @@ interface PaymentVerificationFailedModalProps {
 
 export function PaymentVerificationFailedModal({ onClose }: PaymentVerificationFailedModalProps) {
   const t = useTranslations("modals.paymentVerificationFailed");
+  const tCommon = useTranslations("common");
   const handleClose = () => {
     onClose?.();
     hideModal();
@@ -20,7 +21,7 @@ export function PaymentVerificationFailedModal({ onClose }: PaymentVerificationF
       <h2 className={styles.title}>{t("title")}</h2>
       <p className={styles.description}>{t("description")}</p>
       <button onClick={handleClose} className="ui-btn ui-btn-primary ui-btn-large">
-        {t("close")}
+        {tCommon("close")}
       </button>
     </div>
   );

--- a/app/lib/modal/modals/PremiumUpgradeModal/BasicPlanSection.tsx
+++ b/app/lib/modal/modals/PremiumUpgradeModal/BasicPlanSection.tsx
@@ -8,8 +8,7 @@ export function BasicPlanSection() {
   return (
     <div className={styles.leftSide}>
       <h1 className={styles.mainHeading}>
-        <span className={styles.highlight}>{t("headlineHighlight")}</span>
-        {t("headlineSuffix")}
+        {t.rich("headline", { highlight: (chunks) => <span className={styles.highlight}>{chunks}</span> })}
       </h1>
       <p className={styles.mainSubheading}>{t("subheading")}</p>
 

--- a/app/lib/modal/modals/PremiumUpgradeModal/PremiumPlanSection.tsx
+++ b/app/lib/modal/modals/PremiumUpgradeModal/PremiumPlanSection.tsx
@@ -11,6 +11,7 @@ interface PremiumPlanSectionProps {
 
 export function PremiumPlanSection({ user, isLoading, onUpgrade }: PremiumPlanSectionProps) {
   const t = useTranslations("modals.premiumUpgrade");
+  const tCommon = useTranslations("common");
 
   const premiumFeatures: React.ReactNode[] = [
     <>
@@ -53,7 +54,7 @@ export function PremiumPlanSection({ user, isLoading, onUpgrade }: PremiumPlanSe
         <span className={styles.amount}>
           <PremiumPrice interval="monthly" />
         </span>
-        <span className={styles.period}>{t("perMonth")}</span>
+        <span className={styles.period}>{tCommon("perMonth")}</span>
       </div>
       <p className={styles.annualNote}>
         {t("dailyNotePrefix")}
@@ -75,7 +76,7 @@ export function PremiumPlanSection({ user, isLoading, onUpgrade }: PremiumPlanSe
             height={24}
           />
         )}
-        {isLoading ? t("processing") : t("upgrade")}
+        {isLoading ? tCommon("processing") : t("upgrade")}
       </button>
 
       <ul className={styles.premiumFeatures}>

--- a/app/lib/modal/modals/PremiumUpgradeModal/PremiumPlanSection.tsx
+++ b/app/lib/modal/modals/PremiumUpgradeModal/PremiumPlanSection.tsx
@@ -13,38 +13,15 @@ export function PremiumPlanSection({ user, isLoading, onUpgrade }: PremiumPlanSe
   const t = useTranslations("modals.premiumUpgrade");
   const tCommon = useTranslations("common");
 
+  const strong = (chunks: React.ReactNode) => <strong>{chunks}</strong>;
   const premiumFeatures: React.ReactNode[] = [
-    <>
-      {t("featureLearnToBuildPrefix")}
-      <strong>{t("featureLearnToBuild")}</strong>
-    </>,
-    <>
-      {t("featureChallengesPrefix")}
-      <strong>{t("featureChallenges")}</strong>
-    </>,
-    <>
-      {t("featureAiPrefix")}
-      <strong>{t("featureAi")}</strong>
-      {t("featureAiSuffix")}
-    </>,
-    <>
-      {t("featureLivestreamsPrefix")}
-      <strong>{t("featureLivestreams")}</strong>
-      {t("featureLivestreamsSuffix")}
-    </>,
-    <>
-      {t("featureCertificatesPrefix")}
-      <strong>{t("featureCertificates")}</strong>
-      {t("featureCertificatesSuffix")}
-    </>,
-    <>
-      <strong>{t("featureAdFree")}</strong>
-      {t("featureAdFreeSuffix")}
-    </>,
-    <>
-      <strong>{t("featureEarlyAccess")}</strong>
-      {t("featureEarlyAccessSuffix")}
-    </>
+    t.rich("featureLearnToBuild", { strong }),
+    t.rich("featureChallenges", { strong }),
+    t.rich("featureAi", { strong }),
+    t.rich("featureLivestreams", { strong }),
+    t.rich("featureCertificates", { strong }),
+    t.rich("featureAdFree", { strong }),
+    t.rich("featureEarlyAccess", { strong })
   ];
 
   return (
@@ -57,9 +34,7 @@ export function PremiumPlanSection({ user, isLoading, onUpgrade }: PremiumPlanSe
         <span className={styles.period}>{tCommon("perMonth")}</span>
       </div>
       <p className={styles.annualNote}>
-        {t("dailyNotePrefix")}
-        <PremiumDailyPrice interval="monthly" />
-        {t("dailyNoteSuffix")}
+        {t.rich("dailyNote", { price: () => <PremiumDailyPrice interval="monthly" /> })}
       </p>
 
       <button

--- a/app/lib/modal/modals/RateLimitModal.tsx
+++ b/app/lib/modal/modals/RateLimitModal.tsx
@@ -60,7 +60,7 @@ export function RateLimitModal({ retryAfterSeconds = 15 }: RateLimitModalProps) 
         </div>
         <div>
           <div className={styles.statusText}>
-            {t("reconnectingIn")} <span>{timeLeft}</span> {t("seconds")}
+            {t.rich("reconnecting", { count: timeLeft, timer: (chunks) => <span>{chunks}</span> })}
           </div>
           <div className={styles.statusSubtext}>{t("autoRefresh")}</div>
         </div>

--- a/app/lib/modal/modals/SessionExpiredModal.tsx
+++ b/app/lib/modal/modals/SessionExpiredModal.tsx
@@ -9,6 +9,7 @@ interface SessionExpiredModalProps {
 
 export function SessionExpiredModal({ error: _error }: SessionExpiredModalProps) {
   const t = useTranslations("modals.sessionExpired");
+  const tCommon = useTranslations("common");
   const handleReload = () => {
     window.location.reload();
   };
@@ -19,7 +20,7 @@ export function SessionExpiredModal({ error: _error }: SessionExpiredModalProps)
       <p className={styles.description}>{t("description")}</p>
       <div className={styles.buttonRow}>
         <button onClick={handleReload} className={`${styles.button} focus-ring`}>
-          {t("reload")}
+          {tCommon("reloadPage")}
         </button>
       </div>
     </div>

--- a/app/lib/modal/modals/SubscriptionCheckoutModal/ModalBody.tsx
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal/ModalBody.tsx
@@ -27,10 +27,7 @@ export function ModalBody({
     return (
       <div className="bg-bg-primary p-4">
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
-          <p className="text-sm text-red-800">
-            {t("errorPrefix")}
-            {checkoutState.error.message}
-          </p>
+          <p className="text-sm text-red-800">{t("error", { message: checkoutState.error.message })}</p>
         </div>
         <button
           onClick={onCancel}

--- a/app/lib/modal/modals/SubscriptionCheckoutModal/ModalBody.tsx
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal/ModalBody.tsx
@@ -18,6 +18,7 @@ export function ModalBody({
   onCancel: () => void;
 }) {
   const t = useTranslations("modals.subscriptionCheckout");
+  const tCommon = useTranslations("common");
   const checkoutState = useCheckout();
   const tierInfo = PRICING_TIERS[selectedTier];
 
@@ -35,7 +36,7 @@ export function ModalBody({
           onClick={onCancel}
           className="w-full px-4 py-2 bg-gray-300 text-gray-700 rounded-lg hover:bg-gray-400 transition-colors"
         >
-          {t("close")}
+          {tCommon("close")}
         </button>
       </div>
     );

--- a/app/lib/modal/modals/SubscriptionCheckoutModal/PaymentForm.tsx
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal/PaymentForm.tsx
@@ -105,8 +105,7 @@ export function PaymentForm({ priorError }: { priorError?: string | null }) {
 
       <p className={styles.footerText}>
         <ShieldIcon />
-        {t("securedByPrefix")}
-        <span className={styles.stripeBrand}>{t("stripeBrand")}</span>
+        {t.rich("securedBy", { stripe: (chunks) => <span className={styles.stripeBrand}>{chunks}</span> })}
       </p>
     </form>
   );

--- a/app/lib/modal/modals/SubscriptionCheckoutModal/PaymentForm.tsx
+++ b/app/lib/modal/modals/SubscriptionCheckoutModal/PaymentForm.tsx
@@ -10,6 +10,7 @@ import styles from "../SubscriptionCheckoutModal.module.css";
 
 export function PaymentForm({ priorError }: { priorError?: string | null }) {
   const t = useTranslations("modals.subscriptionCheckout");
+  const tCommon = useTranslations("common");
   // Seed the error banner with a previous attempt's failure (e.g. a declined retry);
   // it clears on the next submit like any other payment error.
   const [message, setMessage] = useState<string | null>(priorError ?? null);
@@ -94,7 +95,7 @@ export function PaymentForm({ priorError }: { priorError?: string | null }) {
         id="submit-btn"
       >
         {isLoading ? (
-          t("processing")
+          tCommon("processing")
         ) : (
           <>
             {t("pay")} <PremiumPrice interval="monthly" />

--- a/app/lib/modal/modals/SubscriptionModal.tsx
+++ b/app/lib/modal/modals/SubscriptionModal.tsx
@@ -40,6 +40,7 @@ export function SubscriptionModal({
   onCancel
 }: SubscriptionModalProps) {
   const t = useTranslations("modals.subscription");
+  const tCommon = useTranslations("common");
   const tToast = useTranslations("toasts.subscription");
   const [isLoading, setIsLoading] = useState(false);
   const user = useAuthStore((state: any) => state.user);
@@ -160,7 +161,7 @@ export function SubscriptionModal({
               <span className="text-3xl font-bold text-text-primary">
                 <PremiumPrice interval="monthly" />
               </span>
-              <span className="text-text-secondary">{t("perMonth")}</span>
+              <span className="text-text-secondary">{tCommon("perMonth")}</span>
             </div>
             <p className="text-text-secondary text-sm mt-2">{premiumTier.description}</p>
           </div>

--- a/app/lib/modal/modals/SubscriptionSuccessModal.tsx
+++ b/app/lib/modal/modals/SubscriptionSuccessModal.tsx
@@ -21,6 +21,7 @@ interface SubscriptionSuccessModalProps {
 
 export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onClose }: SubscriptionSuccessModalProps) {
   const t = useTranslations("modals.subscriptionSuccess");
+  const tCommon = useTranslations("common");
   const tierInfo = PRICING_TIERS[tier];
 
   // Calculate renewal date once at render time to avoid calling Date.now() during render
@@ -94,7 +95,7 @@ export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onCl
           <span className="font-medium text-text-primary">{t("planLabel", { tier: tierInfo.name })}</span>
           <span className="text-2xl font-bold text-text-primary">
             <PremiumPrice interval="monthly" />
-            <span className="text-sm font-normal text-text-secondary">{t("perMonth")}</span>
+            <span className="text-sm font-normal text-text-secondary">{tCommon("perMonth")}</span>
           </span>
         </div>
 
@@ -141,7 +142,7 @@ export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onCl
         )}
 
         <button onClick={handleClose} className="text-text-secondary hover:text-text-primary text-sm underline">
-          {nextSteps ? t("skipForNow") : t("close")}
+          {nextSteps ? t("skipForNow") : tCommon("close")}
         </button>
       </div>
 

--- a/app/lib/modal/modals/WalkthroughConfirmModal.tsx
+++ b/app/lib/modal/modals/WalkthroughConfirmModal.tsx
@@ -12,6 +12,7 @@ interface WalkthroughConfirmModalProps {
 
 export function WalkthroughConfirmModal({ onConfirm }: WalkthroughConfirmModalProps) {
   const t = useTranslations("modals.walkthroughConfirm");
+  const strong = (chunks: React.ReactNode) => <strong>{chunks}</strong>;
   const handleWatch = () => {
     hideModal();
     onConfirm?.();
@@ -26,37 +27,25 @@ export function WalkthroughConfirmModal({ onConfirm }: WalkthroughConfirmModalPr
           <span className={`${styles.resourceIcon} ${styles.blue}`}>
             <LearningSettingsIcon width={16} height={16} />
           </span>
-          <p>
-            <strong>{t("conceptPagesLabel")}</strong>
-            {t("conceptPagesText")}
-          </p>
+          <p>{t.rich("conceptPages", { strong })}</p>
         </li>
         <li>
           <span className={`${styles.resourceIcon} ${styles.purple}`}>
             <ChatIcon width={16} height={16} />
           </span>
-          <p>
-            <strong>{t("askJikiLabel")}</strong>
-            {t("askJikiText")}
-          </p>
+          <p>{t.rich("askJiki", { strong })}</p>
         </li>
         <li>
           <span className={`${styles.resourceIcon} ${styles.green}`}>
             <EyeOpenIcon width={16} height={16} />
           </span>
-          <p>
-            <strong>{t("whatHappenedLabel")}</strong>
-            {t("whatHappenedText")}
-          </p>
+          <p>{t.rich("whatHappened", { strong })}</p>
         </li>
         <li>
           <span className={`${styles.resourceIcon} ${styles.amber}`}>
             <ChallengesIcon width={16} height={16} />
           </span>
-          <p>
-            <strong>{t("revealHintsLabel")}</strong>
-            {t("revealHintsText")}
-          </p>
+          <p>{t.rich("revealHints", { strong })}</p>
         </li>
       </ul>
       <div className={styles.buttons}>

--- a/app/lib/modal/modals/WelcomeModal.tsx
+++ b/app/lib/modal/modals/WelcomeModal.tsx
@@ -14,6 +14,7 @@ const WELCOME_VIDEO_PLAYBACK_ID = "rhfF43a6sjaqX7E5Cxcvt7efmwn00knZZ202CvgViQRDc
 
 export function WelcomeModal() {
   const t = useTranslations("modals.welcome");
+  const tCommon = useTranslations("common");
   const playerRef = useRef<MuxPlayerRefAttributes>(null);
   const [watched, setWatched] = useState(false);
   const [confirmSkip, setConfirmSkip] = useState(false);
@@ -50,7 +51,7 @@ export function WelcomeModal() {
         />
       </div>
       <button onClick={handleContinue} className={`ui-btn ui-btn-primary ui-btn-purple ui-btn-large ${styles.cta}`}>
-        {t("continue")}
+        {tCommon("continue")}
       </button>
       {/* Nested dialog: cancel must leave WelcomeModal open, so closeOnAction={false}. */}
       <Modal

--- a/app/lib/modal/modals/WelcomeToPremiumModal.tsx
+++ b/app/lib/modal/modals/WelcomeToPremiumModal.tsx
@@ -29,8 +29,7 @@ export function WelcomeToPremiumModal({ onClose }: WelcomeToPremiumModalProps) {
       </span>
 
       <h2 className={styles.title}>
-        {t("titlePrefix")}
-        <span className={styles.highlight}>{t("titleHighlight")}</span>
+        {t.rich("title", { highlight: (chunks) => <span className={styles.highlight}>{chunks}</span> })}
       </h2>
 
       <p className={styles.description}>{t("description")}</p>

--- a/app/lib/modal/modals/WelcomeToPremiumModal.tsx
+++ b/app/lib/modal/modals/WelcomeToPremiumModal.tsx
@@ -10,6 +10,7 @@ interface WelcomeToPremiumModalProps {
 
 export function WelcomeToPremiumModal({ onClose }: WelcomeToPremiumModalProps) {
   const t = useTranslations("modals.welcomeToPremium");
+  const tCommon = useTranslations("common");
   const handleClose = () => {
     onClose?.();
     hideModal();
@@ -36,7 +37,7 @@ export function WelcomeToPremiumModal({ onClose }: WelcomeToPremiumModalProps) {
 
       <div className={styles.actions}>
         <button onClick={handleClose} className="ui-btn ui-btn-primary ui-btn-purple ui-btn-large">
-          {t("continue")}
+          {tCommon("continue")}
         </button>
       </div>
     </div>

--- a/app/lib/modal/modals/steps/ChallengeUnlockedStep.tsx
+++ b/app/lib/modal/modals/steps/ChallengeUnlockedStep.tsx
@@ -69,9 +69,10 @@ export function ChallengeUnlockedStep({
       </div>
       <div className={styles.premiumInfoBox}>
         <p>
-          <span className="font-semibold">{t("premiumOnly")}</span>{" "}
-          <Link href={routes.premium()}>{t("upgradeLink")}</Link>
-          {t("premiumInfoSuffix")}
+          {t.rich("premiumInfo", {
+            strong: (chunks) => <span className="font-semibold">{chunks}</span>,
+            link: (chunks) => <Link href={routes.premium()}>{chunks}</Link>
+          })}
         </p>
       </div>
       <div className={styles.modalButtonsDivider}></div>

--- a/app/lib/modal/modals/steps/ChallengeUnlockedStep.tsx
+++ b/app/lib/modal/modals/steps/ChallengeUnlockedStep.tsx
@@ -29,6 +29,7 @@ export function ChallengeUnlockedStep({
   onContinue
 }: ChallengeUnlockedStepProps) {
   const t = useTranslations("modals.exerciseCompletion.challengeUnlocked");
+  const tCommon = useTranslations("common");
   const routes = useLocaleRoutes();
   const unlockedChallengeData = completionResponse.find((item) => item.type === "challenge_unlocked")?.data.challenge;
 
@@ -76,7 +77,7 @@ export function ChallengeUnlockedStep({
       <div className={styles.modalButtonsDivider}></div>
       <div className={styles.modalButtons}>
         <button onClick={onContinue} className="ui-btn ui-btn-primary ui-btn-large flex-1">
-          {t("continue")}
+          {tCommon("continue")}
         </button>
       </div>
     </>

--- a/app/lib/modal/modals/steps/CompletedStep.tsx
+++ b/app/lib/modal/modals/steps/CompletedStep.tsx
@@ -118,13 +118,14 @@ function BonusActions({
 
 function DefaultActions({ onTidyCode, onContinue }: { onTidyCode: () => void; onContinue: () => void }) {
   const t = useTranslations("modals.exerciseCompletion.completed");
+  const tCommon = useTranslations("common");
   return (
     <>
       <button onClick={onTidyCode} className="ui-btn ui-btn-tertiary ui-btn-large flex-1">
         {t("tidyCode")}
       </button>
       <button onClick={onContinue} className="ui-btn ui-btn-primary ui-btn-large flex-1">
-        {t("continue")}
+        {tCommon("continue")}
       </button>
     </>
   );

--- a/app/lib/modal/modals/steps/ConceptUnlockedStep.tsx
+++ b/app/lib/modal/modals/steps/ConceptUnlockedStep.tsx
@@ -15,6 +15,7 @@ interface ConceptUnlockedStepProps {
 
 export function ConceptUnlockedStep({ completionResponse, onContinue }: ConceptUnlockedStepProps) {
   const t = useTranslations("modals.exerciseCompletion.conceptUnlocked");
+  const tCommon = useTranslations("common");
   const [concept, setConcept] = useState<ConceptMeta | null>(null);
 
   // Support both new format (concept_slug) and old format (concept object)
@@ -36,7 +37,7 @@ export function ConceptUnlockedStep({ completionResponse, onContinue }: ConceptU
         <div className={styles.modalButtonsDivider}></div>
         <div className={styles.modalButtons}>
           <button onClick={onContinue} className="ui-btn ui-btn-primary ui-btn-large flex-1">
-            {t("continue")}
+            {tCommon("continue")}
           </button>
         </div>
       </>
@@ -56,7 +57,7 @@ export function ConceptUnlockedStep({ completionResponse, onContinue }: ConceptU
       <div className={styles.modalButtonsDivider}></div>
       <div className={styles.modalButtons}>
         <button onClick={onContinue} className="ui-btn ui-btn-primary ui-btn-large flex-1">
-          {t("continue")}
+          {tCommon("continue")}
         </button>
       </div>
     </>

--- a/app/lib/modal/modals/steps/DifficultyRatingStep.tsx
+++ b/app/lib/modal/modals/steps/DifficultyRatingStep.tsx
@@ -13,6 +13,7 @@ interface DifficultyRatingStepProps {
 
 export function DifficultyRatingStep({ exerciseTitle, onRatingsSubmit }: DifficultyRatingStepProps) {
   const t = useTranslations("modals.exerciseCompletion.difficultyRating");
+  const tCommon = useTranslations("common");
   const [difficultyRating, setDifficultyRating] = useState<number | null>(null);
   const [funRating, setFunRating] = useState<number | null>(null);
   const difficultyLabels = [
@@ -91,7 +92,7 @@ export function DifficultyRatingStep({ exerciseTitle, onRatingsSubmit }: Difficu
 
       <div className={modalStyles.modalButtons}>
         <button onClick={handleSubmit} disabled={!canSubmit} className="ui-btn ui-btn-primary ui-btn-large flex-1">
-          {t("continue")}
+          {tCommon("continue")}
         </button>
       </div>
     </>

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -100,6 +100,17 @@
     "languageNames": {
       "en": "English",
       "hu": "Hungarian"
+    },
+    "verifying": "Verifying...",
+    "sending": "Sending...",
+    "perMonth": "/month",
+    "validation": {
+      "emailInvalid": "Please enter a valid email address",
+      "passwordRequired": "Password is required",
+      "passwordMinLength": "Password must be at least 6 characters",
+      "currentPasswordRequired": "Current password is required",
+      "newPasswordRequired": "New password is required",
+      "passwordsNoMatch": "Passwords do not match"
     }
   },
   "build": {
@@ -120,11 +131,7 @@
       "emailPlaceholder": "Enter your email address",
       "passwordLabel": "Password",
       "passwordPlaceholder": "Enter your password",
-      "emailRequired": "Email is required",
-      "emailInvalid": "Please enter a valid email",
-      "emailInvalidAddress": "Please enter a valid email address",
-      "passwordRequired": "Password is required",
-      "passwordMinLength": "Password must be at least 6 characters"
+      "emailRequired": "Email is required"
     },
     "captchaError": {
       "signup": "Our systems tried to determine whether you were a bot or a human, but couldn't. Please try signing up again using the button below.",
@@ -141,7 +148,6 @@
       "forgotPassword": "Forgot your password?",
       "submit": "Log In",
       "submitting": "Logging in...",
-      "verifying": "Verifying...",
       "resendPrompt": "Didn't receive your confirmation email? ",
       "resendLink": "Resend it."
     },
@@ -152,7 +158,6 @@
       "emailAlreadyRegistered": "This email is already registered",
       "submit": "Sign Up",
       "submitting": "Signing up...",
-      "verifying": "Verifying...",
       "resendPrompt": "Didn't receive your confirmation email? ",
       "resendLink": "Resend it."
     },
@@ -161,8 +166,6 @@
       "subtitle": "If you've forgotten your password, use the form below to request a link to change it.",
       "successMessage": "If an account with that email exists, you'll receive reset instructions shortly.",
       "submit": "Send Reset Link",
-      "submitting": "Sending...",
-      "verifying": "Verifying...",
       "rememberedPrompt": "Remembered your password? ",
       "loginLink": "Log in"
     },
@@ -173,10 +176,7 @@
       "title": "Reset your password",
       "subtitle": "Enter your new password below.",
       "tokenMissing": "Reset token is missing or invalid",
-      "passwordRequired": "Password is required",
-      "passwordMinLength": "Password must be at least 6 characters",
       "confirmationRequired": "Password confirmation is required",
-      "passwordsDontMatch": "Passwords don't match",
       "successMessage": "Password reset successfully! Redirecting to login...",
       "newPasswordLabel": "New Password",
       "newPasswordPlaceholder": "Enter your new password",
@@ -190,10 +190,8 @@
     "resendConfirmation": {
       "title": "Resend confirmation instructions",
       "subtitle": "Not received a confirmation email? Use the form below and we'll send you another.",
-      "emailInvalid": "Please enter a valid email address",
       "successMessage": "If an account with that email exists, you'll receive confirmation instructions shortly.",
       "submit": "Resend confirmation instructions",
-      "submitting": "Sending...",
       "confirmedPrompt": "Already confirmed? ",
       "loginLink": "Log in"
     },
@@ -228,20 +226,12 @@
     "twoFactorVerify": {
       "title": "Two-Factor Authentication",
       "subtitle": "Enter the 6-digit code from your authenticator app.",
-      "codeLabel": "Verification code",
-      "verifying": "Verifying...",
-      "cancel": "Cancel and sign in again",
-      "invalidCode": "Invalid verification code",
-      "verificationFailed": "Verification failed. Please try again."
+      "codeLabel": "Verification code"
     },
     "twoFactorSetup": {
       "instructionsHeading": "Scan the QR code with your authenticator app to secure your account.",
       "appsHint": "Use Google Authenticator, 1Password, Authy, or a similar app to scan the code above.",
-      "codeLabel": "Enter the 6-digit code from your app",
-      "verifying": "Verifying...",
-      "cancel": "Cancel and sign in again",
-      "invalidCode": "Invalid verification code",
-      "verificationFailed": "Verification failed. Please try again."
+      "codeLabel": "Enter the 6-digit code from your app"
     },
     "unsubscribe": {
       "noToken": "No unsubscribe token provided.",
@@ -255,6 +245,11 @@
       "successTitle": "Successfully Unsubscribed",
       "successDescription": "You have been unsubscribed from our mailing list.",
       "errorTitle": "Unsubscribe Failed"
+    },
+    "twoFactor": {
+      "cancel": "Cancel and sign in again",
+      "invalidCode": "Invalid verification code",
+      "verificationFailed": "Verification failed. Please try again."
     }
   },
   "settings": {
@@ -267,13 +262,6 @@
       "tabLearning": "Learning",
       "tabDanger": "Danger Zone"
     },
-    "common": {
-      "cancel": "Cancel",
-      "save": "Save",
-      "back": "Back",
-      "edit": "Edit",
-      "change": "Change"
-    },
     "avatarEdit": {
       "adjustTitle": "Adjust Photo",
       "adjustSubtitle": "Zoom and position your photo.",
@@ -283,8 +271,7 @@
       "changeSubtitlePart1": "Upload a new profile image.",
       "changeSubtitlePart2": "This will only be visible to you.",
       "uploadText": "Click to upload a new photo",
-      "uploadHint": "JPG, PNG or GIF. Max 5MB.",
-      "cancel": "Cancel"
+      "uploadHint": "JPG, PNG or GIF. Max 5MB."
     },
     "avatarUpload": {
       "label": "Profile Photo"
@@ -321,12 +308,9 @@
       "passwordPlaceholder": "Enter your current password",
       "passwordHint": "Required for security verification",
       "newEmailRequired": "New email is required",
-      "emailInvalid": "Please enter a valid email address",
       "emailSame": "New email must be different from current email",
-      "passwordRequired": "Current password is required",
       "updateFailed": "Failed to update email",
-      "submit": "Update Email",
-      "cancel": "Cancel"
+      "submit": "Update Email"
     },
     "changePassword": {
       "title": "Change Password",
@@ -334,24 +318,17 @@
       "currentPlaceholder": "Enter your current password",
       "newLabel": "New Password",
       "newPlaceholder": "Enter your new password",
-      "newHint": "Must be at least 8 characters long",
+      "newHint": "Must be at least 6 characters long",
       "confirmLabel": "Confirm New Password",
       "confirmPlaceholder": "Confirm your new password",
-      "currentRequired": "Current password is required",
-      "newRequired": "New password is required",
-      "minLength": "Password must be at least 8 characters long",
-      "noMatch": "Passwords do not match",
       "mustDiffer": "New password must be different from current password",
       "updateFailed": "Failed to update password",
-      "submit": "Update Password",
-      "cancel": "Cancel"
+      "submit": "Update Password"
     },
     "deleteAccount": {
       "sendFailed": "Failed to send confirmation email. Please try again.",
       "confirmTitle": "Are you sure?",
       "confirmMessage": "Do you really want to delete your account? You will lose all your work. This is irreversible.",
-      "cancel": "Cancel",
-      "submitting": "Sending...",
       "submit": "Delete Account",
       "securityTitle": "Security Check",
       "securityMessage": "We've sent you an email to confirm this is really you. Please click the button in that email to delete your account.",
@@ -386,7 +363,6 @@
       "emailPlaceholder": "Enter your email",
       "updateEmail": "Update Email",
       "emailEmpty": "Email cannot be empty",
-      "emailInvalid": "Please enter a valid email address",
       "confirmationPendingPrefix": "Confirmation pending for: ",
       "confirmationPendingHint": "Please check your email to confirm the change.",
       "emailNotConfirmed": "Your email address is not confirmed."
@@ -410,21 +386,8 @@
       "cancellingSubtitle": "Here's what you'll miss when your access ends",
       "resubscribeTitle": "Keep learning without limits",
       "resubscribePrefix": "Resubscribe now for just ",
-      "resubscribePerMonth": "/month",
       "resubscribeSuffix": " and continue your coding journey with Jiki's support.",
-      "resubscribeButton": "Resubscribe to Premium",
-      "unlimitedAiTitle": "Unlimited AI help",
-      "unlimitedAiDescription": "Get personalised guidance from Jiki whenever you're stuck",
-      "unlimitedContentTitle": "Unlimited content",
-      "unlimitedContentDescription": "Access all exercises, projects, and learning paths",
-      "certificatesTitle": "Certificates",
-      "certificatesDescription": "Earn shareable certificates when you complete courses",
-      "adFreeTitle": "Ad-free",
-      "adFreeDescription": "Enjoy a distraction-free learning experience",
-      "prioritySupportTitle": "Priority support",
-      "prioritySupportDescription": "Get faster responses when you need help",
-      "earlyAccessTitle": "Early access",
-      "earlyAccessDescription": "Be the first to try new features and content"
+      "resubscribeButton": "Resubscribe to Premium"
     },
     "cancelSectionPanel": {
       "title": "Cancel Subscription",
@@ -437,24 +400,13 @@
       "headlineSuffix": " way to learn",
       "subtitle": "You're currently on the Free plan. Upgrade to Premium to unlock:",
       "planName": "Jiki Premium",
-      "perMonth": "/month",
       "dailyNotePrefix": "That's only ",
       "dailyNoteSuffix": " a day",
-      "processing": "Processing...",
-      "upgrade": "Upgrade to Premium",
-      "unlimitedAiTitle": "Unlimited AI help",
-      "unlimitedAiDescription": "Get personalised guidance from Jiki whenever you're stuck",
-      "unlimitedContentTitle": "Unlimited content",
-      "unlimitedContentDescription": "Access all exercises, projects, and learning paths",
-      "certificatesTitle": "Certificates",
-      "certificatesDescription": "Earn shareable certificates when you complete courses",
-      "adFreeTitle": "Ad-free",
-      "adFreeDescription": "Enjoy a distraction-free learning experience"
+      "upgrade": "Upgrade to Premium"
     },
     "neverSubscribed": {
       "heading": "Upgrade Your Plan",
       "subtitle": "Unlock advanced features and enhanced learning experiences with our premium plans.",
-      "perMonth": "/month",
       "featuresLabel": "Premium plan features",
       "upgradeAriaLabel": "Upgrade to {plan} plan",
       "upgrade": "Upgrade to Premium"
@@ -498,15 +450,10 @@
     },
     "editableField": {
       "update": "Update",
-      "cancel": "Cancel",
       "edit": "Edit",
       "saveFailed": "Failed to save"
     },
     "passwordField": {
-      "currentRequired": "Current password is required",
-      "newRequired": "New password is required",
-      "minLength": "New password must be at least 8 characters",
-      "noMatch": "Passwords do not match",
       "updateFailed": "Failed to update password",
       "currentLabel": "Current password",
       "currentPlaceholder": "Enter current password",
@@ -514,13 +461,9 @@
       "newPlaceholder": "Enter new password",
       "confirmLabel": "Confirm new password",
       "confirmPlaceholder": "Confirm new password",
-      "cancel": "Cancel",
       "submit": "Update Password",
       "label": "Password",
       "change": "Change"
-    },
-    "subscriptionButton": {
-      "loading": "Loading..."
     },
     "subscriptionStatus": {
       "statusActive": "Active",
@@ -534,7 +477,6 @@
       "activePrefix": "You are on the ",
       "activePlanName": "Jiki {tier}",
       "activeMiddle": " plan at ",
-      "activePerMonth": "/month",
       "activeNextBillingPrefix": ". Your next billing date is ",
       "cancellingMessage": "Your Jiki Premium subscription has been cancelled.",
       "cancellingRemainingPrefix": " You have ",
@@ -548,7 +490,6 @@
       "planSuffix": " Plan",
       "currentPlanAriaLabel": "Current plan: {plan} Plan",
       "statusAriaLabel": "Subscription status: {status}",
-      "perMonth": "/month",
       "messageCanceled": "Service continues until period end",
       "messagePaymentFailed": "Payment failed - please update payment method",
       "messageCancelling": "Cancellation scheduled - access until period end",
@@ -642,7 +583,6 @@
       "q1a1": "The <strong>Learn to Code</strong> exercises — the core learn-to-code curriculum — are <strong>completely free</strong>. No card, no trial, no catch.",
       "q1a2Prefix": "<strong>Jiki Premium</strong> is ",
       "q1a2Suffix": " (priced by country) and unlocks:",
-      "q1PerMonth": "/month",
       "q1Item1": "Full access to <strong>Learn to Build</strong>",
       "q1Item2": "Combine your skills in <strong>Jiki Projects</strong>",
       "q1Item3": "Unlimited <strong>Ask Jiki</strong> AI support",
@@ -705,7 +645,6 @@
       "heading5": "Sound fun?",
       "para15": "If all <highlight>this sounds exciting</highlight>, then I'd love for you to join us! 💙",
       "para16Prefix": "The core \"learn to code\" curriculum is <strong>entirely free</strong> - over 200 hours of fun challenges to hone your skills. And the rest, where you get to follow me as I teach you how to build things, costs only ",
-      "para16PerMonth": "/month",
       "para16Suffix": " (as cheap as we can make it and still pay the bills!)",
       "para17Prefix": "Want more details? Or to hear from others that I've taught? Read on below for even more details or ",
       "para17Link": "just sign up!",
@@ -893,6 +832,20 @@
     },
     "publicPrice": {
       "unavailable": "—"
+    },
+    "benefits": {
+      "unlimitedAiTitle": "Unlimited AI help",
+      "unlimitedAiDescription": "Get personalised guidance from Jiki whenever you're stuck",
+      "unlimitedContentTitle": "Unlimited content",
+      "unlimitedContentDescription": "Access all exercises, projects, and learning paths",
+      "certificatesTitle": "Certificates",
+      "certificatesDescription": "Earn shareable certificates when you complete courses",
+      "adFreeTitle": "Ad-free",
+      "adFreeDescription": "Enjoy a distraction-free learning experience",
+      "prioritySupportTitle": "Priority support",
+      "prioritySupportDescription": "Get faster responses when you need help",
+      "earlyAccessTitle": "Early access",
+      "earlyAccessDescription": "Be the first to try new features and content"
     }
   },
   "roadmap": {
@@ -1156,8 +1109,7 @@
       "badge": "Premium Member",
       "titlePrefix": "Welcome to ",
       "titleHighlight": "Premium!",
-      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!",
-      "continue": "Continue"
+      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!"
     },
     "subscriptionSuccess": {
       "chatGate": {
@@ -1180,19 +1132,15 @@
         "description": "Thank you for upgrading your plan. You now have access to all premium features."
       },
       "planLabel": "{tier} Plan",
-      "perMonth": "/month",
       "whatYouCanDo": "What you can do now:",
       "getStarted": "Get Started",
       "continueLearning": "Continue Learning",
       "skipForNow": "Skip for now",
-      "close": "Close",
       "renewalNotice": "Your subscription will renew automatically on {date}. Manage your subscription in Settings."
     },
     "confirmation": {
       "defaultTitle": "Confirm Action",
-      "defaultMessage": "Are you sure you want to proceed?",
-      "defaultConfirm": "Confirm",
-      "defaultCancel": "Cancel"
+      "defaultMessage": "Are you sure you want to proceed?"
     },
     "info": {
       "defaultTitle": "Information",
@@ -1208,13 +1156,11 @@
     },
     "sessionExpired": {
       "title": "Session Expired",
-      "description": "Your session has expired. Please log in again.",
-      "reload": "Reload Page"
+      "description": "Your session has expired. Please log in again."
     },
     "paymentVerificationFailed": {
       "title": "We couldn't confirm your payment",
-      "description": "Something went wrong while checking with Stripe. Try refreshing the page in a moment — if Premium still isn't active, contact support.",
-      "close": "Close"
+      "description": "Something went wrong while checking with Stripe. Try refreshing the page in a moment — if Premium still isn't active, contact support."
     },
     "levelMilestone": {
       "title": "🎉 Level Complete!",
@@ -1232,7 +1178,6 @@
     "authError": {
       "title": "You've been Logged out.",
       "subtitle": "For some reason you've been logged out (maybe a security check, maybe you logged out on a different device?). Please reload the page to continue.",
-      "reload": "Reload Page",
       "helpTextPrefix": "If this keeps happening, try ",
       "clearCookies": "clearing your cookies",
       "helpTextOr": " or ",
@@ -1249,13 +1194,11 @@
     },
     "exerciseSuccess": {
       "defaultTitle": "Congratulations!",
-      "defaultMessage": "All tests passed! You've successfully completed this exercise.",
-      "defaultButton": "Continue"
+      "defaultMessage": "All tests passed! You've successfully completed this exercise."
     },
     "welcome": {
       "title": "Welcome to Jiki!",
       "subtitle": "Watch this short video to get started.",
-      "continue": "Continue",
       "skipTitle": "Skip the welcome video?",
       "skipMessage": "This video helps you get the most out of Jiki. Are you sure you want to skip it?",
       "skipConfirm": "Skip video",
@@ -1281,7 +1224,6 @@
       },
       "unlockWith": "What you'll unlock with {feature}:",
       "recommended": "Recommended",
-      "perMonth": "/month",
       "choosePremium": "Choose Premium",
       "subscribeAriaLabel": "Subscribe to {plan} plan",
       "renewNotice": "Your subscription will renew automatically each month. You can cancel anytime from your settings.",
@@ -1307,9 +1249,7 @@
     },
     "example": {
       "defaultTitle": "Example Modal",
-      "defaultMessage": "This is an example modal!",
-      "cancel": "Cancel",
-      "confirm": "Confirm"
+      "defaultMessage": "This is an example modal!"
     },
     "paymentProcessing": {
       "title": "Payment Processing",
@@ -1328,8 +1268,7 @@
       "conceptUnlocked": {
         "title": "Concept unlocked!",
         "messageGeneric": "You've unlocked a new concept to explore.",
-        "messageNamed": "You've unlocked a new concept: <strong>{title}</strong>",
-        "continue": "Continue"
+        "messageNamed": "You've unlocked a new concept: <strong>{title}</strong>"
       },
       "completed": {
         "titleExercise": "Exercise completed!",
@@ -1340,7 +1279,6 @@
         "bonusPrompt": "{count, plural, one {This exercise has <strong>a bonus scenario</strong>. Would you like to solve it before moving on?} other {This exercise has <strong>bonus scenarios</strong>. Would you like to solve them before moving on?}}",
         "tidyCode": "Tidy code",
         "solveBonuses": "{count, plural, one {Solve Bonus} other {Solve Bonuses}}",
-        "continue": "Continue",
         "moveOn": "Move on"
       },
       "difficultyRating": {
@@ -1358,8 +1296,7 @@
         "funAmazing": "Amazing!",
         "rateDifficultyAriaLabel": "Rate difficulty as {label}",
         "rateFunAriaLabel": "Rate fun as {label}",
-        "funOptionFallback": "option {number}",
-        "continue": "Continue"
+        "funOptionFallback": "option {number}"
       },
       "challengeUnlocked": {
         "title": "Challenge unlocked!",
@@ -1367,17 +1304,14 @@
         "newLabel": "New",
         "premiumOnly": "Exclusively for Premium members.",
         "upgradeLink": "Upgrade your account",
-        "premiumInfoSuffix": " to access all the Challenges as you unlock them.",
-        "continue": "Continue"
+        "premiumInfoSuffix": " to access all the Challenges as you unlock them."
       }
     },
     "premiumUpgrade": {
       "skipLink": "Not now, maybe later",
       "userAvatarAlt": "User",
-      "processing": "Processing...",
       "upgrade": "Upgrade to Premium",
       "planName": "Jiki Premium",
-      "perMonth": "/month",
       "dailyNotePrefix": "(That's only ",
       "dailyNoteSuffix": " a day)",
       "featureLearnToBuildPrefix": "Full access to ",
@@ -1415,12 +1349,10 @@
       "unexpectedError": "An unexpected error occurred. Please try again.",
       "paymentFailedTitle": "Payment failed",
       "paymentInfoAriaLabel": "Payment information",
-      "processing": "Processing...",
       "pay": "Pay",
       "securedByPrefix": "Secured by ",
       "stripeBrand": "stripe",
       "errorPrefix": "Error: ",
-      "close": "Close",
       "orderTitle": "Jiki {tier}",
       "orderBilling": "Billed monthly. Cancel anytime.",
       "perMonthShort": "/mo"

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -566,7 +566,7 @@
     "latestNews": {
       "heading": "Our latest news",
       "byAuthor": "by {name}",
-      "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>"
+      "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>."
     },
     "monthlyPrice": {
       "fallback": "$9.99"
@@ -1125,7 +1125,7 @@
     "authError": {
       "title": "You've been Logged out.",
       "subtitle": "For some reason you've been logged out (maybe a security check, maybe you logged out on a different device?). Please reload the page to continue.",
-      "helpText": "If this keeps happening, try <cookiesLink>clearing your cookies</cookiesLink> or <supportLink>contact support</supportLink>"
+      "helpText": "If this keeps happening, try <cookiesLink>clearing your cookies</cookiesLink> or <supportLink>contact support</supportLink>."
     },
     "rateLimit": {
       "title": "You've moved too fast.",

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -140,34 +140,28 @@
     },
     "login": {
       "title": "Log In",
-      "noAccountPrefix": "Don't have an account? ",
-      "signUpLink": "Sign up for free.",
       "invalidCredentials": "Invalid email or password",
-      "unconfirmedPrefix": "Please confirm your email before logging in. ",
-      "resendConfirmationLink": "Resend confirmation",
       "forgotPassword": "Forgot your password?",
       "submit": "Log In",
       "submitting": "Logging in...",
-      "resendPrompt": "Didn't receive your confirmation email? ",
-      "resendLink": "Resend it."
+      "unconfirmed": "Please confirm your email before logging in. <link>Resend confirmation</link>",
+      "resend": "Didn't receive your confirmation email? <link>Resend it.</link>",
+      "noAccount": "Don't have an account? <link>Sign up for free.</link>"
     },
     "signup": {
       "title": "Sign Up",
-      "haveAccountPrefix": "Already got an account? ",
-      "loginLink": "Log in",
       "emailAlreadyRegistered": "This email is already registered",
       "submit": "Sign Up",
       "submitting": "Signing up...",
-      "resendPrompt": "Didn't receive your confirmation email? ",
-      "resendLink": "Resend it."
+      "haveAccount": "Already got an account? <link>Log in</link>.",
+      "resend": "Didn't receive your confirmation email? <link>Resend it.</link>"
     },
     "forgotPassword": {
       "title": "Forgot your password?",
       "subtitle": "If you've forgotten your password, use the form below to request a link to change it.",
       "successMessage": "If an account with that email exists, you'll receive reset instructions shortly.",
       "submit": "Send Reset Link",
-      "rememberedPrompt": "Remembered your password? ",
-      "loginLink": "Log in"
+      "remembered": "Remembered your password? <link>Log in</link>"
     },
     "resetPassword": {
       "invalidTitle": "Invalid Reset Link",
@@ -184,22 +178,19 @@
       "confirmPasswordPlaceholder": "Confirm your new password",
       "submit": "Reset password",
       "submitting": "Resetting...",
-      "rememberedPrefix": "Remember your password? ",
-      "signInLink": "Sign in"
+      "remembered": "Remember your password? <link>Sign in</link>"
     },
     "resendConfirmation": {
       "title": "Resend confirmation instructions",
       "subtitle": "Not received a confirmation email? Use the form below and we'll send you another.",
       "successMessage": "If an account with that email exists, you'll receive confirmation instructions shortly.",
       "submit": "Resend confirmation instructions",
-      "confirmedPrompt": "Already confirmed? ",
-      "loginLink": "Log in"
+      "confirmed": "Already confirmed? <link>Log in</link>"
     },
     "checkInbox": {
       "heading": "Check your inbox",
       "sentTo": "We've sent a confirmation email to",
-      "hintPrefix": "Click the link in the email to activate your account. Didn't receive it? ",
-      "resendLink": "Resend email"
+      "hint": "Click the link in the email to activate your account. Didn't receive it? <link>Resend email</link>"
     },
     "emailConfirmed": {
       "heading": "Email Confirmed!",
@@ -220,8 +211,7 @@
       "authFailed": "Exercism authentication failed"
     },
     "errorCard": {
-      "needHelpPrefix": "Need help? ",
-      "contactSupport": "Contact support"
+      "needHelp": "Need help? <link>Contact support</link>"
     },
     "twoFactorVerify": {
       "title": "Two-Factor Authentication",
@@ -363,9 +353,9 @@
       "emailPlaceholder": "Enter your email",
       "updateEmail": "Update Email",
       "emailEmpty": "Email cannot be empty",
-      "confirmationPendingPrefix": "Confirmation pending for: ",
       "confirmationPendingHint": "Please check your email to confirm the change.",
-      "emailNotConfirmed": "Your email address is not confirmed."
+      "emailNotConfirmed": "Your email address is not confirmed.",
+      "confirmationPending": "Confirmation pending for: <strong>{email}</strong>"
     },
     "subscriptionSection": {
       "loadingCardTitle": "Subscription",
@@ -373,21 +363,14 @@
       "loadingData": "Loading subscription data..."
     },
     "benefits": {
-      "activeHeadingPrefix": "You're enjoying ",
-      "premium": "Premium",
-      "activeHeadingSuffix": " benefits",
       "activeSubtitle": "Here's what you're unlocking every day",
-      "footerPrefix": "Got a question? Learn more about ",
-      "footerWhatsIncluded": "what's included",
-      "footerOr": " or ",
-      "footerContactSupport": "contact support",
-      "cancellingHeadingPrefix": "Don't lose your ",
-      "cancellingHeadingSuffix": " benefits",
       "cancellingSubtitle": "Here's what you'll miss when your access ends",
       "resubscribeTitle": "Keep learning without limits",
-      "resubscribePrefix": "Resubscribe now for just ",
-      "resubscribeSuffix": " and continue your coding journey with Jiki's support.",
-      "resubscribeButton": "Resubscribe to Premium"
+      "resubscribeButton": "Resubscribe to Premium",
+      "activeHeading": "You're enjoying <highlight>Premium</highlight> benefits",
+      "cancellingHeading": "Don't lose your <highlight>Premium</highlight> benefits",
+      "footer": "Got a question? Learn more about <includedLink>what's included</includedLink> or <supportLink>contact support</supportLink>.",
+      "resubscribe": "Resubscribe now for just <price></price> and continue your coding journey with Jiki's support."
     },
     "cancelSectionPanel": {
       "title": "Cancel Subscription",
@@ -395,14 +378,11 @@
       "cancel": "Cancel"
     },
     "premiumUpsell": {
-      "headlinePrefix": "Unlock a ",
-      "headlineHighlight": "better",
-      "headlineSuffix": " way to learn",
       "subtitle": "You're currently on the Free plan. Upgrade to Premium to unlock:",
       "planName": "Jiki Premium",
-      "dailyNotePrefix": "That's only ",
-      "dailyNoteSuffix": " a day",
-      "upgrade": "Upgrade to Premium"
+      "upgrade": "Upgrade to Premium",
+      "headline": "Unlock a <highlight>better</highlight> way to learn",
+      "dailyNote": "That's only <price></price> a day"
     },
     "neverSubscribed": {
       "heading": "Upgrade Your Plan",
@@ -474,42 +454,25 @@
       "statusSessionExpired": "Session Expired",
       "statusNotSubscribed": "Not Subscribed",
       "currentPlan": "Current Plan",
-      "activePrefix": "You are on the ",
-      "activePlanName": "Jiki {tier}",
-      "activeMiddle": " plan at ",
-      "activeNextBillingPrefix": ". Your next billing date is ",
       "cancellingMessage": "Your Jiki Premium subscription has been cancelled.",
-      "cancellingRemainingPrefix": " You have ",
-      "cancellingDay": "day",
-      "cancellingDays": "days",
-      "cancellingRemainingSuffix": " remaining to enjoy all Premium features.",
-      "cancellingEndsPrefix": " Your Premium plan will end on ",
-      "freePrefix": "You are on the ",
-      "freePlanName": "Free",
-      "freeSuffix": " plan. This gives you all the content plus Ask Jiki to help you out on one exercise.",
-      "planSuffix": " Plan",
       "currentPlanAriaLabel": "Current plan: {plan} Plan",
       "statusAriaLabel": "Subscription status: {status}",
       "messageCanceled": "Service continues until period end",
       "messagePaymentFailed": "Payment failed - please update payment method",
       "messageCancelling": "Cancellation scheduled - access until period end",
       "messageIncomplete": "Payment setup incomplete - please complete setup",
-      "messageIncompleteExpired": "Previous checkout session expired - please start a new subscription"
+      "messageIncompleteExpired": "Previous checkout session expired - please start a new subscription",
+      "active": "You are on the <plan>Jiki {tier}</plan> plan at <strong><price></price>/month</strong>.",
+      "activeWithBilling": "You are on the <plan>Jiki {tier}</plan> plan at <strong><price></price>/month</strong>. Your next billing date is <strong>{date}</strong>.",
+      "cancellingRemaining": "You have <strong>{count, plural, one {# day} other {# days}}</strong> remaining to enjoy all Premium features.",
+      "cancellingEnds": "Your Premium plan will end on <strong>{date}</strong>.",
+      "free": "You are on the <strong>Free</strong> plan. This gives you all the content plus Ask Jiki to help you out on one exercise.",
+      "planLabel": "{tier} Plan"
     }
   },
   "landing": {
     "hero": {
-      "headlinePart1": "Learn to ",
-      "headlineHighlight": "code and build",
-      "headlinePart2": " in the LLM era!",
       "tagline": "Learn the skills you need to create awesome things, be productive, and <strong>stay relevant in {year}.</strong>",
-      "audiencePrefix": "Designed for ",
-      "audience1": "people getting into tech",
-      "audienceMiddle": ", ",
-      "audience2": "junior developers",
-      "audienceAfter2": " who want to accelerate, and ",
-      "audience3": "vibe-coders",
-      "audienceSuffix": " wanting to do things properly!",
       "ctaSubtext": "...or read on to learn more!",
       "loadingVideo": "Loading video",
       "playVideo": "Play video",
@@ -547,7 +510,9 @@
         "t30": "\"Its massively increased my confidence and motivation\"",
         "t31": "\"Very supportive community!\"",
         "t32": "\"Even as a prior programmer, its transformative!\""
-      }
+      },
+      "headline": "Learn to <highlight>code and build</highlight> in the LLM era!",
+      "audience": "Designed for <highlight>people getting into tech</highlight>, <highlight>junior developers</highlight> who want to accelerate, and <highlight>vibe-coders</highlight> wanting to do things properly!"
     },
     "exercism": {
       "heading": "What makes Exercism special?",
@@ -566,23 +531,17 @@
       "mentoringDesc": "Our unique mentoring program is one of the best ways to get tips from experts!"
     },
     "signupSection": {
-      "headingPrefix": "Get started - ",
-      "headingHighlight": "it's free!",
       "intro": "The <strong>Learn to Code</strong> curriculum is <strong>completely free</strong>. No card. No trial. No catch.",
-      "button": "Sign up & start coding →"
+      "button": "Sign up & start coding →",
+      "heading": "Get started - <strong>it's free!</strong>"
     },
     "signupButton": {
-      "signUp": "Sign Up",
-      "free": " (it's free!)"
+      "label": "Sign Up <free>(it's free!)</free>"
     },
     "faqs": {
       "heading": "Frequently Asked Questions",
-      "introPrefix": "These are the questions we get asked the most. Your question not answered here? ",
-      "introLink": "Ping us an email!",
       "q1": "How much does it cost?",
       "q1a1": "The <strong>Learn to Code</strong> exercises — the core learn-to-code curriculum — are <strong>completely free</strong>. No card, no trial, no catch.",
-      "q1a2Prefix": "<strong>Jiki Premium</strong> is ",
-      "q1a2Suffix": " (priced by country) and unlocks:",
       "q1Item1": "Full access to <strong>Learn to Build</strong>",
       "q1Item2": "Combine your skills in <strong>Jiki Projects</strong>",
       "q1Item3": "Unlimited <strong>Ask Jiki</strong> AI support",
@@ -600,20 +559,19 @@
       "q4a2": "The first <strong>Learn to Build</strong> session will be in <strong>mid-June</strong>. You can sign up for a reminder once you're inside.",
       "q5": "I already signed up to the Bootcamp - is this different?",
       "q5a1": "Thanks for being part of the Bootcamp! Jiki is the next stage in the evolution of our Bootcamp. Most of the exercises you solved will appear in Jiki along with lots more. We've also broken down the 3 hour videos into smaller, 5-10 minute chunks to make watching easier!",
-      "q5a2": "As a member of the Bootcamp, you'll automatically get Jiki Premium for Life. This applies to both the initial Learn to Code course and future courses."
+      "q5a2": "As a member of the Bootcamp, you'll automatically get Jiki Premium for Life. This applies to both the initial Learn to Code course and future courses.",
+      "intro": "These are the questions we get asked the most. Your question not answered here? <link>Ping us an email!</link>",
+      "q1a2": "<strong>Jiki Premium</strong> is <price></price> (priced by country) and unlocks:"
     },
     "latestNews": {
       "heading": "Our latest news",
-      "subheadingPrefix": "Keep up to date with what's happening at Jiki in ",
-      "subheadingLink": "our blog",
-      "byAuthor": "by {name}"
+      "byAuthor": "by {name}",
+      "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>"
     },
     "monthlyPrice": {
       "fallback": "$9.99"
     },
     "welcome": {
-      "headingHighlight": "Coding has changed.",
-      "headingRest": " The way you learn needs to change too.",
       "para1": "In 2026, anyone can open Cursor and create a fully-functional product in minutes. Maybe you've done it yourself! Something that would have taken you <strong>years to learn</strong> to make in the past is now available in seconds. So what does it mean to be a developer now? What does it mean to have a <strong>career in tech</strong>?",
       "para2": "Here's a secret no-one tells you. <highlight><strong>Software engineering has never been about writing code.</strong></highlight> Coding is how you communicate with the computer, but the real skill has always been in <strong>critical-thinking</strong>, in <strong>problem solving</strong>, in <strong>building and architecting</strong>. It's always been about taking ideas and <strong>turning them into reality</strong>.",
       "para3": "Thanks to LLMs <highlight><strong>you don't have to spend years mastering coding</strong></highlight> in order to be useful. But you still have a lot to learn! You still need to learn <strong>coding fundamentals</strong>. You need to learn <strongHighlight>how everything works</strongHighlight>. You need to learn <strongHighlight>how to build</strongHighlight>. But the journey is <strong>much more fun</strong> than it's ever been before. And I'm here <strong><you>to be your guide on that journey!</you></strong>",
@@ -629,8 +587,6 @@
       "rhodriAlt": "Jeremy and Rhodri in 1998 making their first paid website",
       "captionShort": "1998: Me making the first website I ever got paid for.",
       "captionLong": "1998: Me and Rhodri making the first website we ever got paid for.",
-      "para10Prefix": "And make stuff I did! I started making games and then graduated to making little bots to play against. And as I grew older I made websites for me and my friends, and ",
-      "para10Eventually": "eventually for customers.",
       "para11": "I created, I played, I experimented. I had fun!",
       "para12": "And through this, I got really good. <strong>I learned the coder mindset,</strong> and I laid the foundations that I've built my whole career on.",
       "heading4": "<highlight>The two parts</highlight> to learning programming today...",
@@ -644,22 +600,19 @@
       "mazeLabel": "Maze solving bot screenshot",
       "heading5": "Sound fun?",
       "para15": "If all <highlight>this sounds exciting</highlight>, then I'd love for you to join us! 💙",
-      "para16Prefix": "The core \"learn to code\" curriculum is <strong>entirely free</strong> - over 200 hours of fun challenges to hone your skills. And the rest, where you get to follow me as I teach you how to build things, costs only ",
-      "para16Suffix": " (as cheap as we can make it and still pay the bills!)",
-      "para17Prefix": "Want more details? Or to hear from others that I've taught? Read on below for even more details or ",
-      "para17Link": "just sign up!",
-      "ctaButton": "Enough with all the talking! Let's do this! "
+      "ctaButton": "Enough with all the talking! Let's do this!",
+      "heading": "<highlight>Coding has changed.</highlight> The way you learn needs to change too.",
+      "para10": "And make stuff I did! I started making games and then graduated to making little bots to play against. And as I grew older I made websites for me and my friends, and <eventually>eventually for customers.</eventually>",
+      "para17": "Want more details? Or to hear from others that I've taught? Read on below for even more details or <link>just sign up!</link>",
+      "para16": "The core \"learn to code\" curriculum is <strong>entirely free</strong> - over 200 hours of fun challenges to hone your skills. And the rest, where you get to follow me as I teach you how to build things, costs only <price></price> (as cheap as we can make it and still pay the bills!)"
     },
     "bootcamp": {
       "tagWhatWeCover": "What we cover",
       "menuHeading": "What's on the <strong>menu?</strong>",
       "menuIntro": "The course has two strands: <strong>Learn to Code</strong> and <strong>Learn to Build</strong>.",
-      "part1Heading": "1. Learn to Code ",
+      "part1Heading": "1. Learn to Code",
       "part1Bubble": "Absolute Beginners",
       "part1Intro": "We're going to help you <highlight>build rock solid coding foundations.</highlight> We'll cover all the core concepts in programming and give you tons of exercises and projects to practice with.",
-      "part1Item1Prefix": "<strong>Build a solid understanding</strong> of ",
-      "part1Item1Link": "core programming principles",
-      "part1Item1Suffix": ", including flow control, conditionals, data types, functions, and much more, using a beginner-friendly version of JavaScript.",
       "part1Item2": "<strong>Gain the confidence</strong> to put your knowledge into practice, being able to solve a wide variety of problems, using the right concept at the right time.",
       "part1Item3": "<strong>Develop the Coder's Mind.</strong> You'll notice that your critical thinking, problem solving, and logic skills are all improving.",
       "part1Item4": "<strong>A base to build on</strong>. Whatever type of programming you want to do, this is the base you need, and one you can easily build on.",
@@ -705,12 +658,11 @@
       "certificatePara2": "Show off your skills on your resume and in the Certifications section of your LinkedIn profile.",
       "certificateAlt": "Jiki course completion certificate",
       "linkedinAlt": "LinkedIn",
-      "linkedinShare": "Share your certificate in your network"
+      "linkedinShare": "Share your certificate in your network",
+      "part1Item1": "<strong>Build a solid understanding</strong> of <link>core programming principles</link>, including flow control, conditionals, data types, functions, and much more, using a beginner-friendly version of JavaScript."
     },
     "testimonials": {
       "heading": "What do our students think?",
-      "subheadingPrefix": "These are some extracts from what our beta users said. ",
-      "subheadingLink": "Read the full versions here!",
       "quoteOpenAlt": "“",
       "quoteCloseAlt": "”",
       "primaryQuote": "Seeing how much effort, thought, and even love is put into this course, it's such a pleasure to be a student here. Every explanation, each exercise turn this course into a masterpiece. I really enjoy it.",
@@ -744,7 +696,8 @@
       "jj": "Jeremy and the mentors have created an amazing <strong>resource like no other</strong> on the web. From the <strong>fun and sleek interface</strong>, to the live classes and labs or the discord discussions, it all comes together to make <strong>a superb learning experience</strong>.",
       "nanouss": "Enrolling in this programming course was one of the <strong>best decisions I've ever made</strong>. The curriculum is well-structured, covering foundational programming concepts. The team is <strong>supportive, and truly invested</strong> in helping students succeed.",
       "thom": "You will not believe <strong>how fantastic this course is</strong>! You learn to write code by writing code to solve problems that match--and push--your abilities. <strong>Jeremy is a master teacher.</strong> Jiki is the perfect environment.",
-      "chris": "For nearly a decade, <strong>I've repeatedly started online coding courses</strong>, but every time I run up against something that didn't make sense or a problem I just couldn't solve which stopped me in my tracks, meaning I have never completed a course, but now after years of trying, suddenly, <strong>coding feels possible.</strong>"
+      "chris": "For nearly a decade, <strong>I've repeatedly started online coding courses</strong>, but every time I run up against something that didn't make sense or a problem I just couldn't solve which stopped me in my tracks, meaning I have never completed a course, but now after years of trying, suddenly, <strong>coding feels possible.</strong>",
+      "subheading": "These are some extracts from what our beta users said. <link>Read the full versions here!</link>"
     }
   },
   "premium": {
@@ -814,11 +767,9 @@
       "q3": "What happens if I cancel my Premium subscription?",
       "a3": "You'll keep Premium access until the end of your current billing period, and then your account will move back to the Basic plan. You don't lose any of your progress — you just lose access to Premium-only features.",
       "q4": "Do you offer discounts for students or those who can't afford Premium?",
-      "a4Prefix": "We want Jiki to be accessible to everyone. If cost is a barrier, please ",
-      "a4Link": "get in touch",
-      "a4Suffix": " and we'll do what we can to help.",
       "q5": "Can I upgrade or downgrade later?",
-      "a5": "Absolutely. You can upgrade to Premium at any time from your account, and you can cancel just as easily whenever you'd like."
+      "a5": "Absolutely. You can upgrade to Premium at any time from your account, and you can cancel just as easily whenever you'd like.",
+      "a4": "We want Jiki to be accessible to everyone. If cost is a barrier, please <link>get in touch</link> and we'll do what we can to help."
     },
     "cta": {
       "alreadyPremiumTitle": "You're already a Premium member",
@@ -909,8 +860,7 @@
       "chooseForMe": "Choose for me",
       "cantChange": "You can't change once selected.",
       "noVideo": "No video available",
-      "videoInstructionPrefix": "Watch the video then choose your language. Already know? ",
-      "skipVideo": "Skip the video"
+      "videoInstruction": "Watch the video then choose your language. Already know? <skip>Skip the video</skip>"
     },
     "deleteAccount": {
       "deletedTitle": "Your account has been deleted",
@@ -955,7 +905,7 @@
     },
     "card": {
       "locked": "Locked",
-      "subConcepts": "{count} sub-concepts"
+      "subConcepts": "{count, plural, one {# sub-concept} other {# sub-concepts}}"
     },
     "error": {
       "notFound": "Concept not found.",
@@ -1107,9 +1057,8 @@
   "modals": {
     "welcomeToPremium": {
       "badge": "Premium Member",
-      "titlePrefix": "Welcome to ",
-      "titleHighlight": "Premium!",
-      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!"
+      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!",
+      "title": "Welcome to <highlight>Premium!</highlight>"
     },
     "subscriptionSuccess": {
       "chatGate": {
@@ -1150,9 +1099,7 @@
       "title": "Whoops! Lost connection",
       "subtitle": "Jiki got a little tangled up and dropped the connection. Don't worry though - we're working on getting things plugged back in!",
       "reconnecting": "Reconnecting",
-      "helpTextPrefix": "Just sit tight - this usually fixes itself in a few moments.",
-      "helpTextPersists": "If the problem persists, ",
-      "checkStatusPage": "check our status page"
+      "helpText": "Just sit tight - this usually fixes itself in a few moments.<br></br>If the problem persists, <link>check our status page</link>."
     },
     "sessionExpired": {
       "title": "Session Expired",
@@ -1178,19 +1125,15 @@
     "authError": {
       "title": "You've been Logged out.",
       "subtitle": "For some reason you've been logged out (maybe a security check, maybe you logged out on a different device?). Please reload the page to continue.",
-      "helpTextPrefix": "If this keeps happening, try ",
-      "clearCookies": "clearing your cookies",
-      "helpTextOr": " or ",
-      "contactSupport": "contact support"
+      "helpText": "If this keeps happening, try <cookiesLink>clearing your cookies</cookiesLink> or <supportLink>contact support</supportLink>"
     },
     "rateLimit": {
       "title": "You've moved too fast.",
       "subtitle": "You've sent too many requests to our servers and so we're putting you on pause for a few seconds. Please wait and you'll be automatically reconnected.",
-      "reconnectingIn": "Reconnecting in",
-      "seconds": "seconds",
       "autoRefresh": "This page will automatically refresh",
       "noteLabel": "Note:",
-      "noteText": "Opening new tabs or making additional requests will extend your wait time."
+      "noteText": "Opening new tabs or making additional requests will extend your wait time.",
+      "reconnecting": "Reconnecting in <timer>{count}</timer> {count, plural, one {second} other {seconds}}"
     },
     "exerciseSuccess": {
       "defaultTitle": "Congratulations!",
@@ -1232,16 +1175,12 @@
     "walkthroughConfirm": {
       "title": "Try solving it yourself first?",
       "intro": "Before watching the Deep Dive, you might want use these resources to help you pass the tests yourself:",
-      "conceptPagesLabel": "Concept Pages",
-      "conceptPagesText": " — review the concepts used in this exercise",
-      "askJikiLabel": "Ask Jiki",
-      "askJikiText": " — get personalised help from Jiki without spoilers",
-      "whatHappenedLabel": "“What happened?” tips",
-      "whatHappenedText": " — step through your code line by line to see what went wrong",
-      "revealHintsLabel": "Reveal all the Hints",
-      "revealHintsText": " — read through all the hints above for guidance",
       "tryFirst": "I'll try first",
-      "watchDeepDive": "Watch the Deep Dive"
+      "watchDeepDive": "Watch the Deep Dive",
+      "conceptPages": "<strong>Concept Pages</strong> — review the concepts used in this exercise",
+      "askJiki": "<strong>Ask Jiki</strong> — get personalised help from Jiki without spoilers",
+      "whatHappened": "<strong>“What happened?” tips</strong> — step through your code line by line to see what went wrong",
+      "revealHints": "<strong>Reveal all the Hints</strong> — read through all the hints above for guidance"
     },
     "paymentConfirming": {
       "title": "Confirming your payment…",
@@ -1302,9 +1241,7 @@
         "title": "Challenge unlocked!",
         "message": "All that practice means you're ready to take on a tougher challenge.",
         "newLabel": "New",
-        "premiumOnly": "Exclusively for Premium members.",
-        "upgradeLink": "Upgrade your account",
-        "premiumInfoSuffix": " to access all the Challenges as you unlock them."
+        "premiumInfo": "<strong>Exclusively for Premium members.</strong> <link>Upgrade your account</link> to access all the Challenges as you unlock them."
       }
     },
     "premiumUpgrade": {
@@ -1312,36 +1249,24 @@
       "userAvatarAlt": "User",
       "upgrade": "Upgrade to Premium",
       "planName": "Jiki Premium",
-      "dailyNotePrefix": "(That's only ",
-      "dailyNoteSuffix": " a day)",
-      "featureLearnToBuildPrefix": "Full access to ",
-      "featureLearnToBuild": "Learn to Build",
-      "featureChallengesPrefix": "Take on harder ",
-      "featureChallenges": "Challenges",
-      "featureAiPrefix": "Unlimited ",
-      "featureAi": "AI support",
-      "featureAiSuffix": " from Jiki",
-      "featureLivestreamsPrefix": "Regular ",
-      "featureLivestreams": "Q&A livestreams",
-      "featureLivestreamsSuffix": " you can join",
-      "featureCertificatesPrefix": "Earn ",
-      "featureCertificates": "certificates",
-      "featureCertificatesSuffix": " for courses",
-      "featureAdFree": "Ad-free",
-      "featureAdFreeSuffix": " learning experience",
-      "featureEarlyAccess": "Early access",
-      "featureEarlyAccessSuffix": " to new features",
+      "featureLearnToBuild": "Full access to <strong>Learn to Build</strong>",
+      "featureChallenges": "Take on harder <strong>Challenges</strong>",
+      "featureAi": "Unlimited <strong>AI support</strong> from Jiki",
+      "featureLivestreams": "Regular <strong>Q&A livestreams</strong> you can join",
+      "featureCertificates": "Earn <strong>certificates</strong> for courses",
+      "featureAdFree": "<strong>Ad-free</strong> learning experience",
+      "featureEarlyAccess": "<strong>Early access</strong> to new features",
       "basic": {
-        "headlineHighlight": "Accelerate",
-        "headlineSuffix": " your learning!",
         "subheading": "Upgrade to Premium to accelerate your road to job-ready.",
         "planName": "Basic Plan",
         "planPrice": "Free forever",
         "feature1": "Over 80 Coding Exercises",
         "feature2": "Full Concept Library",
         "feature3": "Ask Jiki on one exercise",
-        "note": "+ Access to public YouTube videos and community forums for additional learning resources."
-      }
+        "note": "+ Access to public YouTube videos and community forums for additional learning resources.",
+        "headline": "<highlight>Accelerate</highlight> your learning!"
+      },
+      "dailyNote": "(That's only <price></price> a day)"
     },
     "subscriptionCheckout": {
       "connectingToStripe": "Connecting to Stripe",
@@ -1350,12 +1275,11 @@
       "paymentFailedTitle": "Payment failed",
       "paymentInfoAriaLabel": "Payment information",
       "pay": "Pay",
-      "securedByPrefix": "Secured by ",
-      "stripeBrand": "stripe",
-      "errorPrefix": "Error: ",
       "orderTitle": "Jiki {tier}",
       "orderBilling": "Billed monthly. Cancel anytime.",
-      "perMonthShort": "/mo"
+      "perMonthShort": "/mo",
+      "securedBy": "Secured by <stripe>stripe</stripe>",
+      "error": "Error: {message}"
     },
     "calendarSubscribe": {
       "title": "Subscribe to Calendar",

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -566,7 +566,7 @@
     "latestNews": {
       "heading": "Our latest news",
       "byAuthor": "by {name}",
-      "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>"
+      "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>."
     },
     "monthlyPrice": {
       "fallback": "$9.99"
@@ -1125,7 +1125,7 @@
     "authError": {
       "title": "You've been Logged out.",
       "subtitle": "For some reason you've been logged out (maybe a security check, maybe you logged out on a different device?). Please reload the page to continue.",
-      "helpText": "If this keeps happening, try <cookiesLink>clearing your cookies</cookiesLink> or <supportLink>contact support</supportLink>"
+      "helpText": "If this keeps happening, try <cookiesLink>clearing your cookies</cookiesLink> or <supportLink>contact support</supportLink>."
     },
     "rateLimit": {
       "title": "You've moved too fast.",

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -100,6 +100,17 @@
     "languageNames": {
       "en": "angol",
       "hu": "magyar"
+    },
+    "verifying": "Verifying...",
+    "sending": "Sending...",
+    "perMonth": "/month",
+    "validation": {
+      "emailInvalid": "Please enter a valid email address",
+      "passwordRequired": "Password is required",
+      "passwordMinLength": "Password must be at least 6 characters",
+      "currentPasswordRequired": "Current password is required",
+      "newPasswordRequired": "New password is required",
+      "passwordsNoMatch": "Passwords do not match"
     }
   },
   "build": {
@@ -120,11 +131,7 @@
       "emailPlaceholder": "Enter your email address",
       "passwordLabel": "Password",
       "passwordPlaceholder": "Enter your password",
-      "emailRequired": "Email is required",
-      "emailInvalid": "Please enter a valid email",
-      "emailInvalidAddress": "Please enter a valid email address",
-      "passwordRequired": "Password is required",
-      "passwordMinLength": "Password must be at least 6 characters"
+      "emailRequired": "Email is required"
     },
     "captchaError": {
       "signup": "Our systems tried to determine whether you were a bot or a human, but couldn't. Please try signing up again using the button below.",
@@ -141,7 +148,6 @@
       "forgotPassword": "Forgot your password?",
       "submit": "Log In (HU!)",
       "submitting": "Logging in...",
-      "verifying": "Verifying...",
       "resendPrompt": "Didn't receive your confirmation email? ",
       "resendLink": "Resend it."
     },
@@ -152,7 +158,6 @@
       "emailAlreadyRegistered": "This email is already registered",
       "submit": "Sign Up",
       "submitting": "Signing up...",
-      "verifying": "Verifying...",
       "resendPrompt": "Didn't receive your confirmation email? ",
       "resendLink": "Resend it."
     },
@@ -161,8 +166,6 @@
       "subtitle": "If you've forgotten your password, use the form below to request a link to change it.",
       "successMessage": "If an account with that email exists, you'll receive reset instructions shortly.",
       "submit": "Send Reset Link",
-      "submitting": "Sending...",
-      "verifying": "Verifying...",
       "rememberedPrompt": "Remembered your password? ",
       "loginLink": "Log in"
     },
@@ -173,10 +176,7 @@
       "title": "Reset your password",
       "subtitle": "Enter your new password below.",
       "tokenMissing": "Reset token is missing or invalid",
-      "passwordRequired": "Password is required",
-      "passwordMinLength": "Password must be at least 6 characters",
       "confirmationRequired": "Password confirmation is required",
-      "passwordsDontMatch": "Passwords don't match",
       "successMessage": "Password reset successfully! Redirecting to login...",
       "newPasswordLabel": "New Password",
       "newPasswordPlaceholder": "Enter your new password",
@@ -190,10 +190,8 @@
     "resendConfirmation": {
       "title": "Resend confirmation instructions",
       "subtitle": "Not received a confirmation email? Use the form below and we'll send you another.",
-      "emailInvalid": "Please enter a valid email address",
       "successMessage": "If an account with that email exists, you'll receive confirmation instructions shortly.",
       "submit": "Resend confirmation instructions",
-      "submitting": "Sending...",
       "confirmedPrompt": "Already confirmed? ",
       "loginLink": "Log in"
     },
@@ -228,20 +226,12 @@
     "twoFactorVerify": {
       "title": "Two-Factor Authentication",
       "subtitle": "Enter the 6-digit code from your authenticator app.",
-      "codeLabel": "Verification code",
-      "verifying": "Verifying...",
-      "cancel": "Cancel and sign in again",
-      "invalidCode": "Invalid verification code",
-      "verificationFailed": "Verification failed. Please try again."
+      "codeLabel": "Verification code"
     },
     "twoFactorSetup": {
       "instructionsHeading": "Scan the QR code with your authenticator app to secure your account.",
       "appsHint": "Use Google Authenticator, 1Password, Authy, or a similar app to scan the code above.",
-      "codeLabel": "Enter the 6-digit code from your app",
-      "verifying": "Verifying...",
-      "cancel": "Cancel and sign in again",
-      "invalidCode": "Invalid verification code",
-      "verificationFailed": "Verification failed. Please try again."
+      "codeLabel": "Enter the 6-digit code from your app"
     },
     "unsubscribe": {
       "noToken": "No unsubscribe token provided.",
@@ -255,6 +245,11 @@
       "successTitle": "Successfully Unsubscribed",
       "successDescription": "You have been unsubscribed from our mailing list.",
       "errorTitle": "Unsubscribe Failed"
+    },
+    "twoFactor": {
+      "cancel": "Cancel and sign in again",
+      "invalidCode": "Invalid verification code",
+      "verificationFailed": "Verification failed. Please try again."
     }
   },
   "settings": {
@@ -267,13 +262,6 @@
       "tabLearning": "Learning",
       "tabDanger": "Danger Zone"
     },
-    "common": {
-      "cancel": "Cancel",
-      "save": "Save",
-      "back": "Back",
-      "edit": "Edit",
-      "change": "Change"
-    },
     "avatarEdit": {
       "adjustTitle": "Adjust Photo",
       "adjustSubtitle": "Zoom and position your photo.",
@@ -283,8 +271,7 @@
       "changeSubtitlePart1": "Upload a new profile image.",
       "changeSubtitlePart2": "This will only be visible to you.",
       "uploadText": "Click to upload a new photo",
-      "uploadHint": "JPG, PNG or GIF. Max 5MB.",
-      "cancel": "Cancel"
+      "uploadHint": "JPG, PNG or GIF. Max 5MB."
     },
     "avatarUpload": {
       "label": "Profile Photo"
@@ -321,12 +308,9 @@
       "passwordPlaceholder": "Enter your current password",
       "passwordHint": "Required for security verification",
       "newEmailRequired": "New email is required",
-      "emailInvalid": "Please enter a valid email address",
       "emailSame": "New email must be different from current email",
-      "passwordRequired": "Current password is required",
       "updateFailed": "Failed to update email",
-      "submit": "Update Email",
-      "cancel": "Cancel"
+      "submit": "Update Email"
     },
     "changePassword": {
       "title": "Change Password",
@@ -334,24 +318,17 @@
       "currentPlaceholder": "Enter your current password",
       "newLabel": "New Password",
       "newPlaceholder": "Enter your new password",
-      "newHint": "Must be at least 8 characters long",
+      "newHint": "Must be at least 6 characters long",
       "confirmLabel": "Confirm New Password",
       "confirmPlaceholder": "Confirm your new password",
-      "currentRequired": "Current password is required",
-      "newRequired": "New password is required",
-      "minLength": "Password must be at least 8 characters long",
-      "noMatch": "Passwords do not match",
       "mustDiffer": "New password must be different from current password",
       "updateFailed": "Failed to update password",
-      "submit": "Update Password",
-      "cancel": "Cancel"
+      "submit": "Update Password"
     },
     "deleteAccount": {
       "sendFailed": "Failed to send confirmation email. Please try again.",
       "confirmTitle": "Are you sure?",
       "confirmMessage": "Do you really want to delete your account? You will lose all your work. This is irreversible.",
-      "cancel": "Cancel",
-      "submitting": "Sending...",
       "submit": "Delete Account",
       "securityTitle": "Security Check",
       "securityMessage": "We've sent you an email to confirm this is really you. Please click the button in that email to delete your account.",
@@ -386,7 +363,6 @@
       "emailPlaceholder": "Enter your email",
       "updateEmail": "Update Email",
       "emailEmpty": "Email cannot be empty",
-      "emailInvalid": "Please enter a valid email address",
       "confirmationPendingPrefix": "Confirmation pending for: ",
       "confirmationPendingHint": "Please check your email to confirm the change.",
       "emailNotConfirmed": "Your email address is not confirmed."
@@ -410,21 +386,8 @@
       "cancellingSubtitle": "Here's what you'll miss when your access ends",
       "resubscribeTitle": "Keep learning without limits",
       "resubscribePrefix": "Resubscribe now for just ",
-      "resubscribePerMonth": "/month",
       "resubscribeSuffix": " and continue your coding journey with Jiki's support.",
-      "resubscribeButton": "Resubscribe to Premium",
-      "unlimitedAiTitle": "Unlimited AI help",
-      "unlimitedAiDescription": "Get personalised guidance from Jiki whenever you're stuck",
-      "unlimitedContentTitle": "Unlimited content",
-      "unlimitedContentDescription": "Access all exercises, projects, and learning paths",
-      "certificatesTitle": "Certificates",
-      "certificatesDescription": "Earn shareable certificates when you complete courses",
-      "adFreeTitle": "Ad-free",
-      "adFreeDescription": "Enjoy a distraction-free learning experience",
-      "prioritySupportTitle": "Priority support",
-      "prioritySupportDescription": "Get faster responses when you need help",
-      "earlyAccessTitle": "Early access",
-      "earlyAccessDescription": "Be the first to try new features and content"
+      "resubscribeButton": "Resubscribe to Premium"
     },
     "cancelSectionPanel": {
       "title": "Cancel Subscription",
@@ -437,24 +400,13 @@
       "headlineSuffix": " way to learn",
       "subtitle": "You're currently on the Free plan. Upgrade to Premium to unlock:",
       "planName": "Jiki Premium",
-      "perMonth": "/month",
       "dailyNotePrefix": "That's only ",
       "dailyNoteSuffix": " a day",
-      "processing": "Processing...",
-      "upgrade": "Upgrade to Premium",
-      "unlimitedAiTitle": "Unlimited AI help",
-      "unlimitedAiDescription": "Get personalised guidance from Jiki whenever you're stuck",
-      "unlimitedContentTitle": "Unlimited content",
-      "unlimitedContentDescription": "Access all exercises, projects, and learning paths",
-      "certificatesTitle": "Certificates",
-      "certificatesDescription": "Earn shareable certificates when you complete courses",
-      "adFreeTitle": "Ad-free",
-      "adFreeDescription": "Enjoy a distraction-free learning experience"
+      "upgrade": "Upgrade to Premium"
     },
     "neverSubscribed": {
       "heading": "Upgrade Your Plan",
       "subtitle": "Unlock advanced features and enhanced learning experiences with our premium plans.",
-      "perMonth": "/month",
       "featuresLabel": "Premium plan features",
       "upgradeAriaLabel": "Upgrade to {plan} plan",
       "upgrade": "Upgrade to Premium"
@@ -498,15 +450,10 @@
     },
     "editableField": {
       "update": "Update",
-      "cancel": "Cancel",
       "edit": "Edit",
       "saveFailed": "Failed to save"
     },
     "passwordField": {
-      "currentRequired": "Current password is required",
-      "newRequired": "New password is required",
-      "minLength": "New password must be at least 8 characters",
-      "noMatch": "Passwords do not match",
       "updateFailed": "Failed to update password",
       "currentLabel": "Current password",
       "currentPlaceholder": "Enter current password",
@@ -514,13 +461,9 @@
       "newPlaceholder": "Enter new password",
       "confirmLabel": "Confirm new password",
       "confirmPlaceholder": "Confirm new password",
-      "cancel": "Cancel",
       "submit": "Update Password",
       "label": "Password",
       "change": "Change"
-    },
-    "subscriptionButton": {
-      "loading": "Loading..."
     },
     "subscriptionStatus": {
       "statusActive": "Active",
@@ -534,7 +477,6 @@
       "activePrefix": "You are on the ",
       "activePlanName": "Jiki {tier}",
       "activeMiddle": " plan at ",
-      "activePerMonth": "/month",
       "activeNextBillingPrefix": ". Your next billing date is ",
       "cancellingMessage": "Your Jiki Premium subscription has been cancelled.",
       "cancellingRemainingPrefix": " You have ",
@@ -548,7 +490,6 @@
       "planSuffix": " Plan",
       "currentPlanAriaLabel": "Current plan: {plan} Plan",
       "statusAriaLabel": "Subscription status: {status}",
-      "perMonth": "/month",
       "messageCanceled": "Service continues until period end",
       "messagePaymentFailed": "Payment failed - please update payment method",
       "messageCancelling": "Cancellation scheduled - access until period end",
@@ -642,7 +583,6 @@
       "q1a1": "The <strong>Learn to Code</strong> exercises — the core learn-to-code curriculum — are <strong>completely free</strong>. No card, no trial, no catch.",
       "q1a2Prefix": "<strong>Jiki Premium</strong> is ",
       "q1a2Suffix": " (priced by country) and unlocks:",
-      "q1PerMonth": "/month",
       "q1Item1": "Full access to <strong>Learn to Build</strong>",
       "q1Item2": "Combine your skills in <strong>Jiki Projects</strong>",
       "q1Item3": "Unlimited <strong>Ask Jiki</strong> AI support",
@@ -705,7 +645,6 @@
       "heading5": "Sound fun?",
       "para15": "If all <highlight>this sounds exciting</highlight>, then I'd love for you to join us! 💙",
       "para16Prefix": "The core \"learn to code\" curriculum is <strong>entirely free</strong> - over 200 hours of fun challenges to hone your skills. And the rest, where you get to follow me as I teach you how to build things, costs only ",
-      "para16PerMonth": "/month",
       "para16Suffix": " (as cheap as we can make it and still pay the bills!)",
       "para17Prefix": "Want more details? Or to hear from others that I've taught? Read on below for even more details or ",
       "para17Link": "just sign up!",
@@ -893,6 +832,20 @@
     },
     "publicPrice": {
       "unavailable": "—"
+    },
+    "benefits": {
+      "unlimitedAiTitle": "Unlimited AI help",
+      "unlimitedAiDescription": "Get personalised guidance from Jiki whenever you're stuck",
+      "unlimitedContentTitle": "Unlimited content",
+      "unlimitedContentDescription": "Access all exercises, projects, and learning paths",
+      "certificatesTitle": "Certificates",
+      "certificatesDescription": "Earn shareable certificates when you complete courses",
+      "adFreeTitle": "Ad-free",
+      "adFreeDescription": "Enjoy a distraction-free learning experience",
+      "prioritySupportTitle": "Priority support",
+      "prioritySupportDescription": "Get faster responses when you need help",
+      "earlyAccessTitle": "Early access",
+      "earlyAccessDescription": "Be the first to try new features and content"
     }
   },
   "roadmap": {
@@ -1156,8 +1109,7 @@
       "badge": "Premium Member",
       "titlePrefix": "Welcome to ",
       "titleHighlight": "Premium!",
-      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!",
-      "continue": "Continue"
+      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!"
     },
     "subscriptionSuccess": {
       "chatGate": {
@@ -1180,19 +1132,15 @@
         "description": "Thank you for upgrading your plan. You now have access to all premium features."
       },
       "planLabel": "{tier} Plan",
-      "perMonth": "/month",
       "whatYouCanDo": "What you can do now:",
       "getStarted": "Get Started",
       "continueLearning": "Continue Learning",
       "skipForNow": "Skip for now",
-      "close": "Close",
       "renewalNotice": "Your subscription will renew automatically on {date}. Manage your subscription in Settings."
     },
     "confirmation": {
       "defaultTitle": "Confirm Action",
-      "defaultMessage": "Are you sure you want to proceed?",
-      "defaultConfirm": "Confirm",
-      "defaultCancel": "Cancel"
+      "defaultMessage": "Are you sure you want to proceed?"
     },
     "info": {
       "defaultTitle": "Information",
@@ -1208,13 +1156,11 @@
     },
     "sessionExpired": {
       "title": "Session Expired",
-      "description": "Your session has expired. Please log in again.",
-      "reload": "Reload Page"
+      "description": "Your session has expired. Please log in again."
     },
     "paymentVerificationFailed": {
       "title": "We couldn't confirm your payment",
-      "description": "Something went wrong while checking with Stripe. Try refreshing the page in a moment — if Premium still isn't active, contact support.",
-      "close": "Close"
+      "description": "Something went wrong while checking with Stripe. Try refreshing the page in a moment — if Premium still isn't active, contact support."
     },
     "levelMilestone": {
       "title": "🎉 Level Complete!",
@@ -1232,7 +1178,6 @@
     "authError": {
       "title": "You've been Logged out.",
       "subtitle": "For some reason you've been logged out (maybe a security check, maybe you logged out on a different device?). Please reload the page to continue.",
-      "reload": "Reload Page",
       "helpTextPrefix": "If this keeps happening, try ",
       "clearCookies": "clearing your cookies",
       "helpTextOr": " or ",
@@ -1249,13 +1194,11 @@
     },
     "exerciseSuccess": {
       "defaultTitle": "Congratulations!",
-      "defaultMessage": "All tests passed! You've successfully completed this exercise.",
-      "defaultButton": "Continue"
+      "defaultMessage": "All tests passed! You've successfully completed this exercise."
     },
     "welcome": {
       "title": "Welcome to Jiki!",
       "subtitle": "Watch this short video to get started.",
-      "continue": "Continue",
       "skipTitle": "Skip the welcome video?",
       "skipMessage": "This video helps you get the most out of Jiki. Are you sure you want to skip it?",
       "skipConfirm": "Skip video",
@@ -1281,7 +1224,6 @@
       },
       "unlockWith": "What you'll unlock with {feature}:",
       "recommended": "Recommended",
-      "perMonth": "/month",
       "choosePremium": "Choose Premium",
       "subscribeAriaLabel": "Subscribe to {plan} plan",
       "renewNotice": "Your subscription will renew automatically each month. You can cancel anytime from your settings.",
@@ -1307,9 +1249,7 @@
     },
     "example": {
       "defaultTitle": "Example Modal",
-      "defaultMessage": "This is an example modal!",
-      "cancel": "Cancel",
-      "confirm": "Confirm"
+      "defaultMessage": "This is an example modal!"
     },
     "paymentProcessing": {
       "title": "Payment Processing",
@@ -1328,8 +1268,7 @@
       "conceptUnlocked": {
         "title": "Concept unlocked!",
         "messageGeneric": "You've unlocked a new concept to explore.",
-        "messageNamed": "You've unlocked a new concept: <strong>{title}</strong>",
-        "continue": "Continue"
+        "messageNamed": "You've unlocked a new concept: <strong>{title}</strong>"
       },
       "completed": {
         "titleExercise": "Exercise completed!",
@@ -1340,7 +1279,6 @@
         "bonusPrompt": "{count, plural, one {This exercise has <strong>a bonus scenario</strong>. Would you like to solve it before moving on?} other {This exercise has <strong>bonus scenarios</strong>. Would you like to solve them before moving on?}}",
         "tidyCode": "Tidy code",
         "solveBonuses": "{count, plural, one {Bónusz megoldása} other {Bónuszok megoldása}}",
-        "continue": "Continue",
         "moveOn": "Move on"
       },
       "difficultyRating": {
@@ -1358,8 +1296,7 @@
         "funAmazing": "Amazing!",
         "rateDifficultyAriaLabel": "Rate difficulty as {label}",
         "rateFunAriaLabel": "Rate fun as {label}",
-        "funOptionFallback": "option {number}",
-        "continue": "Continue"
+        "funOptionFallback": "option {number}"
       },
       "challengeUnlocked": {
         "title": "Challenge unlocked!",
@@ -1367,17 +1304,14 @@
         "newLabel": "New",
         "premiumOnly": "Exclusively for Premium members.",
         "upgradeLink": "Upgrade your account",
-        "premiumInfoSuffix": " to access all the Challenges as you unlock them.",
-        "continue": "Continue"
+        "premiumInfoSuffix": " to access all the Challenges as you unlock them."
       }
     },
     "premiumUpgrade": {
       "skipLink": "Not now, maybe later",
       "userAvatarAlt": "User",
-      "processing": "Processing...",
       "upgrade": "Upgrade to Premium",
       "planName": "Jiki Premium",
-      "perMonth": "/month",
       "dailyNotePrefix": "(That's only ",
       "dailyNoteSuffix": " a day)",
       "featureLearnToBuildPrefix": "Full access to ",
@@ -1415,12 +1349,10 @@
       "unexpectedError": "An unexpected error occurred. Please try again.",
       "paymentFailedTitle": "Payment failed",
       "paymentInfoAriaLabel": "Payment information",
-      "processing": "Processing...",
       "pay": "Pay",
       "securedByPrefix": "Secured by ",
       "stripeBrand": "stripe",
       "errorPrefix": "Error: ",
-      "close": "Close",
       "orderTitle": "Jiki {tier}",
       "orderBilling": "Billed monthly. Cancel anytime.",
       "perMonthShort": "/mo"

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -140,34 +140,28 @@
     },
     "login": {
       "title": "Log In",
-      "noAccountPrefix": "Don't have an account? ",
-      "signUpLink": "Sign up for free.",
       "invalidCredentials": "Invalid email or password",
-      "unconfirmedPrefix": "Please confirm your email before logging in. ",
-      "resendConfirmationLink": "Resend confirmation",
       "forgotPassword": "Forgot your password?",
       "submit": "Log In (HU!)",
       "submitting": "Logging in...",
-      "resendPrompt": "Didn't receive your confirmation email? ",
-      "resendLink": "Resend it."
+      "unconfirmed": "Please confirm your email before logging in. <link>Resend confirmation</link>",
+      "resend": "Didn't receive your confirmation email? <link>Resend it.</link>",
+      "noAccount": "Don't have an account? <link>Sign up for free.</link>"
     },
     "signup": {
       "title": "Sign Up",
-      "haveAccountPrefix": "Already got an account? ",
-      "loginLink": "Log in",
       "emailAlreadyRegistered": "This email is already registered",
       "submit": "Sign Up",
       "submitting": "Signing up...",
-      "resendPrompt": "Didn't receive your confirmation email? ",
-      "resendLink": "Resend it."
+      "haveAccount": "Already got an account? <link>Log in</link>.",
+      "resend": "Didn't receive your confirmation email? <link>Resend it.</link>"
     },
     "forgotPassword": {
       "title": "Forgot your password?",
       "subtitle": "If you've forgotten your password, use the form below to request a link to change it.",
       "successMessage": "If an account with that email exists, you'll receive reset instructions shortly.",
       "submit": "Send Reset Link",
-      "rememberedPrompt": "Remembered your password? ",
-      "loginLink": "Log in"
+      "remembered": "Remembered your password? <link>Log in</link>"
     },
     "resetPassword": {
       "invalidTitle": "Invalid Reset Link",
@@ -184,22 +178,19 @@
       "confirmPasswordPlaceholder": "Confirm your new password",
       "submit": "Reset password",
       "submitting": "Resetting...",
-      "rememberedPrefix": "Remember your password? ",
-      "signInLink": "Sign in"
+      "remembered": "Remember your password? <link>Sign in</link>"
     },
     "resendConfirmation": {
       "title": "Resend confirmation instructions",
       "subtitle": "Not received a confirmation email? Use the form below and we'll send you another.",
       "successMessage": "If an account with that email exists, you'll receive confirmation instructions shortly.",
       "submit": "Resend confirmation instructions",
-      "confirmedPrompt": "Already confirmed? ",
-      "loginLink": "Log in"
+      "confirmed": "Already confirmed? <link>Log in</link>"
     },
     "checkInbox": {
       "heading": "Check your inbox",
       "sentTo": "We've sent a confirmation email to",
-      "hintPrefix": "Click the link in the email to activate your account. Didn't receive it? ",
-      "resendLink": "Resend email"
+      "hint": "Click the link in the email to activate your account. Didn't receive it? <link>Resend email</link>"
     },
     "emailConfirmed": {
       "heading": "Email Confirmed!",
@@ -220,8 +211,7 @@
       "authFailed": "Exercism authentication failed"
     },
     "errorCard": {
-      "needHelpPrefix": "Need help? ",
-      "contactSupport": "Contact support"
+      "needHelp": "Need help? <link>Contact support</link>"
     },
     "twoFactorVerify": {
       "title": "Two-Factor Authentication",
@@ -363,9 +353,9 @@
       "emailPlaceholder": "Enter your email",
       "updateEmail": "Update Email",
       "emailEmpty": "Email cannot be empty",
-      "confirmationPendingPrefix": "Confirmation pending for: ",
       "confirmationPendingHint": "Please check your email to confirm the change.",
-      "emailNotConfirmed": "Your email address is not confirmed."
+      "emailNotConfirmed": "Your email address is not confirmed.",
+      "confirmationPending": "Confirmation pending for: <strong>{email}</strong>"
     },
     "subscriptionSection": {
       "loadingCardTitle": "Subscription",
@@ -373,21 +363,14 @@
       "loadingData": "Loading subscription data..."
     },
     "benefits": {
-      "activeHeadingPrefix": "You're enjoying ",
-      "premium": "Premium",
-      "activeHeadingSuffix": " benefits",
       "activeSubtitle": "Here's what you're unlocking every day",
-      "footerPrefix": "Got a question? Learn more about ",
-      "footerWhatsIncluded": "what's included",
-      "footerOr": " or ",
-      "footerContactSupport": "contact support",
-      "cancellingHeadingPrefix": "Don't lose your ",
-      "cancellingHeadingSuffix": " benefits",
       "cancellingSubtitle": "Here's what you'll miss when your access ends",
       "resubscribeTitle": "Keep learning without limits",
-      "resubscribePrefix": "Resubscribe now for just ",
-      "resubscribeSuffix": " and continue your coding journey with Jiki's support.",
-      "resubscribeButton": "Resubscribe to Premium"
+      "resubscribeButton": "Resubscribe to Premium",
+      "activeHeading": "You're enjoying <highlight>Premium</highlight> benefits",
+      "cancellingHeading": "Don't lose your <highlight>Premium</highlight> benefits",
+      "footer": "Got a question? Learn more about <includedLink>what's included</includedLink> or <supportLink>contact support</supportLink>.",
+      "resubscribe": "Resubscribe now for just <price></price> and continue your coding journey with Jiki's support."
     },
     "cancelSectionPanel": {
       "title": "Cancel Subscription",
@@ -395,14 +378,11 @@
       "cancel": "Cancel"
     },
     "premiumUpsell": {
-      "headlinePrefix": "Unlock a ",
-      "headlineHighlight": "better",
-      "headlineSuffix": " way to learn",
       "subtitle": "You're currently on the Free plan. Upgrade to Premium to unlock:",
       "planName": "Jiki Premium",
-      "dailyNotePrefix": "That's only ",
-      "dailyNoteSuffix": " a day",
-      "upgrade": "Upgrade to Premium"
+      "upgrade": "Upgrade to Premium",
+      "headline": "Unlock a <highlight>better</highlight> way to learn",
+      "dailyNote": "That's only <price></price> a day"
     },
     "neverSubscribed": {
       "heading": "Upgrade Your Plan",
@@ -474,42 +454,25 @@
       "statusSessionExpired": "Session Expired",
       "statusNotSubscribed": "Not Subscribed",
       "currentPlan": "Current Plan",
-      "activePrefix": "You are on the ",
-      "activePlanName": "Jiki {tier}",
-      "activeMiddle": " plan at ",
-      "activeNextBillingPrefix": ". Your next billing date is ",
       "cancellingMessage": "Your Jiki Premium subscription has been cancelled.",
-      "cancellingRemainingPrefix": " You have ",
-      "cancellingDay": "day",
-      "cancellingDays": "days",
-      "cancellingRemainingSuffix": " remaining to enjoy all Premium features.",
-      "cancellingEndsPrefix": " Your Premium plan will end on ",
-      "freePrefix": "You are on the ",
-      "freePlanName": "Free",
-      "freeSuffix": " plan. This gives you all the content plus Ask Jiki to help you out on one exercise.",
-      "planSuffix": " Plan",
       "currentPlanAriaLabel": "Current plan: {plan} Plan",
       "statusAriaLabel": "Subscription status: {status}",
       "messageCanceled": "Service continues until period end",
       "messagePaymentFailed": "Payment failed - please update payment method",
       "messageCancelling": "Cancellation scheduled - access until period end",
       "messageIncomplete": "Payment setup incomplete - please complete setup",
-      "messageIncompleteExpired": "Previous checkout session expired - please start a new subscription"
+      "messageIncompleteExpired": "Previous checkout session expired - please start a new subscription",
+      "active": "You are on the <plan>Jiki {tier}</plan> plan at <strong><price></price>/month</strong>.",
+      "activeWithBilling": "You are on the <plan>Jiki {tier}</plan> plan at <strong><price></price>/month</strong>. Your next billing date is <strong>{date}</strong>.",
+      "cancellingRemaining": "You have <strong>{count, plural, one {# day} other {# days}}</strong> remaining to enjoy all Premium features.",
+      "cancellingEnds": "Your Premium plan will end on <strong>{date}</strong>.",
+      "free": "You are on the <strong>Free</strong> plan. This gives you all the content plus Ask Jiki to help you out on one exercise.",
+      "planLabel": "{tier} Plan"
     }
   },
   "landing": {
     "hero": {
-      "headlinePart1": "Learn to ",
-      "headlineHighlight": "code and build",
-      "headlinePart2": " in the LLM era!",
       "tagline": "Learn the skills you need to create awesome things, be productive, and <strong>stay relevant in {year}.</strong>",
-      "audiencePrefix": "Designed for ",
-      "audience1": "people getting into tech",
-      "audienceMiddle": ", ",
-      "audience2": "junior developers",
-      "audienceAfter2": " who want to accelerate, and ",
-      "audience3": "vibe-coders",
-      "audienceSuffix": " wanting to do things properly!",
       "ctaSubtext": "...or read on to learn more!",
       "loadingVideo": "Loading video",
       "playVideo": "Play video",
@@ -547,7 +510,9 @@
         "t30": "\"Its massively increased my confidence and motivation\"",
         "t31": "\"Very supportive community!\"",
         "t32": "\"Even as a prior programmer, its transformative!\""
-      }
+      },
+      "headline": "Learn to <highlight>code and build</highlight> in the LLM era!",
+      "audience": "Designed for <highlight>people getting into tech</highlight>, <highlight>junior developers</highlight> who want to accelerate, and <highlight>vibe-coders</highlight> wanting to do things properly!"
     },
     "exercism": {
       "heading": "What makes Exercism special?",
@@ -566,23 +531,17 @@
       "mentoringDesc": "Our unique mentoring program is one of the best ways to get tips from experts!"
     },
     "signupSection": {
-      "headingPrefix": "Get started - ",
-      "headingHighlight": "it's free!",
       "intro": "The <strong>Learn to Code</strong> curriculum is <strong>completely free</strong>. No card. No trial. No catch.",
-      "button": "Sign up & start coding →"
+      "button": "Sign up & start coding →",
+      "heading": "Get started - <strong>it's free!</strong>"
     },
     "signupButton": {
-      "signUp": "Sign Up",
-      "free": " (it's free!)"
+      "label": "Sign Up <free>(it's free!)</free>"
     },
     "faqs": {
       "heading": "Frequently Asked Questions",
-      "introPrefix": "These are the questions we get asked the most. Your question not answered here? ",
-      "introLink": "Ping us an email!",
       "q1": "How much does it cost?",
       "q1a1": "The <strong>Learn to Code</strong> exercises — the core learn-to-code curriculum — are <strong>completely free</strong>. No card, no trial, no catch.",
-      "q1a2Prefix": "<strong>Jiki Premium</strong> is ",
-      "q1a2Suffix": " (priced by country) and unlocks:",
       "q1Item1": "Full access to <strong>Learn to Build</strong>",
       "q1Item2": "Combine your skills in <strong>Jiki Projects</strong>",
       "q1Item3": "Unlimited <strong>Ask Jiki</strong> AI support",
@@ -600,20 +559,19 @@
       "q4a2": "The first <strong>Learn to Build</strong> session will be in <strong>mid-June</strong>. You can sign up for a reminder once you're inside.",
       "q5": "I already signed up to the Bootcamp - is this different?",
       "q5a1": "Thanks for being part of the Bootcamp! Jiki is the next stage in the evolution of our Bootcamp. Most of the exercises you solved will appear in Jiki along with lots more. We've also broken down the 3 hour videos into smaller, 5-10 minute chunks to make watching easier!",
-      "q5a2": "As a member of the Bootcamp, you'll automatically get Jiki Premium for Life. This applies to both the initial Learn to Code course and future courses."
+      "q5a2": "As a member of the Bootcamp, you'll automatically get Jiki Premium for Life. This applies to both the initial Learn to Code course and future courses.",
+      "intro": "These are the questions we get asked the most. Your question not answered here? <link>Ping us an email!</link>",
+      "q1a2": "<strong>Jiki Premium</strong> is <price></price> (priced by country) and unlocks:"
     },
     "latestNews": {
       "heading": "Our latest news",
-      "subheadingPrefix": "Keep up to date with what's happening at Jiki in ",
-      "subheadingLink": "our blog",
-      "byAuthor": "by {name}"
+      "byAuthor": "by {name}",
+      "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>"
     },
     "monthlyPrice": {
       "fallback": "$9.99"
     },
     "welcome": {
-      "headingHighlight": "Coding has changed.",
-      "headingRest": " The way you learn needs to change too.",
       "para1": "In 2026, anyone can open Cursor and create a fully-functional product in minutes. Maybe you've done it yourself! Something that would have taken you <strong>years to learn</strong> to make in the past is now available in seconds. So what does it mean to be a developer now? What does it mean to have a <strong>career in tech</strong>?",
       "para2": "Here's a secret no-one tells you. <highlight><strong>Software engineering has never been about writing code.</strong></highlight> Coding is how you communicate with the computer, but the real skill has always been in <strong>critical-thinking</strong>, in <strong>problem solving</strong>, in <strong>building and architecting</strong>. It's always been about taking ideas and <strong>turning them into reality</strong>.",
       "para3": "Thanks to LLMs <highlight><strong>you don't have to spend years mastering coding</strong></highlight> in order to be useful. But you still have a lot to learn! You still need to learn <strong>coding fundamentals</strong>. You need to learn <strongHighlight>how everything works</strongHighlight>. You need to learn <strongHighlight>how to build</strongHighlight>. But the journey is <strong>much more fun</strong> than it's ever been before. And I'm here <strong><you>to be your guide on that journey!</you></strong>",
@@ -629,8 +587,6 @@
       "rhodriAlt": "Jeremy and Rhodri in 1998 making their first paid website",
       "captionShort": "1998: Me making the first website I ever got paid for.",
       "captionLong": "1998: Me and Rhodri making the first website we ever got paid for.",
-      "para10Prefix": "And make stuff I did! I started making games and then graduated to making little bots to play against. And as I grew older I made websites for me and my friends, and ",
-      "para10Eventually": "eventually for customers.",
       "para11": "I created, I played, I experimented. I had fun!",
       "para12": "And through this, I got really good. <strong>I learned the coder mindset,</strong> and I laid the foundations that I've built my whole career on.",
       "heading4": "<highlight>The two parts</highlight> to learning programming today...",
@@ -644,22 +600,19 @@
       "mazeLabel": "Maze solving bot screenshot",
       "heading5": "Sound fun?",
       "para15": "If all <highlight>this sounds exciting</highlight>, then I'd love for you to join us! 💙",
-      "para16Prefix": "The core \"learn to code\" curriculum is <strong>entirely free</strong> - over 200 hours of fun challenges to hone your skills. And the rest, where you get to follow me as I teach you how to build things, costs only ",
-      "para16Suffix": " (as cheap as we can make it and still pay the bills!)",
-      "para17Prefix": "Want more details? Or to hear from others that I've taught? Read on below for even more details or ",
-      "para17Link": "just sign up!",
-      "ctaButton": "Enough with all the talking! Let's do this! "
+      "ctaButton": "Enough with all the talking! Let's do this!",
+      "heading": "<highlight>Coding has changed.</highlight> The way you learn needs to change too.",
+      "para10": "And make stuff I did! I started making games and then graduated to making little bots to play against. And as I grew older I made websites for me and my friends, and <eventually>eventually for customers.</eventually>",
+      "para17": "Want more details? Or to hear from others that I've taught? Read on below for even more details or <link>just sign up!</link>",
+      "para16": "The core \"learn to code\" curriculum is <strong>entirely free</strong> - over 200 hours of fun challenges to hone your skills. And the rest, where you get to follow me as I teach you how to build things, costs only <price></price> (as cheap as we can make it and still pay the bills!)"
     },
     "bootcamp": {
       "tagWhatWeCover": "What we cover",
       "menuHeading": "What's on the <strong>menu?</strong>",
       "menuIntro": "The course has two strands: <strong>Learn to Code</strong> and <strong>Learn to Build</strong>.",
-      "part1Heading": "1. Learn to Code ",
+      "part1Heading": "1. Learn to Code",
       "part1Bubble": "Absolute Beginners",
       "part1Intro": "We're going to help you <highlight>build rock solid coding foundations.</highlight> We'll cover all the core concepts in programming and give you tons of exercises and projects to practice with.",
-      "part1Item1Prefix": "<strong>Build a solid understanding</strong> of ",
-      "part1Item1Link": "core programming principles",
-      "part1Item1Suffix": ", including flow control, conditionals, data types, functions, and much more, using a beginner-friendly version of JavaScript.",
       "part1Item2": "<strong>Gain the confidence</strong> to put your knowledge into practice, being able to solve a wide variety of problems, using the right concept at the right time.",
       "part1Item3": "<strong>Develop the Coder's Mind.</strong> You'll notice that your critical thinking, problem solving, and logic skills are all improving.",
       "part1Item4": "<strong>A base to build on</strong>. Whatever type of programming you want to do, this is the base you need, and one you can easily build on.",
@@ -705,12 +658,11 @@
       "certificatePara2": "Show off your skills on your resume and in the Certifications section of your LinkedIn profile.",
       "certificateAlt": "Jiki course completion certificate",
       "linkedinAlt": "LinkedIn",
-      "linkedinShare": "Share your certificate in your network"
+      "linkedinShare": "Share your certificate in your network",
+      "part1Item1": "<strong>Build a solid understanding</strong> of <link>core programming principles</link>, including flow control, conditionals, data types, functions, and much more, using a beginner-friendly version of JavaScript."
     },
     "testimonials": {
       "heading": "What do our students think?",
-      "subheadingPrefix": "These are some extracts from what our beta users said. ",
-      "subheadingLink": "Read the full versions here!",
       "quoteOpenAlt": "“",
       "quoteCloseAlt": "”",
       "primaryQuote": "Seeing how much effort, thought, and even love is put into this course, it's such a pleasure to be a student here. Every explanation, each exercise turn this course into a masterpiece. I really enjoy it.",
@@ -744,7 +696,8 @@
       "jj": "Jeremy and the mentors have created an amazing <strong>resource like no other</strong> on the web. From the <strong>fun and sleek interface</strong>, to the live classes and labs or the discord discussions, it all comes together to make <strong>a superb learning experience</strong>.",
       "nanouss": "Enrolling in this programming course was one of the <strong>best decisions I've ever made</strong>. The curriculum is well-structured, covering foundational programming concepts. The team is <strong>supportive, and truly invested</strong> in helping students succeed.",
       "thom": "You will not believe <strong>how fantastic this course is</strong>! You learn to write code by writing code to solve problems that match--and push--your abilities. <strong>Jeremy is a master teacher.</strong> Jiki is the perfect environment.",
-      "chris": "For nearly a decade, <strong>I've repeatedly started online coding courses</strong>, but every time I run up against something that didn't make sense or a problem I just couldn't solve which stopped me in my tracks, meaning I have never completed a course, but now after years of trying, suddenly, <strong>coding feels possible.</strong>"
+      "chris": "For nearly a decade, <strong>I've repeatedly started online coding courses</strong>, but every time I run up against something that didn't make sense or a problem I just couldn't solve which stopped me in my tracks, meaning I have never completed a course, but now after years of trying, suddenly, <strong>coding feels possible.</strong>",
+      "subheading": "These are some extracts from what our beta users said. <link>Read the full versions here!</link>"
     }
   },
   "premium": {
@@ -814,11 +767,9 @@
       "q3": "What happens if I cancel my Premium subscription?",
       "a3": "You'll keep Premium access until the end of your current billing period, and then your account will move back to the Basic plan. You don't lose any of your progress — you just lose access to Premium-only features.",
       "q4": "Do you offer discounts for students or those who can't afford Premium?",
-      "a4Prefix": "We want Jiki to be accessible to everyone. If cost is a barrier, please ",
-      "a4Link": "get in touch",
-      "a4Suffix": " and we'll do what we can to help.",
       "q5": "Can I upgrade or downgrade later?",
-      "a5": "Absolutely. You can upgrade to Premium at any time from your account, and you can cancel just as easily whenever you'd like."
+      "a5": "Absolutely. You can upgrade to Premium at any time from your account, and you can cancel just as easily whenever you'd like.",
+      "a4": "We want Jiki to be accessible to everyone. If cost is a barrier, please <link>get in touch</link> and we'll do what we can to help."
     },
     "cta": {
       "alreadyPremiumTitle": "You're already a Premium member",
@@ -909,8 +860,7 @@
       "chooseForMe": "Choose for me",
       "cantChange": "You can't change once selected.",
       "noVideo": "No video available",
-      "videoInstructionPrefix": "Watch the video then choose your language. Already know? ",
-      "skipVideo": "Skip the video"
+      "videoInstruction": "Watch the video then choose your language. Already know? <skip>Skip the video</skip>"
     },
     "deleteAccount": {
       "deletedTitle": "Your account has been deleted",
@@ -955,7 +905,7 @@
     },
     "card": {
       "locked": "Locked",
-      "subConcepts": "{count} sub-concepts"
+      "subConcepts": "{count, plural, one {# sub-concepts} other {# sub-concepts}}"
     },
     "error": {
       "notFound": "Concept not found.",
@@ -1107,9 +1057,8 @@
   "modals": {
     "welcomeToPremium": {
       "badge": "Premium Member",
-      "titlePrefix": "Welcome to ",
-      "titleHighlight": "Premium!",
-      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!"
+      "description": "Thanks for upgrading! You now have access to all Premium benefits, including unlimited chats with Jiki, Projects, and Learn to Build!",
+      "title": "Welcome to <highlight>Premium!</highlight>"
     },
     "subscriptionSuccess": {
       "chatGate": {
@@ -1150,9 +1099,7 @@
       "title": "Whoops! Lost connection",
       "subtitle": "Jiki got a little tangled up and dropped the connection. Don't worry though - we're working on getting things plugged back in!",
       "reconnecting": "Reconnecting",
-      "helpTextPrefix": "Just sit tight - this usually fixes itself in a few moments.",
-      "helpTextPersists": "If the problem persists, ",
-      "checkStatusPage": "check our status page"
+      "helpText": "Just sit tight - this usually fixes itself in a few moments.<br></br>If the problem persists, <link>check our status page</link>."
     },
     "sessionExpired": {
       "title": "Session Expired",
@@ -1178,19 +1125,15 @@
     "authError": {
       "title": "You've been Logged out.",
       "subtitle": "For some reason you've been logged out (maybe a security check, maybe you logged out on a different device?). Please reload the page to continue.",
-      "helpTextPrefix": "If this keeps happening, try ",
-      "clearCookies": "clearing your cookies",
-      "helpTextOr": " or ",
-      "contactSupport": "contact support"
+      "helpText": "If this keeps happening, try <cookiesLink>clearing your cookies</cookiesLink> or <supportLink>contact support</supportLink>"
     },
     "rateLimit": {
       "title": "You've moved too fast.",
       "subtitle": "You've sent too many requests to our servers and so we're putting you on pause for a few seconds. Please wait and you'll be automatically reconnected.",
-      "reconnectingIn": "Reconnecting in",
-      "seconds": "seconds",
       "autoRefresh": "This page will automatically refresh",
       "noteLabel": "Note:",
-      "noteText": "Opening new tabs or making additional requests will extend your wait time."
+      "noteText": "Opening new tabs or making additional requests will extend your wait time.",
+      "reconnecting": "Reconnecting in <timer>{count}</timer> {count, plural, one {seconds} other {seconds}}"
     },
     "exerciseSuccess": {
       "defaultTitle": "Congratulations!",
@@ -1232,16 +1175,12 @@
     "walkthroughConfirm": {
       "title": "Try solving it yourself first?",
       "intro": "Before watching the Deep Dive, you might want use these resources to help you pass the tests yourself:",
-      "conceptPagesLabel": "Concept Pages",
-      "conceptPagesText": " — review the concepts used in this exercise",
-      "askJikiLabel": "Ask Jiki",
-      "askJikiText": " — get personalised help from Jiki without spoilers",
-      "whatHappenedLabel": "“What happened?” tips",
-      "whatHappenedText": " — step through your code line by line to see what went wrong",
-      "revealHintsLabel": "Reveal all the Hints",
-      "revealHintsText": " — read through all the hints above for guidance",
       "tryFirst": "I'll try first",
-      "watchDeepDive": "Watch the Deep Dive"
+      "watchDeepDive": "Watch the Deep Dive",
+      "conceptPages": "<strong>Concept Pages</strong> — review the concepts used in this exercise",
+      "askJiki": "<strong>Ask Jiki</strong> — get personalised help from Jiki without spoilers",
+      "whatHappened": "<strong>“What happened?” tips</strong> — step through your code line by line to see what went wrong",
+      "revealHints": "<strong>Reveal all the Hints</strong> — read through all the hints above for guidance"
     },
     "paymentConfirming": {
       "title": "Confirming your payment…",
@@ -1302,9 +1241,7 @@
         "title": "Challenge unlocked!",
         "message": "All that practice means you're ready to take on a tougher challenge.",
         "newLabel": "New",
-        "premiumOnly": "Exclusively for Premium members.",
-        "upgradeLink": "Upgrade your account",
-        "premiumInfoSuffix": " to access all the Challenges as you unlock them."
+        "premiumInfo": "<strong>Exclusively for Premium members.</strong> <link>Upgrade your account</link> to access all the Challenges as you unlock them."
       }
     },
     "premiumUpgrade": {
@@ -1312,36 +1249,24 @@
       "userAvatarAlt": "User",
       "upgrade": "Upgrade to Premium",
       "planName": "Jiki Premium",
-      "dailyNotePrefix": "(That's only ",
-      "dailyNoteSuffix": " a day)",
-      "featureLearnToBuildPrefix": "Full access to ",
-      "featureLearnToBuild": "Learn to Build",
-      "featureChallengesPrefix": "Take on harder ",
-      "featureChallenges": "Challenges",
-      "featureAiPrefix": "Unlimited ",
-      "featureAi": "AI support",
-      "featureAiSuffix": " from Jiki",
-      "featureLivestreamsPrefix": "Regular ",
-      "featureLivestreams": "Q&A livestreams",
-      "featureLivestreamsSuffix": " you can join",
-      "featureCertificatesPrefix": "Earn ",
-      "featureCertificates": "certificates",
-      "featureCertificatesSuffix": " for courses",
-      "featureAdFree": "Ad-free",
-      "featureAdFreeSuffix": " learning experience",
-      "featureEarlyAccess": "Early access",
-      "featureEarlyAccessSuffix": " to new features",
+      "featureLearnToBuild": "Full access to <strong>Learn to Build</strong>",
+      "featureChallenges": "Take on harder <strong>Challenges</strong>",
+      "featureAi": "Unlimited <strong>AI support</strong> from Jiki",
+      "featureLivestreams": "Regular <strong>Q&A livestreams</strong> you can join",
+      "featureCertificates": "Earn <strong>certificates</strong> for courses",
+      "featureAdFree": "<strong>Ad-free</strong> learning experience",
+      "featureEarlyAccess": "<strong>Early access</strong> to new features",
       "basic": {
-        "headlineHighlight": "Accelerate",
-        "headlineSuffix": " your learning!",
         "subheading": "Upgrade to Premium to accelerate your road to job-ready.",
         "planName": "Basic Plan",
         "planPrice": "Free forever",
         "feature1": "Over 80 Coding Exercises",
         "feature2": "Full Concept Library",
         "feature3": "Ask Jiki on one exercise",
-        "note": "+ Access to public YouTube videos and community forums for additional learning resources."
-      }
+        "note": "+ Access to public YouTube videos and community forums for additional learning resources.",
+        "headline": "<highlight>Accelerate</highlight> your learning!"
+      },
+      "dailyNote": "(That's only <price></price> a day)"
     },
     "subscriptionCheckout": {
       "connectingToStripe": "Connecting to Stripe",
@@ -1350,12 +1275,11 @@
       "paymentFailedTitle": "Payment failed",
       "paymentInfoAriaLabel": "Payment information",
       "pay": "Pay",
-      "securedByPrefix": "Secured by ",
-      "stripeBrand": "stripe",
-      "errorPrefix": "Error: ",
       "orderTitle": "Jiki {tier}",
       "orderBilling": "Billed monthly. Cancel anytime.",
-      "perMonthShort": "/mo"
+      "perMonthShort": "/mo",
+      "securedBy": "Secured by <stripe>stripe</stripe>",
+      "error": "Error: {message}"
     },
     "calendarSubscribe": {
       "title": "Subscribe to Calendar",

--- a/app/package.json
+++ b/app/package.json
@@ -115,6 +115,7 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "15.5.9",
     "gray-matter": "^4.0.3",
+    "intl-messageformat": "^11.2.11",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "knip": "^5.82.0",

--- a/app/tests/e2e/auth.test.ts
+++ b/app/tests/e2e/auth.test.ts
@@ -314,7 +314,7 @@ test.describe("Authentication E2E", () => {
           await page.locator('button[type="submit"]').click();
 
           // Wait for validation error
-          await expect(page.getByText("Passwords don't match")).toBeVisible();
+          await expect(page.getByText("Passwords do not match")).toBeVisible();
         });
 
         test("should clear validation errors when user starts typing", async ({ page }) => {

--- a/app/tests/unit/messages.test.ts
+++ b/app/tests/unit/messages.test.ts
@@ -42,6 +42,22 @@ describe("message catalogs", () => {
     expect(Object.keys(flatten(hu)).sort()).toEqual(Object.keys(flatten(en)).sort());
   });
 
+  it("plural messages stay within the subset the jest next-intl mock supports", () => {
+    // jest.setup.js mocks next-intl with a regex-based ICU approximation: plurals
+    // must be exactly `{arg, plural, one {...} other {...}}` where the bodies
+    // contain at most simple `{var}` placeholders (no nested plural/select).
+    // A message outside this subset would render correctly at runtime but
+    // silently produce wrong output in unit tests — fail loudly here instead.
+    // If you need a richer plural, upgrade the mock in jest.setup.js first.
+    const supportedPlural = /\{\w+, plural, one \{(?:[^{}]|\{\w+\})*\} other \{(?:[^{}]|\{\w+\})*\}\}/g;
+    for (const locale of Object.keys(CATALOGS) as (keyof typeof CATALOGS)[]) {
+      const unsupported = Object.entries(flatten(CATALOGS[locale]))
+        .filter(([, message]) => message.replace(supportedPlural, "").includes(", plural,"))
+        .map(([key]) => `${locale}:${key}`);
+      expect(unsupported).toEqual([]);
+    }
+  });
+
   it("no message has leading or trailing whitespace", () => {
     for (const locale of Object.keys(CATALOGS) as (keyof typeof CATALOGS)[]) {
       const padded = Object.entries(flatten(CATALOGS[locale]))

--- a/app/tests/unit/messages.test.ts
+++ b/app/tests/unit/messages.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Guards for the next-intl message catalogs.
+ *
+ * The unit-test suite mocks next-intl, so a syntactically invalid ICU message
+ * (unclosed brace, malformed plural, bad tag) would only surface at runtime.
+ * This test runs every catalog string through the real ICU parser, and also
+ * enforces the catalog invariants documented in .context/i18n.md.
+ */
+import { IntlMessageFormat } from "intl-messageformat";
+import en from "@/messages/en.json";
+import hu from "@/messages/hu.json";
+
+const CATALOGS = { en, hu } as const;
+
+function flatten(node: unknown, prefix = ""): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      result[path] = value;
+    } else {
+      Object.assign(result, flatten(value, path));
+    }
+  }
+  return result;
+}
+
+describe("message catalogs", () => {
+  it.each(Object.keys(CATALOGS) as (keyof typeof CATALOGS)[])("every %s message is valid ICU", (locale) => {
+    const failures: string[] = [];
+    for (const [key, message] of Object.entries(flatten(CATALOGS[locale]))) {
+      try {
+        new IntlMessageFormat(message, locale);
+      } catch (error) {
+        failures.push(`${key}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("en and hu have identical key trees", () => {
+    expect(Object.keys(flatten(hu)).sort()).toEqual(Object.keys(flatten(en)).sort());
+  });
+
+  it("no message has leading or trailing whitespace", () => {
+    for (const locale of Object.keys(CATALOGS) as (keyof typeof CATALOGS)[]) {
+      const padded = Object.entries(flatten(CATALOGS[locale]))
+        .filter(([, message]) => message !== message.trim())
+        .map(([key]) => `${locale}:${key}`);
+      expect(padded).toEqual([]);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      intl-messageformat:
+        specifier: ^11.2.11
+        version: 11.2.11
       jest:
         specifier: ^30.2.0
         version: 30.3.0(@types/node@25.6.0)
@@ -2244,11 +2247,20 @@ packages:
   '@formatjs/fast-memoize@3.1.6':
     resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
 
+  '@formatjs/fast-memoize@3.1.7':
+    resolution: {integrity: sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==}
+
   '@formatjs/icu-messageformat-parser@3.5.12':
     resolution: {integrity: sha512-YyzzxVgYJ8DELmmkhn0Yr0rUj0dTJFf9Jp628K3S0ysInBWxLVDOS8i3RP91cCp4DMK4WYb4cVMhWA9i4knSJg==}
 
+  '@formatjs/icu-messageformat-parser@3.5.14':
+    resolution: {integrity: sha512-jDvgtoLqe3U6yzoBlToMTkWBe38qSi7LN7kFlnXzd5ig8nn+4tSlED0xtEtdYakZVZGJJY2rW1D5xS3BFZh6kA==}
+
   '@formatjs/icu-skeleton-parser@2.1.10':
     resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
+
+  '@formatjs/icu-skeleton-parser@2.1.11':
+    resolution: {integrity: sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==}
 
   '@formatjs/intl-localematcher@0.8.10':
     resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
@@ -5958,8 +5970,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  intl-messageformat@11.2.9:
-    resolution: {integrity: sha512-cGzymZerpDhVXRKjKLgXKda9gI29TU2o88L7gwNMHp3WZVxA/0c5tX52udXbW9JklDApolvMXZG6Dhhdz5eirA==}
+  intl-messageformat@11.2.11:
+    resolution: {integrity: sha512-aDG5bvFRbQvRoT2Bh9FV6yV8t7o0MjEGknZ6pnin5Wt52PJwaBOHDfvz+oPEe78Pl3InQYKugBgCdXijLj6viQ==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10455,11 +10467,19 @@ snapshots:
 
   '@formatjs/fast-memoize@3.1.6': {}
 
+  '@formatjs/fast-memoize@3.1.7': {}
+
   '@formatjs/icu-messageformat-parser@3.5.12':
     dependencies:
       '@formatjs/icu-skeleton-parser': 2.1.10
 
+  '@formatjs/icu-messageformat-parser@3.5.14':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.11
+
   '@formatjs/icu-skeleton-parser@2.1.10': {}
+
+  '@formatjs/icu-skeleton-parser@2.1.11': {}
 
   '@formatjs/intl-localematcher@0.8.10':
     dependencies:
@@ -14664,10 +14684,10 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  intl-messageformat@11.2.9:
+  intl-messageformat@11.2.11:
     dependencies:
-      '@formatjs/fast-memoize': 3.1.6
-      '@formatjs/icu-messageformat-parser': 3.5.12
+      '@formatjs/fast-memoize': 3.1.7
+      '@formatjs/icu-messageformat-parser': 3.5.14
 
   ipaddr.js@1.9.1: {}
 
@@ -16992,7 +17012,7 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.6
       '@schummar/icu-type-parser': 1.21.5
       icu-minify: 4.13.1
-      intl-messageformat: 11.2.9
+      intl-messageformat: 11.2.11
       react: 19.2.3
 
   util-deprecate@1.0.2: {}


### PR DESCRIPTION
Phases 1–3 of the i18n string-extraction audit (fix what's in the catalog before extracting the rest).

## Password minimum: 6, not 8

The backend (Devise) allows `6..128`. The auth forms validated 6 but the settings password flows (`PasswordField`, `ChangePasswordModal`) validated 8 and said "at least 8 characters" — so a user could hold a valid 6-char password they couldn't re-enter via settings. Both validators and all messages now say 6.

## SubscriptionErrorBoundary localized

The `settings.errorBoundary.*` keys existed in the catalog but the class component hardcoded English. It now receives a `messages` prop built with `useTranslations` in `SubscriptionTab`, keeping the "Try Again" state-reset behavior. Removed from the deferred list in `.context/i18n.md`.

## Deduplication (1098 → 1028 keys)

Merged mechanically-identical strings where the meaning is the same everywhere:

- `common.*`: `continue` (×8), `close` (×4), `cancel` (dialog-dismiss, ×9), `confirm` (×3), `processing` (×4), `verifying` (×5), `sending` (×3), `loading` (×2), `reloadPage` (×3), `perMonth` (×10)
- `common.validation.*`: email-invalid (×5, also unifying "valid email" vs "valid email address"), password required/min-length/no-match/current/new (×14)
- `auth.twoFactor.*`: the 3 strings shared verbatim by the setup and verify forms
- `premium.benefits.*`: the benefit title/description pairs previously duplicated across `settings.benefits` and `settings.premiumUpsell`

Kept deliberately duplicated (context changes the translation): `settings.cancelSectionPanel.cancel` (= cancel the subscription), nav labels, page titles vs button labels, and the differently-worded benefit copy in `premium.features` / `modals.premiumUpgrade`. The rule is documented in `.context/i18n.md`.

Also deleted the dead `settings.common.*` namespace.

## Fragment keys → single ICU messages (1028 → 952 keys)

Sentence fragments split across prefix/middle/suffix keys (with load-bearing leading/trailing whitespace) are untranslatable: word order differs across languages and translation tools trim whitespace. Every fragment group is now one ICU message rendered with `t.rich()` tag handlers (`<link>`, `<highlight>`, `<strong>`, self-closing `<price>`), assembled per-locale from the old fragment values so rendered output is unchanged in both en and hu:

- ~50 groups collapsed across auth forms, settings (benefits, upsell, subscription status), landing (hero, welcome, bootcamp, FAQs…), premium FAQ, choose-language, and modals. Zero whitespace-padded messages remain.
- Hand-rolled plurals converted to ICU `{count, plural, ...}`: subscription day/days, concept-card sub-concepts (which rendered "1 sub-concepts"), rate-limit countdown.
- `premium.faq` no longer constructs `${key}Prefix/Link/Suffix` key names dynamically.

## Guard rails

- New `tests/unit/messages.test.ts` (using `intl-messageformat`, the parser next-intl uses): every catalog message must parse as valid ICU, en/hu key trees must be identical, and no message may have leading/trailing whitespace.
- `jest.setup.js` next-intl mock upgraded to handle ICU plurals, values in `t.rich`, and nested tags.

## Notes for review

- `modals.exerciseSuccess.defaultButton` ("Continue") merged into `common.continue`.
- Found but not touched: `ChangePasswordModal` is registered as `change-password-modal` but nothing ever opens it (settings uses `PasswordField` inline) — candidate for deletion in a later cleanup.

## Test plan

- `tsc --noEmit` clean (message keys are typed via `global.d.ts`, so every moved key was compiler-verified)
- `pnpm test` (app): 163 suites / 2016 tests pass, including the new catalog guards
- `pnpm run lint` clean
- All 952×2 messages validated against the real ICU parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)