### PR TITLE
Guard document.body appendChild in VisualTestCanvas

### DIFF
--- a/app/components/coding-exercise/ui/test-results-view/VisualTestCanvas.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/VisualTestCanvas.tsx
@@ -18,7 +18,10 @@ export function VisualTestCanvas({ view, isSpotlightActive = false }: VisualTest
     // Clean up old view
     if (viewContainerRef.current.children.length > 0) {
       const oldView = viewContainerRef.current.children[0] as HTMLElement;
-      document.body.appendChild(oldView);
+      // document.body is a temporary parking parent and can genuinely be null
+      // during page teardown (typed non-null but seen null in production -
+      // JIKI-FRONT-END-3R, same class as #873), so skip it safely.
+      (document.body as HTMLElement | null)?.appendChild(oldView);
       oldView.style.display = "none";
     }
 
@@ -31,7 +34,10 @@ export function VisualTestCanvas({ view, isSpotlightActive = false }: VisualTest
 
     return () => {
       view.style.display = "none";
-      document.body.appendChild(view);
+      // document.body can be null when this cleanup runs during page teardown
+      // (typed non-null but seen null in production - JIKI-FRONT-END-3R, same
+      // class as #873).
+      (document.body as HTMLElement | null)?.appendChild(view);
     };
   }, [view]);
 


### PR DESCRIPTION
## The crash

`VisualTestCanvas` crashed in production with `TypeError: Cannot read properties of null (reading 'appendChild')` during React passive-effect teardown (seen on jiki.io/dashboard, Chrome 150/Windows — Sentry issue **JIKI-FRONT-END-3R**).

The effect's cleanup does `document.body.appendChild(view)` unguarded. `document.body` is typed non-null, but React can run this cleanup during page teardown where the body is genuinely null. The lower-risk old-view path (`document.body.appendChild(oldView)`) had the same class of bug.

## The fix

`document.body` is only a temporary parking parent for the view element while it is re-parented between the canvas and this hidden holding spot, so it degrades safely when the body is gone. Both `appendChild` sites are now optional-chained via `(document.body as HTMLElement | null)?.appendChild(...)`.

This is the exact same bug class fixed in #873 ("Guard document.body accesses in resize cleanup and visual-exercise views"); this file was missed in that sweep, so the guard pattern matches #873 exactly.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)