### PR TITLE
Skip Sentry reporting for MuxPlayer decode errors (code 3)

### DIFF
--- a/app/components/ui/JikiMuxPlayer.tsx
+++ b/app/components/ui/JikiMuxPlayer.tsx
@@ -8,6 +8,12 @@ import { reportError } from "@/lib/reportError";
 // Mux's HTML5 media error code for a network failure (see MediaError.MEDIA_ERR_NETWORK).
 const MEDIA_ERR_NETWORK = 2;
 
+// Mux's HTML5 media error code for a decode failure (see MediaError.MEDIA_ERR_DECODE).
+// In practice these come from codec-limited clients — Firefox on Linux without an
+// H.264/ffmpeg codec (hls.js finds no playable rendition), in-app webviews, and the
+// like — rather than genuinely corrupt media or an actionable app bug.
+const MEDIA_ERR_DECODE = 3;
+
 // A Mux MediaError, carried on the error event's `detail`. It extends the native
 // MediaError with Mux-specific fields. Typed locally so we don't depend on the
 // playback-core internals just to read a few properties.
@@ -43,6 +49,14 @@ function defaultOnError(event: Event) {
   // Network failures are transient client-side connectivity drops (laptop sleep,
   // wifi loss) rather than actionable bugs — log them but keep them out of Sentry.
   if (code === MEDIA_ERR_NETWORK) {
+    console.error(error);
+    return;
+  }
+
+  // Decode failures are missing-codec problems on the client (Firefox/Linux without
+  // H.264, in-app webviews) rather than corrupt media or an actionable app bug — log
+  // them but keep them out of Sentry.
+  if (code === MEDIA_ERR_DECODE) {
     console.error(error);
     return;
   }

--- a/app/tests/unit/components/ui/JikiMuxPlayer.test.tsx
+++ b/app/tests/unit/components/ui/JikiMuxPlayer.test.tsx
@@ -56,6 +56,24 @@ describe("JikiMuxPlayer defaultOnError", () => {
     expect(reported.message).toBe("MuxPlayer error: code 4: muxCode 2404000: Source not supported.");
   });
 
+  it("does not report decode errors to Sentry but still logs them", () => {
+    // code 3 (MEDIA_ERR_DECODE) comes from codec-limited clients (Firefox/Linux
+    // without H.264, in-app webviews), not corrupt media or an app bug.
+    fireMuxError({
+      code: 3,
+      muxCode: 2000003,
+      message:
+        "The media playback was aborted due to a corruption problem or because the media used features your browser did not support."
+    });
+
+    expect(mockReportError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const [logged] = consoleErrorSpy.mock.calls[0];
+    expect(logged).toBeInstanceOf(Error);
+    expect((logged as Error).message).toContain("code 3");
+    expect((logged as Error).message).toContain("muxCode 2000003");
+  });
+
   it("does not report codeless events with no detail but still logs them", () => {
     // No detail and no event.target.error means no code and no message. These are
     // duplicate signals of the paired rich CustomEvent, so keep them out of Sentry.
@@ -92,7 +110,7 @@ describe("JikiMuxPlayer defaultOnError", () => {
     const target = document.createElement("video");
     Object.defineProperty(target, "error", {
       configurable: true,
-      value: { code: 3, message: "Decode failed." }
+      value: { code: 4, message: "Source not supported." }
     });
     const event = new Event("error");
     Object.defineProperty(event, "target", { value: target });
@@ -100,7 +118,7 @@ describe("JikiMuxPlayer defaultOnError", () => {
     capturedOnError?.(event);
 
     expect(mockReportError).toHaveBeenCalledTimes(1);
-    expect((mockReportError.mock.calls[0][0] as Error).message).toBe("MuxPlayer error: code 3: Decode failed.");
+    expect((mockReportError.mock.calls[0][0] as Error).message).toBe("MuxPlayer error: code 4: Source not supported.");
   });
 
   it("silences network errors that arrive via event.target.error (native fallback path)", () => {
@@ -110,6 +128,23 @@ describe("JikiMuxPlayer defaultOnError", () => {
     Object.defineProperty(target, "error", {
       configurable: true,
       value: { code: 2, message: "Network error." }
+    });
+    const event = new Event("error");
+    Object.defineProperty(event, "target", { value: target });
+
+    capturedOnError?.(event);
+
+    expect(mockReportError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("silences decode errors that arrive via event.target.error (native fallback path)", () => {
+    // Decode skip keys off the HTML5 `code`, present on both the Mux detail
+    // payload and the native MediaError, so this path is silenced too.
+    const target = document.createElement("video");
+    Object.defineProperty(target, "error", {
+      configurable: true,
+      value: { code: 3, message: "Decode failed." }
     });
     const event = new Event("error");
     Object.defineProperty(event, "target", { value: target });


### PR DESCRIPTION
## What

Treat MuxPlayer `MEDIA_ERR_DECODE` (HTML5 media error code 3) the same way we already treat `MEDIA_ERR_NETWORK` (code 2) in `defaultOnError`: `console.error` the constructed error and return without calling `reportError`, so it stays out of Sentry. No fallback UI is added — nothing else changes.

## Why

Sentry issue **JIKI-FRONT-END-3Q** — `MuxPlayer error: code 3` (MEDIA_ERR_DECODE, "media could be corrupt or your browser does not support this format").

Triaging the events showed they all come from codec-limited clients, not from corrupt media or an app bug:

- **Firefox on Linux without an H.264/ffmpeg codec** — hls.js's `filterAndSortMediaOptions` finds no playable rendition, so decoding fails.
- **The Google-app iOS webview**.
- **Opera on Linux**.

These are environmental client-capability failures we can't fix in the app, and they're noise in Sentry. Logging them to the console preserves local debuggability while keeping the issue closed.

## Changes

- Add a `MEDIA_ERR_DECODE = 3` constant alongside `MEDIA_ERR_NETWORK`, with a comment explaining the codec-capability cause.
- Add a decode branch in `defaultOnError` mirroring the network branch (log + return, no report).
- Extend `JikiMuxPlayer.test.tsx`: code 3 (via both the Mux `detail` payload and the native `event.target.error` fallback path) is console-logged but **not** reported; a different fatal code (4) still reports.

## Stacking

Stacked on **#893** (`ihid-mux-skip-codeless-errors`), which also touches `defaultOnError`. Base branch is `ihid-mux-skip-codeless-errors`; GitHub will retarget this PR to `main` once #893 merges.

Closes #877
Fixes JIKI-FRONT-END-3Q

🤖 Generated with [Claude Code](https://claude.com/claude-code)
