### PR TITLE
Guard hu translations for projects, episodes and project configs

### DIFF
--- a/app/lib/content/validator.ts
+++ b/app/lib/content/validator.ts
@@ -328,7 +328,7 @@ export const REQUIRED_LOCALES = ["en", "hu"] as const;
  * Validate that all required locale files exist for a content item
  */
 export function validateRequiredLocales(
-  type: "blog" | "article" | "guide",
+  type: "blog" | "article" | "guide" | "episode",
   slug: string,
   slugDir: string,
   existingLocales: string[]
@@ -336,12 +336,89 @@ export function validateRequiredLocales(
   const typeLabels: Record<typeof type, string> = {
     blog: "Blog post",
     article: "Article",
-    guide: "Guide"
+    guide: "Guide",
+    episode: "Episode"
   };
   for (const locale of REQUIRED_LOCALES) {
     if (!existingLocales.includes(locale)) {
       const expectedFile = path.join(slugDir, `${locale}.md`);
       throw new ValidationError(`${typeLabels[type]} '${slug}' is missing required locale file: ${expectedFile}`);
+    }
+  }
+}
+
+// Project config.json fields that are localized maps (keyed by locale)
+export const LOCALIZED_PROJECT_FIELDS = ["title", "description", "tags"] as const;
+
+/**
+ * Validate that a project's localized config.json maps (title, description, tags)
+ * contain an entry for every required locale.
+ *
+ * Unlike blog/article/guide posts, a project's translatable copy lives in
+ * config.json as `{ en: ..., hu: ... }` maps rather than in per-language md
+ * files, so a missing translation cannot be caught by a missing-file check.
+ */
+export function validateProjectRequiredLocales(slug: string, config: unknown): void {
+  if (config === null || typeof config !== "object") {
+    throw new ValidationError(`Project '${slug}' has invalid config.json: not an object`);
+  }
+
+  const cfg = config as Record<string, unknown>;
+
+  for (const field of LOCALIZED_PROJECT_FIELDS) {
+    const map = cfg[field];
+    if (map === null || typeof map !== "object" || Array.isArray(map)) {
+      throw new ValidationError(
+        `Project '${slug}' config.json field '${field}' must be a localized map (e.g. { "en": ..., "hu": ... })`
+      );
+    }
+
+    for (const locale of REQUIRED_LOCALES) {
+      if (!(locale in (map as Record<string, unknown>))) {
+        throw new ValidationError(
+          `Project '${slug}' config.json field '${field}' is missing required locale: '${locale}'`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validate episode summary-block parity across locales.
+ *
+ * The `summary` frontmatter block (from/to/keyConcepts) is optional, but if the
+ * English episode defines one, every required locale must define a well-formed one
+ * too, so a translation stub cannot silently drop it.
+ *
+ * `localeSummaries` maps each existing locale to its parsed frontmatter `summary`
+ * value (or undefined when absent).
+ */
+export function validateEpisodeSummaryParity(slug: string, localeSummaries: Record<string, unknown>): void {
+  // Nothing to enforce if the English episode has no summary block.
+  if (localeSummaries["en"] === undefined) {
+    return;
+  }
+
+  for (const locale of REQUIRED_LOCALES) {
+    const summary = localeSummaries[locale];
+    if (summary === null || summary === undefined || typeof summary !== "object") {
+      throw new ValidationError(`Episode '${slug}' (${locale}) is missing required summary block (present in en.md)`);
+    }
+
+    const s = summary as Record<string, unknown>;
+
+    if (typeof s.from !== "string" || s.from.trim() === "") {
+      throw new ValidationError(`Episode '${slug}' (${locale}) has invalid summary.from: must be non-empty string`);
+    }
+
+    if (typeof s.to !== "string" || s.to.trim() === "") {
+      throw new ValidationError(`Episode '${slug}' (${locale}) has invalid summary.to: must be non-empty string`);
+    }
+
+    if (!Array.isArray(s.keyConcepts) || s.keyConcepts.length === 0) {
+      throw new ValidationError(
+        `Episode '${slug}' (${locale}) has invalid summary.keyConcepts: must be non-empty array`
+      );
     }
   }
 }

--- a/app/tests/unit/content/content-validation.test.ts
+++ b/app/tests/unit/content/content-validation.test.ts
@@ -8,7 +8,9 @@ import {
   validateFrontmatter,
   validateAuthors,
   validateNoDuplicateSlugs,
-  validateRequiredLocales
+  validateRequiredLocales,
+  validateProjectRequiredLocales,
+  validateEpisodeSummaryParity
 } from "@/lib/content/validator";
 import authorsData from "../../../../content/src/authors.json";
 import type { AuthorRegistry } from "@/lib/content/types";
@@ -181,6 +183,69 @@ describe("Content Validation", () => {
               expect(() => {
                 validateFrontmatter(slug, locale, parsed.data);
               }).not.toThrow();
+            });
+          });
+        });
+      });
+    }
+  });
+
+  describe("Projects", () => {
+    const projectsDir = path.join(POSTS_DIR, "projects");
+
+    if (fs.existsSync(projectsDir)) {
+      const projectSlugs = fs.readdirSync(projectsDir).filter((item) => {
+        return fs.statSync(path.join(projectsDir, item)).isDirectory();
+      });
+
+      projectSlugs.forEach((slug) => {
+        describe(`Project: ${slug}`, () => {
+          const projectDir = path.join(projectsDir, slug);
+
+          it("should have config.json file", () => {
+            const configFile = path.join(projectDir, "config.json");
+            expect(fs.existsSync(configFile)).toBe(true);
+          });
+
+          it("should have all required locale keys in config.json", () => {
+            const configFile = path.join(projectDir, "config.json");
+            const config = JSON.parse(fs.readFileSync(configFile, "utf-8"));
+
+            expect(() => {
+              validateProjectRequiredLocales(slug, config);
+            }).not.toThrow();
+          });
+
+          // Episodes live in UUID-named subdirectories, each with a config.json.
+          const episodeDirs = fs.readdirSync(projectDir).filter((item) => {
+            const itemPath = path.join(projectDir, item);
+            return fs.statSync(itemPath).isDirectory() && fs.existsSync(path.join(itemPath, "config.json"));
+          });
+
+          episodeDirs.forEach((episodeId) => {
+            describe(`Episode: ${episodeId}`, () => {
+              const episodeDir = path.join(projectDir, episodeId);
+              const mdFiles = fs.readdirSync(episodeDir).filter((f) => f.endsWith(".md"));
+              const existingLocales = mdFiles.map((f) => path.basename(f, ".md"));
+
+              it("should have all required locale files", () => {
+                expect(() => {
+                  validateRequiredLocales("episode", episodeId, episodeDir, existingLocales);
+                }).not.toThrow();
+              });
+
+              it("should have a summary block in every locale if en.md has one", () => {
+                const localeSummaries: Record<string, unknown> = {};
+                for (const mdFile of mdFiles) {
+                  const locale = path.basename(mdFile, ".md");
+                  const parsed = matter(fs.readFileSync(path.join(episodeDir, mdFile), "utf-8"));
+                  localeSummaries[locale] = (parsed.data as Record<string, unknown>).summary;
+                }
+
+                expect(() => {
+                  validateEpisodeSummaryParity(episodeId, localeSummaries);
+                }).not.toThrow();
+              });
             });
           });
         });

--- a/content/src/posts/projects/build-a-nutrition-platform/config.json
+++ b/content/src/posts/projects/build-a-nutrition-platform/config.json
@@ -1,12 +1,15 @@
 {
   "tags": {
-    "en": ["Agentic Coding", "NextJS", "React", "Databases"]
+    "en": ["Agentic Coding", "NextJS", "React", "Databases"],
+    "hu": ["Agentic Coding", "NextJS", "React", "Databases"]
   },
   "title": {
-    "en": "Build a Nutrition Platform"
+    "en": "Build a Nutrition Platform",
+    "hu": "Build a Nutrition Platform"
   },
   "description": {
-    "en": "Join Jeremy as he builds a platform to calculate recipes from the ingredients in his house. Choose your own food-related project to build!"
+    "en": "Join Jeremy as he builds a platform to calculate recipes from the ingredients in his house. Choose your own food-related project to build!",
+    "hu": "Join Jeremy as he builds a platform to calculate recipes from the ingredients in his house. Choose your own food-related project to build!"
   },
   "image": "coming-soon.webp",
   "livestream": true,

--- a/content/src/posts/projects/build-your-personal-homepage/5981d746-0aaf-40c1-9f44-344ddfb004ad/hu.md
+++ b/content/src/posts/projects/build-your-personal-homepage/5981d746-0aaf-40c1-9f44-344ddfb004ad/hu.md
@@ -1,6 +1,10 @@
 ---
 title: "1. rész: Agentic Coding 101"
 excerpt: "A magyar fordítás hamarosan érkezik."
+summary:
+  from: "Feltételezzük, hogy semmit sem tudsz a webről vagy az agentic codingról."
+  to: "Megérted az agentic coding folyamatát, és megírod az első egyszerű kezdőlapodat a böngészőben."
+  keyConcepts: ["Agentic coding", "Modellek és effort", "Tokenek és kontextus", "HTML-alapok"]
 seo:
   description: "A magyar fordítás hamarosan érkezik."
   keywords: ["agentic coding", "llm", "html"]

--- a/content/src/posts/projects/build-your-personal-homepage/config.json
+++ b/content/src/posts/projects/build-your-personal-homepage/config.json
@@ -1,12 +1,15 @@
 {
   "tags": {
-    "en": ["Agentic Coding", "Git and GitHub", "HTML/CSS/JavaScript Basics"]
+    "en": ["Agentic Coding", "Git and GitHub", "HTML/CSS/JavaScript Basics"],
+    "hu": ["Agentic Coding", "Git and GitHub", "HTML/CSS/JavaScript Basics"]
   },
   "title": {
-    "en": "Build your Personal Homepage"
+    "en": "Build your Personal Homepage",
+    "hu": "Build your Personal Homepage"
   },
   "description": {
-    "en": "Join Jeremy as he builds his own homepage from scratch. Learn about how to use Agentic Coding, how the Web Works, and deploy your first website."
+    "en": "Join Jeremy as he builds his own homepage from scratch. Learn about how to use Agentic Coding, how the Web Works, and deploy your first website.",
+    "hu": "Join Jeremy as he builds his own homepage from scratch. Learn about how to use Agentic Coding, how the Web Works, and deploy your first website."
   },
   "image": "build-yourself-a-homepage.webp",
   "livestream": true,

--- a/content/src/posts/projects/build-your-personal-homepage/f3e23284-2470-42bb-8782-9aad2eaf3e2e/hu.md
+++ b/content/src/posts/projects/build-your-personal-homepage/f3e23284-2470-42bb-8782-9aad2eaf3e2e/hu.md
@@ -1,0 +1,15 @@
+---
+title: "2. rész: Navigáció, stílusok és élesítés"
+excerpt: "A magyar fordítás hamarosan érkezik."
+summary:
+  from: "Néhány különálló, stílus nélküli HTML-oldal."
+  to: "Egy stílusos, összekapcsolt weboldal, élesben az interneten."
+  keyConcepts: ["Linkek és navigáció", "Stílusozás CSS-sel", "Élesítés GitHubbal", "Egyedi domainek"]
+seo:
+  description: "A magyar fordítás hamarosan érkezik."
+  keywords: ["html", "css", "navigation", "github", "deploy", "custom domain", "beginner"]
+---
+
+## Bevezetés
+
+A magyar fordítás hamarosan érkezik. Addig is nézd meg a videót, vagy olvasd el az angol változatot.

--- a/content/src/posts/projects/building-a-real-web-platform/config.json
+++ b/content/src/posts/projects/building-a-real-web-platform/config.json
@@ -1,12 +1,15 @@
 {
   "tags": {
-    "en": ["Agentic Coding", "Full-Stack Web", "Advanced"]
+    "en": ["Agentic Coding", "Full-Stack Web", "Advanced"],
+    "hu": ["Agentic Coding", "Full-Stack Web", "Advanced"]
   },
   "title": {
-    "en": "Build a Learning Platform"
+    "en": "Build a Learning Platform",
+    "hu": "Build a Learning Platform"
   },
   "description": {
-    "en": "Join Jeremy as he builds a full Japanese language-learning platform. Choose your own learning platform to build, then wrestle with every decision, feature and bug alongside him, and learn along the way."
+    "en": "Join Jeremy as he builds a full Japanese language-learning platform. Choose your own learning platform to build, then wrestle with every decision, feature and bug alongside him, and learn along the way.",
+    "hu": "Join Jeremy as he builds a full Japanese language-learning platform. Choose your own learning platform to build, then wrestle with every decision, feature and bug alongside him, and learn along the way."
   },
   "image": "coming-soon.webp",
   "livestream": true,


### PR DESCRIPTION
## Context

The `content/` package is data-only; all validation runs in the **app** package via `pnpm test:app`. A `hu` guard already existed for blog posts, articles, and guides (`REQUIRED_LOCALES = ["en", "hu"]` enforced by `content-validation.test.ts`). The **projects area** was not covered, and its translatable copy doesn't all live in md files, so Hungarian content could go silently missing:

1. **Episode `hu.md`** — the projects tree wasn't walked, so a missing episode translation was never caught.
2. **Project `config.json` localized maps** — `title` / `description` / `tags` are `{ "en": … }` maps; all projects were English-only.
3. **Episode `summary` block parity** — the optional `summary` frontmatter block could be silently dropped in a translated stub (the existing `5981…/hu.md` already dropped it).

Hu translations are deliberately not finished — this only guards **extraction completeness**: every translatable surface must have an `hu` counterpart, even if a stub.

## Changes

**Guard** (`app/lib/content/validator.ts`):
- Extend `validateRequiredLocales` to accept `"episode"`.
- `validateProjectRequiredLocales` — project config maps must contain every required locale.
- `validateEpisodeSummaryParity` — if `en.md` has a `summary`, every locale must have a well-formed one.

**Test** (`content-validation.test.ts`): new `Projects` block walking `src/posts/projects/` — asserts config hu-keys, episode `hu.md` existence, and summary parity.

**Stubs** (`content/`): `hu` keys (copied from English) on all 3 project configs; translated Hungarian `summary` blocks on both episode stubs (the existing `5981…/hu.md` and the new `f3e23284…/hu.md`).

## Verification

- `content-validation` + `validator` tests: **188 pass**.
- Bite check: removing a stub fails the guard with `missing required locale file` and `missing required summary block`.
- `content:generate` runs clean (`Locales: en, hu`); Prettier clean; full app suite green in pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)