### PR TITLE
Add staging.jiki.io deployment (jiki-app-staging worker)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,113 @@
+name: Deploy Staging
+
+# Manual-only. Pick the branch/ref to ship to staging.jiki.io.
+# Staging is a full production build (NODE_ENV=production) that talks to the same
+# API and shares the .jiki.io cookie; it differs from prod only via ENVIRONMENT=staging
+# (set in wrangler.staging.jsonc), which disables indexing and caching.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag or SHA to deploy to staging"
+        required: true
+        default: "main"
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy-app-staging:
+    runs-on: ubuntu-latest
+    name: Deploy Next.js App (staging)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Validate required environment variables
+        run: |
+          missing_vars=()
+
+          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]; then
+            missing_vars+=("CLOUDFLARE_API_TOKEN")
+          fi
+
+          if [ -z "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ]; then
+            missing_vars+=("CLOUDFLARE_ACCOUNT_ID")
+          fi
+
+          if [ -z "${{ secrets.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID }}" ]; then
+            missing_vars+=("NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID")
+          fi
+
+          if [ -z "${{ secrets.NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID }}" ]; then
+            missing_vars+=("NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID")
+          fi
+
+          if [ -z "${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}" ]; then
+            missing_vars+=("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY")
+          fi
+
+          if [ -z "${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}" ]; then
+            missing_vars+=("NEXT_PUBLIC_TURNSTILE_SITE_KEY")
+          fi
+
+          if [ -z "${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}" ]; then
+            missing_vars+=("NEXT_PUBLIC_POSTHOG_KEY")
+          fi
+
+          if [ -z "${{ secrets.SENTRY_AUTH_TOKEN }}" ]; then
+            missing_vars+=("SENTRY_AUTH_TOKEN")
+          fi
+
+          if [ -z "${{ secrets.R2_ACCESS_KEY_ID }}" ]; then
+            missing_vars+=("R2_ACCESS_KEY_ID")
+          fi
+
+          if [ -z "${{ secrets.R2_SECRET_ACCESS_KEY }}" ]; then
+            missing_vars+=("R2_SECRET_ACCESS_KEY")
+          fi
+
+          if [ ${#missing_vars[@]} -ne 0 ]; then
+            echo "❌ Error: The following required secrets are not set:"
+            printf '  - %s\n' "${missing_vars[@]}"
+            exit 1
+          fi
+
+          echo "✅ All required environment variables are set"
+
+      - name: Deploy to Cloudflare Workers (staging)
+        run: pnpm run deploy:staging
+        working-directory: app
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID }}
+          NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_EXERCISM_OAUTH_CLIENT_ID }}
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # R2 credentials for the `static:upload` step. Shared `assets` bucket:
+          # uploads are additive/content-hashed, so staging never mutates prod assets.
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required

--- a/app/.context/deployment.md
+++ b/app/.context/deployment.md
@@ -11,6 +11,38 @@ Cloudflare Workers with Next.js Edge Runtime
 - **Custom Domain**: Automatic DNS management via Cloudflare
 - **Caching**: R2 bucket for incremental builds with 30-minute regional cache
 
+## Staging Environment
+
+`staging.jiki.io` is a second deployment of the app Worker (`jiki-app-staging`),
+used to preview unmerged branches against the real backend.
+
+- **Same everything as prod except the deployment tier.** It is a full production
+  build (`NODE_ENV=production`), talks to the **same API** (`api.jiki.io`), and
+  shares the `.jiki.io` auth cookie, so a user logged in on `jiki.io` is logged in
+  on staging as the same real user against real data. This is intentional.
+- **The only differentiator is `ENVIRONMENT=staging`** (a Worker `var` in
+  `wrangler.staging.jsonc`). This is a separate axis from `NODE_ENV` - never set
+  `NODE_ENV` to anything but `production` on staging, or the auth cookie name, API
+  base URL, `assetPrefix`, and CSP all change. `lib/env.ts` exposes `isStaging()`
+  (fail-safe: unknown/unset `ENVIRONMENT` resolves to `production`).
+- **Hidden, not sandboxed.** `robots.ts` blocks all crawling, `middleware.ts` adds
+  `X-Robots-Tag: noindex` and forces `Cache-Control: no-store` (so neither browser,
+  CDN, nor Worker edge cache serve staging content). The Worker edge cache is also
+  off because it requires `ENVIRONMENT=production`.
+- **Shared buckets.** Staging reuses the prod `assets` and `build-cache` R2 buckets.
+  Safe because asset uploads are additive/content-hashed and the incremental cache
+  is namespaced by build ID.
+- **Deploy**: manual only via the `Deploy Staging` GitHub Action
+  (`workflow_dispatch`, pick a ref) which runs `pnpm run deploy:staging`. Uses the
+  same secrets as prod.
+- **Infra**: a `cloudflare_workers_custom_domain` for `staging.jiki.io` -> the
+  `jiki-app-staging` service (in the Terraform repo). The wildcard cert
+  (`*.jiki.io`), unconditional asset CORS, and cookie-based cache bypass already
+  cover staging with no further Cloudflare changes.
+- **Provider allowlists**: `staging.jiki.io` must be added to the Google OAuth
+  redirect URIs, the Exercism Doorkeeper callback, and the Turnstile hostnames or
+  those flows fail on staging.
+
 ## Deployment Process
 
 ### Automatic Deployment (CI/CD)

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -89,6 +89,8 @@ This is the frontend for Jiki, a learn-to-code platform.
 
 **Note**: React Compiler is enabled, so manual memoization (`useMemo`, `useCallback`, `memo()`) is generally not needed.
 
