### PR TITLE
Skip codeless MuxPlayer errors instead of reporting them to Sentry

### DIFF
--- a/app/components/ui/JikiMuxPlayer.tsx
+++ b/app/components/ui/JikiMuxPlayer.tsx
@@ -47,6 +47,15 @@ function defaultOnError(event: Event) {
     return;
   }
 
+  // A codeless plain Event (no detail, null event.target.error, so no code and no
+  // message) carries nothing actionable. These fire from the native-video path as a
+  // duplicate signal of the paired rich CustomEvent, which lands in its own Sentry
+  // issue with a real code. Log it but keep the empty duplicate out of Sentry.
+  if (code == null && !mediaError?.message) {
+    console.error(error);
+    return;
+  }
+
   // Every variant funnels through this same stack frame, so without an explicit
   // fingerprint Sentry lumps decode failures, unsupported formats, and unknown
   // errors into one issue. Group per code/muxCode so each class is triaged on

--- a/app/tests/unit/components/ui/JikiMuxPlayer.test.tsx
+++ b/app/tests/unit/components/ui/JikiMuxPlayer.test.tsx
@@ -56,11 +56,35 @@ describe("JikiMuxPlayer defaultOnError", () => {
     expect(reported.message).toBe("MuxPlayer error: code 4: muxCode 2404000: Source not supported.");
   });
 
-  it("falls back to a bare message when no error detail is present", () => {
+  it("does not report codeless events with no detail but still logs them", () => {
+    // No detail and no event.target.error means no code and no message. These are
+    // duplicate signals of the paired rich CustomEvent, so keep them out of Sentry.
     fireMuxError(undefined);
 
+    expect(mockReportError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect((consoleErrorSpy.mock.calls[0][0] as Error).message).toBe("MuxPlayer error");
+  });
+
+  it("does not report a plain Event with a null event.target.error but still logs it", () => {
+    // The native-video path dispatches a plain Event whose target.error is null.
+    const target = document.createElement("video");
+    Object.defineProperty(target, "error", { configurable: true, value: null });
+    const event = new Event("error");
+    Object.defineProperty(event, "target", { value: target });
+
+    capturedOnError?.(event);
+
+    expect(mockReportError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect((consoleErrorSpy.mock.calls[0][0] as Error).message).toBe("MuxPlayer error");
+  });
+
+  it("reports an error that has a message but no code", () => {
+    fireMuxError({ message: "Something broke." });
+
     expect(mockReportError).toHaveBeenCalledTimes(1);
-    expect((mockReportError.mock.calls[0][0] as Error).message).toBe("MuxPlayer error");
+    expect((mockReportError.mock.calls[0][0] as Error).message).toBe("MuxPlayer error: Something broke.");
   });
 
   it("reads error info from event.target.error on the native-video fallback path", () => {


### PR DESCRIPTION
## Problem

Sentry issue [JIKI-FRONT-END-3P](https://de.sentry.io) is a bare "MuxPlayer error" with fingerprint `none/none`. The `defaultOnError` handler in `components/ui/JikiMuxPlayer.tsx` builds an `Error` from the Mux error event and reports it to Sentry. On the native-video fallback path, Mux dispatches a plain `Event` with no `detail` and a null `event.target.error`, so the constructed error has no code and no message.

## Duplicate-signal analysis

These codeless plain events are duplicate signals: the same underlying failures also fire a rich `CustomEvent` whose `detail` carries a real Mux code, and that variant lands in its own Sentry issue (e.g. JIKI-FRONT-END-3Q) with a meaningful fingerprint. The codeless plain event carries nothing actionable — no code, no muxCode, no message — so reporting it just adds a low-signal, un-triageable duplicate issue.

## Fix

When there is no error information at all (no `detail` and no `event.target.error`, i.e. `code == null` and no message), `console.error` the constructed error and return without calling `reportError`. This mirrors the existing `MEDIA_ERR_NETWORK` branch. Behavior is unchanged for any event that carries a code or a message.

Added unit coverage for the new skip path (codeless CustomEvent and plain Event with null `target.error`) and for the "message but no code" case that still reports.

Fixes JIKI-FRONT-END-3P
Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)