### PR TITLE
Fix two typos in relational-sun and space-invaders

### DIFF
--- a/curriculum/src/exercise-categories/space-invaders/SpaceInvadersExercise.ts
+++ b/curriculum/src/exercise-categories/space-invaders/SpaceInvadersExercise.ts
@@ -216,7 +216,7 @@ export default class SpaceInvadersExercise extends VisualExercise {
   public shoot(executionCtx: ExecutionContext) {
     if (this.preventRepeatShot && this.justShot) {
       executionCtx.logicError(
-        "Oh no! Your laser canon overheated from shooting too fast! You need to move before you can shoot a second time."
+        "Oh no! Your laser cannon overheated from shooting too fast! You need to move before you can shoot a second time."
       );
     }
     this.justShot = true;
@@ -337,12 +337,12 @@ export default class SpaceInvadersExercise extends VisualExercise {
     {
       name: "move_left",
       func: this.moveLeft.bind(this),
-      description: "moved the laser canon to the left"
+      description: "moved the laser cannon to the left"
     },
     {
       name: "move_right",
       func: this.moveRight.bind(this),
-      description: "moved the laser canon to the right"
+      description: "moved the laser cannon to the right"
     },
     {
       name: "shoot",
@@ -352,7 +352,7 @@ export default class SpaceInvadersExercise extends VisualExercise {
     {
       name: "is_alien_above",
       func: this.isAlienAbove.bind(this),
-      description: "determined if there was an alien above the laser canon"
+      description: "determined if there was an alien above the laser cannon"
     },
     {
       name: "get_starting_aliens_in_row",

--- a/curriculum/src/exercises/relational-sun/instructions/en.md
+++ b/curriculum/src/exercises/relational-sun/instructions/en.md
@@ -8,7 +8,7 @@ In this exercise, your task is to position a sun in the top-right corner of the 
 We've preset four variables for you at the top of the file:
 
 - `canvasSize`: the size of the canvas, which is `100`.
-- `color`: set it to `"yellow"`.
+- `color`: set to `"yellow"`.
 - `gap`: how far the sun's edge sits from the top and right edges of the canvas.
 - `radius`: the sun's radius.
 


### PR DESCRIPTION
Fixes two typos:

- **relational-sun** instructions: `color`: "set it to" → "set to"
- **space-invaders**: "laser canon" → "laser cannon" (4 occurrences: logic error message + 3 action descriptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)