### PR TITLE
Improve MissingRightBraceInTemplateLiteral error message

### DIFF
--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -21,7 +21,7 @@
       "MissingDeclarationKeywordWithSuggestion": "Did you mean `{{suggestion}}` instead of `{{name}}`? Variable declarations must start with `let` or `const`.",
       "MissingLeftParenthesisAfterIf": "Missing opening parenthesis `(` after `if` keyword.",
       "MissingRightBraceAfterBlock": "Missing closing brace `}` after block statement.",
-      "MissingRightBraceInTemplateLiteral": "Missing closing brace `}` in template literal interpolation.",
+      "MissingRightBraceInTemplateLiteral": "Jiki couldn't find a closing brace (`}`) in this template literal. Check in case you missed it or made a typo. The correct shape is ``` `...${...}...` ```.",
       "MissingRightBracketInArray": "Missing closing bracket `]` to close the array.",
       "MissingRightBracketInMemberAccess": "Missing closing bracket `]` after array index.",
       "MissingRightParenthesisAfterExpression": "Missing closing parenthesis `)` after expression.",


### PR DESCRIPTION
## What

Rewords the JavaScript interpreter's `MissingRightBraceInTemplateLiteral` scanner error to be more student-friendly.

This fires when a template literal opens an interpolation with `${` but never closes it with `}`, e.g. `` `${x]Pling` `` (a `]` typo instead of `}`).

**Before:**
> Missing closing brace `}` in template literal interpolation.

**After:**
> Jiki couldn't find a closing brace (`}`) in this template literal. Check in case you missed it or made a typo. The correct shape is `` `...${...}...` ``.

## Scope

- `en` translation only. The `system` key stays the bare `MissingRightBraceInTemplateLiteral` (test convention), so the existing `tests/javascript/template-literals.test.ts` assertions are unaffected.
- Consistent with the fenced-backtick rendering already used by the sibling `MissingBacktickToTerminateTemplateLiteral` / `QuoteUsedToTerminateTemplateLiteral` messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)