### PR TITLE
Fix unreachable "shoot twice" guard in space-invaders

### DIFF
--- a/curriculum/src/exercise-categories/space-invaders/SpaceInvadersExercise.ts
+++ b/curriculum/src/exercise-categories/space-invaders/SpaceInvadersExercise.ts
@@ -48,12 +48,14 @@ export default class SpaceInvadersExercise extends VisualExercise {
     (_, idx) => this.laserStart + idx * this.laserStep
   );
   private laserPosition = 0;
-  protected shotCooldown: number | false = 50;
+  // When true, shooting twice without moving in between is a logic error.
+  // Subclasses can disable this to allow rapid-fire shooting.
+  protected preventRepeatShot: boolean = true;
   private features = { alienRespawning: false };
   private laser!: HTMLElement;
   private aliens: (Alien | null)[][] = [];
   private startingAliens: (Alien | null)[][] = [];
-  private lastShotAt = -100;
+  private justShot = false;
 
   constructor() {
     super();
@@ -173,6 +175,9 @@ export default class SpaceInvadersExercise extends VisualExercise {
   }
 
   private moveLaser(executionCtx: ExecutionContext) {
+    // Moving clears the repeat-shot guard: the student is free to shoot again
+    // once they've moved.
+    this.justShot = false;
     this.addAnimation({
       targets: `#${this.view.id} .laser`,
       duration: this.moveDuration,
@@ -209,12 +214,12 @@ export default class SpaceInvadersExercise extends VisualExercise {
   }
 
   public shoot(executionCtx: ExecutionContext) {
-    if (this.shotCooldown !== false && this.lastShotAt > executionCtx.getCurrentTimeInMs() - this.shotCooldown) {
+    if (this.preventRepeatShot && this.justShot) {
       executionCtx.logicError(
         "Oh no! Your laser canon overheated from shooting too fast! You need to move before you can shoot a second time."
       );
     }
-    this.lastShotAt = executionCtx.getCurrentTimeInMs();
+    this.justShot = true;
 
     let targetRow = null;
     let targetAlien: Alien | null = null;

--- a/curriculum/src/exercises/space-invaders-conditional/Exercise.ts
+++ b/curriculum/src/exercises/space-invaders-conditional/Exercise.ts
@@ -1,7 +1,7 @@
 import SpaceInvadersExercise from "../../exercise-categories/space-invaders/SpaceInvadersExercise";
 
 export default class SpaceInvadersConditionalExercise extends SpaceInvadersExercise {
-  protected shotCooldown: number | false = false;
+  protected preventRepeatShot: boolean = false;
 
   public availableFunctions = [
     {

--- a/curriculum/src/exercises/space-invaders-nested-repeat/Exercise.ts
+++ b/curriculum/src/exercises/space-invaders-nested-repeat/Exercise.ts
@@ -1,7 +1,7 @@
 import SpaceInvadersExercise from "../../exercise-categories/space-invaders/SpaceInvadersExercise";
 
 export default class SpaceInvadersNestedRepeatExercise extends SpaceInvadersExercise {
-  protected shotCooldown: number | false = false;
+  protected preventRepeatShot: boolean = false;
 
   public availableFunctions = [
     {

--- a/curriculum/src/exercises/space-invaders-repeat/Exercise.ts
+++ b/curriculum/src/exercises/space-invaders-repeat/Exercise.ts
@@ -1,7 +1,7 @@
 import SpaceInvadersExercise from "../../exercise-categories/space-invaders/SpaceInvadersExercise";
 
 export default class SpaceInvadersRepeatExercise extends SpaceInvadersExercise {
-  protected shotCooldown: number | false = false;
+  protected preventRepeatShot: boolean = false;
 
   public availableFunctions = [
     {


### PR DESCRIPTION
## Problem

The double-shoot logic error in `SpaceInvadersExercise` was **dead code**. It used a 50ms time-based cooldown:

```js
if (this.shotCooldown !== false && this.lastShotAt > getCurrentTimeInMs() - this.shotCooldown) {
  executionCtx.logicError("Oh no! Your laser canon overheated...");
}
```

But every successful `shoot()` calls `executionCtx.fastForward(300)`, so two consecutive shots are always ~300ms apart — well beyond the 50ms cooldown. The guard could never fire. The only path without a fast-forward is a miss, which throws its own error and halts.

Net effect: students could shoot the same column repeatedly (e.g. clearing stacked aliens in `scroll-and-shoot`) without ever tripping the "you must move before shooting again" rule, so incorrect solutions passed.

## Fix

Replace the time-based cooldown with a `justShot` boolean:

- `shoot()` sets `justShot = true` (and errors if it was already set)
- moving clears `justShot = false`

This directly expresses the intended "move before you shoot again" rule and is immune to the fast-forward timing. The `shotCooldown` toggle is renamed to `preventRepeatShot`; the three siblings that disabled it (`space-invaders-repeat`, `-nested-repeat`, `-conditional`) are updated to match.

## Verification

- Two shots at the same column now produce an error frame **immediately** after the first shot, instead of being swallowed.
- `shoot → move → move → shoot` is allowed.
- The reference `scroll-and-shoot` solution still wins every wave.
- Full curriculum suite passes (672 tests) + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)