### PR TITLE
Fix Ask Jiki conversation not scrolling via trackpad/keyboard

### DIFF
--- a/app/components/coding-exercise/ui/ChatPanel.module.css
+++ b/app/components/coding-exercise/ui/ChatPanel.module.css
@@ -1,10 +1,13 @@
 .chatPanel {
     background: white;
-    /* min-height (not height) so the panel can grow with tall content and let
-       the white tab-content wrapper scroll, matching the instructions panel.
-       The in-progress conversation still stays bounded because its messages
-       list scrolls internally. */
-    min-height: 100%;
+    /* height:100% (a definite height, matching the instructions panel's .container)
+       so the in-progress conversation gets a bounded chain and its message list
+       scrolls internally. With min-height:100% a long conversation grows the panel
+       instead, the outer tab wrapper scrolls, and overscroll-behavior:none on the
+       message list blocks trackpad/keyboard scroll from chaining out to it. Tall
+       non-conversation states still scroll because their overflow spills into the
+       outer overflow:auto wrapper. */
+    height: 100%;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
## Problem

In the **Ask Jiki** tab, an in-progress conversation could only be scrolled by dragging the scrollbar — a two-finger trackpad swipe or the arrow keys did nothing. Scrolling in the Instructions tab was fine. Reported on the [forum](https://forum.jiki.io/t/scrolling-issue-with-ask-jiki/407) (Win 11 / Chrome), reproduced by more than one user.

## Root cause

`.chatPanel` used `min-height: 100%`, which leaves its height **indefinite**. In a flex column, free space is only distributed to `flex: 1` children when the container has a *definite* main size. For a long conversation the panel instead grows to fit its content (zero free space), so the element that actually scrolls becomes the **outer** tab wrapper, not the inner `.chatScrollWrapper`.

A wheel/keyboard gesture then lands on `.chatScrollWrapper` — a scroll container that can't scroll because it's content-sized — and its `overscroll-behavior: none` **blocks the scroll from chaining out** to the wrapper that could scroll. Dragging the outer scrollbar bypasses the chain, which is exactly why only that worked. (Short conversations happened to bound correctly, so this only bit long ones.)

The Instructions panel was unaffected because its `.container` uses `height: 100%` — a definite chain.

## Fix

Switch `.chatPanel` to `height: 100%` (matching the Instructions panel's `.container`). The flex chain is now bounded, so `.chatScrollWrapper` becomes the genuine internal scroller:

- trackpad/wheel and arrow keys scroll it directly,
- `overscroll-behavior: none` now correctly prevents page-bounce instead of eating the gesture,
- `useStickToBottom`'s `scrollTo` finally acts on the real scroller.

Tall non-conversation chat states (CanStart, premium-blocked, etc.) still scroll because their `overflow: visible` content spills into the outer `overflow: auto` wrapper.

One-line CSS change (plus an explanatory comment).

## Test plan

- [ ] Open Ask Jiki with a long conversation → scroll with trackpad two-finger swipe (regression case)
- [ ] Same, with arrow keys
- [ ] Scrollbar drag still works
- [ ] Streaming a new reply still auto-sticks to the bottom
- [ ] Instructions tab scrolling unchanged
- [ ] Non-conversation chat states (can-start / limit-reached) still scroll if tall

🤖 Generated with [Claude Code](https://claude.com/claude-code)