+**Staging**: `staging.jiki.io` (`jiki-app-staging` Worker) must be deployed via the Deploy Staging GitHub Action **before** the Terraform custom-domain apply — the domain can't attach to a Worker service that doesn't exist yet.
+
 ### Organizational Patterns
 
 #### Component Organization

--- a/app/app/robots.ts
+++ b/app/app/robots.ts
@@ -1,7 +1,19 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/site";
+import { isStaging } from "@/lib/env";
 
 export default function robots(): MetadataRoute.Robots {
+  // Staging shares the production domain and API but must never be crawled or
+  // indexed, so block everything and omit the sitemap.
+  if (isStaging()) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/"
+      }
+    };
+  }
+
   return {
     rules: {
       userAgent: "*",

--- a/app/lib/env.ts
+++ b/app/lib/env.ts
@@ -1,0 +1,24 @@
+/**
+ * Deployment-tier helpers.
+ *
+ * This is a SEPARATE axis from `NODE_ENV`. `NODE_ENV` describes the build mode
+ * (development vs production) and is relied on across the app for the auth cookie
+ * name, the API base URL, `assetPrefix`, and the CSP - so a production build must
+ * always keep `NODE_ENV=production`, including on staging.
+ *
+ * `ENVIRONMENT` (a Worker `var`, promoted to `process.env` via
+ * `nodejs_compat_populate_process_env`) is what distinguishes deployment tiers:
+ * `production` vs `staging`. Staging is a full production build that talks to the
+ * real API and shares the `.jiki.io` cookie, so the only things that differ are
+ * indexing and caching - both keyed off `isStaging()`.
+ *
+ * Fail-safe: an unset/unknown value resolves to `production`, so the staging-only
+ * behaviour (noindex, no-store) can never accidentally fire on production.
+ */
+export type DeployEnv = "production" | "staging";
+
+export const DEPLOY_ENV: DeployEnv = process.env.ENVIRONMENT === "staging" ? "staging" : "production";
+
+export function isStaging(): boolean {
+  return DEPLOY_ENV === "staging";
+}

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { AUTHENTICATION_COOKIE_NAME } from "./lib/auth/cookie-config";
+import { isStaging } from "./lib/env";
 import { PATHNAME_HEADER, URL_LOCALE_HEADER, isSupportedLocale } from "./lib/i18n/config";
 import { resolveLocaleRouting } from "./lib/i18n/localeRouting";
 import { isCacheableRoute } from "./lib/cache/cacheable-routes";
@@ -96,18 +97,31 @@ export function middleware(request: NextRequest) {
   setInternalNavigationCookie(request, response);
 
   //
+  // Staging shares the production domain and API but must never be indexed or
+  // cached (browser or CDN). This is a separate cache layer from the Worker edge
+  // cache (disabled via ENVIRONMENT=staging) - the Cache-Control header below is
+  // what the Cloudflare zone honours - so it must be suppressed here too.
+  //
+  const staging = isStaging();
+  if (staging) {
+    response.headers.set("X-Robots-Tag", "noindex");
+  }
+
+  //
   // Set cache headers for unauthenticated external URL requests
   // Skip for RSC requests (client-side navigation)
   //
   const isAuthenticated = request.cookies.has(AUTHENTICATION_COOKIE_NAME);
   const isRscRequest = request.headers.has("rsc");
-  if (!isAuthenticated && !isRscRequest && isCacheableRoute(path)) {
+  if (staging) {
+    response.headers.set("Cache-Control", "no-store");
+  } else if (!isAuthenticated && !isRscRequest && isCacheableRoute(path)) {
     response.headers.set("Cache-Control", "public, max-age=600, s-maxage=600");
     response.headers.set("Vary", "Cookie");
   }
 
-  // Cache favicon for 10 minutes
-  if (path === "/favicon.ico") {
+  // Cache favicon for 10 minutes (never on staging)
+  if (!staging && path === "/favicon.ico") {
     response.headers.set("Cache-Control", "public, max-age=600");
   }
 

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "preview": "wrangler dev",
     "static:upload": "aws s3 sync .open-next/assets/_next/static s3://assets/_next/static --endpoint-url https://0a0e6f92decf825364b860e2286ceebf.r2.cloudflarestorage.com --cache-control 'public, max-age=31536000, immutable' --size-only && aws s3 sync public/static s3://assets/static --endpoint-url https://0a0e6f92decf825364b860e2286ceebf.r2.cloudflarestorage.com --cache-control 'public, max-age=3600' --exclude 'hashed/*' && aws s3 sync public/static/hashed s3://assets/static/hashed --endpoint-url https://0a0e6f92decf825364b860e2286ceebf.r2.cloudflarestorage.com --cache-control 'public, max-age=31536000, immutable'",
     "deploy": "DEPLOY_ID=$(git rev-parse --short HEAD) && npx opennextjs-cloudflare build && pnpm run static:upload && wrangler deploy --var DEPLOY_ID:$DEPLOY_ID",
+    "deploy:staging": "DEPLOY_ID=$(git rev-parse --short HEAD) && npx opennextjs-cloudflare build && pnpm run static:upload && wrangler deploy -c wrangler.staging.jsonc --var DEPLOY_ID:$DEPLOY_ID",
     "content:generate": "node scripts/generate-content-cache.js",
     "content:watch": "onchange '../content/src/**' -- node scripts/generate-content-cache.js",
     "exercise-cache:generate": "node scripts/generate-exercise-cache.js",

--- a/app/tests/unit/app/robots.test.ts
+++ b/app/tests/unit/app/robots.test.ts
@@ -1,0 +1,30 @@
+import robots from "@/app/robots";
+import { isStaging } from "@/lib/env";
+
+jest.mock("@/lib/env");
+
+const mockIsStaging = isStaging as jest.MockedFunction<typeof isStaging>;
+
+describe("robots", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("allows all crawling and lists the sitemap in production", () => {
+    mockIsStaging.mockReturnValue(false);
+
+    const result = robots();
+
+    expect(result.rules).toEqual({ userAgent: "*", allow: "/" });
+    expect(result.sitemap).toBe("https://jiki.io/sitemap.xml");
+  });
+
+  it("blocks everything and omits the sitemap on staging", () => {
+    mockIsStaging.mockReturnValue(true);
+
+    const result = robots();
+
+    expect(result.rules).toEqual({ userAgent: "*", disallow: "/" });
+    expect(result.sitemap).toBeUndefined();
+  });
+});

--- a/app/tests/unit/lib/env.test.ts
+++ b/app/tests/unit/lib/env.test.ts
@@ -1,0 +1,39 @@
+describe("DEPLOY_ENV / isStaging", () => {
+  const original = process.env.ENVIRONMENT;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.ENVIRONMENT;
+    } else {
+      process.env.ENVIRONMENT = original;
+    }
+    jest.resetModules();
+  });
+
+  async function load(value: string | undefined) {
+    jest.resetModules();
+    if (value === undefined) {
+      delete process.env.ENVIRONMENT;
+    } else {
+      process.env.ENVIRONMENT = value;
+    }
+    return import("@/lib/env");
+  }
+
+  it("is staging only when ENVIRONMENT is exactly 'staging'", async () => {
+    const mod = await load("staging");
+    expect(mod.DEPLOY_ENV).toBe("staging");
+    expect(mod.isStaging()).toBe(true);
+  });
+
+  it("defaults to production when ENVIRONMENT is unset", async () => {
+    const mod = await load(undefined);
+    expect(mod.DEPLOY_ENV).toBe("production");
+    expect(mod.isStaging()).toBe(false);
+  });
+
+  it("fails safe to production for production and any unknown value", async () => {
+    expect((await load("production")).isStaging()).toBe(false);
+    expect((await load("preview")).isStaging()).toBe(false);
+  });
+});

--- a/app/tests/unit/middleware.test.ts
+++ b/app/tests/unit/middleware.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { middleware } from "@/middleware";
+import { isStaging } from "@/lib/env";
+
+jest.mock("@/lib/env");
+
+const mockIsStaging = isStaging as jest.MockedFunction<typeof isStaging>;
+
+function requestFor(path: string) {
+  return new NextRequest(new URL(`https://staging.jiki.io${path}`));
+}
+
+describe("middleware staging behaviour", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sets noindex and no-store on every staging response", () => {
+    mockIsStaging.mockReturnValue(true);
+
+    const res = middleware(requestFor("/"));
+
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("forces no-store on staging even for the favicon", () => {
+    mockIsStaging.mockReturnValue(true);
+
+    const res = middleware(requestFor("/favicon.ico"));
+
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("never sets noindex on production and keeps the public cache header", () => {
+    mockIsStaging.mockReturnValue(false);
+
+    // "/" is an unauthenticated, cacheable public route.
+    const res = middleware(requestFor("/"));
+
+    expect(res.headers.get("X-Robots-Tag")).toBeNull();
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600, s-maxage=600");
+  });
+});

--- a/app/wrangler.staging.jsonc
+++ b/app/wrangler.staging.jsonc
@@ -1,0 +1,43 @@
+{
+  // Staging deployment of the app Worker.
+  //
+  // Identical to wrangler.jsonc EXCEPT:
+  //   - a distinct Worker `name` (so a staging deploy can never overwrite prod)
+  //   - `ENVIRONMENT: "staging"` (disables the edge cache and drives the
+  //     noindex/no-store behaviour in robots.ts + middleware.ts)
+  //   - the `staging.jiki.io` route
+  //   - WORKER_SELF_REFERENCE points at this staging service, not prod
+  //
+  // Buckets are intentionally SHARED with prod: the `assets` uploads are
+  // additive/content-hashed and the incremental cache is namespaced by build ID,
+  // so sharing is safe. Staging keeps NODE_ENV=production (set by the build), so
+  // the API base URL, auth cookie name, assetPrefix and CSP all match prod.
+  "name": "jiki-app-staging",
+  "main": "worker-wrapper.js",
+  "compatibility_date": "2025-08-16",
+  "compatibility_flags": ["nodejs_compat", "nodejs_compat_populate_process_env", "global_fetch_strictly_public"],
+  "vars": {
+    "ENVIRONMENT": "staging"
+  },
+  "assets": {
+    "directory": ".open-next/assets"
+  },
+  "routes": [
+    {
+      "pattern": "staging.jiki.io",
+      "custom_domain": true
+    }
+  ],
+  "r2_buckets": [
+    {
+      "binding": "NEXT_INC_CACHE_R2_BUCKET",
+      "bucket_name": "build-cache"
+    }
+  ],
+  "services": [
+    {
+      "binding": "WORKER_SELF_REFERENCE",
+      "service": "jiki-app-staging"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Stands up `staging.jiki.io` as a **second deployment of the app Worker** (`jiki-app-staging`) for previewing unmerged branches against the real backend. This PR is the **app-repo side only**; the Cloudflare custom-domain (Terraform) and provider allowlists are handled separately.

## Design

- **Staging is a full production build.** `NODE_ENV` stays `production` (it drives the auth cookie name, API base URL, `assetPrefix`, and CSP — changing it would break all of these). Staging talks to the **same API** (`api.jiki.io`) and shares the `.jiki.io` auth cookie, so a user logged in on prod is logged in on staging as the **same real user against real data**. This is intentional.
- **The deploy tier is a separate axis: `ENVIRONMENT`.** New `lib/env.ts` exposes `isStaging()`, keyed off the `ENVIRONMENT` Worker var. It **fails safe to `production`** — an unset/unknown value never enables the staging-only behaviour, so `noindex`/`no-store` can't accidentally fire on prod.
- **Hidden, not sandboxed.** On staging: `robots.ts` blocks all crawling, `middleware.ts` adds `X-Robots-Tag: noindex` and forces `Cache-Control: no-store`. That covers all three cache layers (browser, Cloudflare zone/CDN, and the Worker edge cache — the last is already off because it requires `ENVIRONMENT=production`).
- **Shared buckets.** Reuses the prod `assets` and `build-cache` R2 buckets. Safe: asset uploads are additive/content-hashed, and the incremental cache is namespaced by build ID.

## Changes

- `lib/env.ts` — `isStaging()` / `DEPLOY_ENV`, fail-safe to production
- `wrangler.staging.jsonc` — `jiki-app-staging` worker, `staging.jiki.io` route, `ENVIRONMENT=staging`, self-reference, shared buckets
- `app/robots.ts` + `middleware.ts` — noindex + no-store on staging
- `package.json` — `deploy:staging` (explicit `-c wrangler.staging.jsonc` so a staging deploy can never overwrite the prod worker)
- `.github/workflows/deploy-staging.yml` — manual `workflow_dispatch`, pick a ref
- Tests for the fail-safe env logic and robots gating
- `.context/deployment.md` — documents the staging environment

## Not in this PR (separate)

- **Terraform**: one `cloudflare_workers_custom_domain` for `staging.jiki.io` → `jiki-app-staging`. Wildcard cert, asset CORS, and cookie cache-bypass already cover staging.
- **Provider allowlists**: add `staging.jiki.io` to Google OAuth redirect URIs, Exercism Doorkeeper callback, and Turnstile hostnames.

## Note

Nothing here is deployed by merging — staging ships only when the `Deploy Staging` action is run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)