### PR TITLE
Disable prefetch on forum links

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -91,6 +91,8 @@ This is the frontend for Jiki, a learn-to-code platform.
 
 **Staging**: `staging.jiki.io` (`jiki-app-staging` Worker) must be deployed via the Deploy Staging GitHub Action **before** the Terraform custom-domain apply — the domain can't attach to a Worker service that doesn't exist yet.
 
+**Deploying a branch/PR to staging**: run the `Deploy Staging` workflow (`gh workflow run deploy-staging.yml -f ref=<branch>`), which deploys that ref to `staging.jiki.io`. **Only ever do this if the user explicitly asks** — it publishes real, working code to a live environment against the production API.
+
 ### Organizational Patterns
 
 #### Component Organization

--- a/app/components/articles/FilterSidebar.tsx
+++ b/app/components/articles/FilterSidebar.tsx
@@ -44,7 +44,10 @@ export default function FilterSidebar({ tagSlugs, selectedTag, locale }: FilterS
         <p className={styles.filterHelpText}>
           Can&apos;t find what you&apos;re looking for? Try our <Link href={routes.blog()}>Blogs</Link>,{" "}
           <Link href={routes.article("faqs")}>FAQs</Link>, <Link href={routes.article("support")}>Contact support</Link>
-          , or ask in our <Link href="/r/forum">Community</Link>
+          , or ask in our{" "}
+          <Link href="/r/forum" prefetch={false}>
+            Community
+          </Link>
         </p>
       </div>
     </div>

--- a/app/components/layout/sidebar/NavigationItem.tsx
+++ b/app/components/layout/sidebar/NavigationItem.tsx
@@ -13,6 +13,7 @@ interface NavigationItemProps {
   showPremiumPill?: boolean;
   isUserPremium?: boolean;
   external?: boolean;
+  prefetch?: boolean;
   onClick?: () => void;
 }
 
@@ -25,6 +26,7 @@ export function NavigationItem({
   showPremiumPill,
   isUserPremium,
   external,
+  prefetch,
   onClick
 }: NavigationItemProps) {
   const t = useTranslations("layout.sidebar");
@@ -65,7 +67,7 @@ export function NavigationItem({
           {content}
         </a>
       ) : (
-        <Link href={href || "#"} className={className} data-nav-id={id} data-label={label}>
+        <Link href={href || "#"} prefetch={prefetch} className={className} data-nav-id={id} data-label={label}>
           {content}
         </Link>
       )}

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -44,6 +44,10 @@ interface NavItem {
   icon?: ComponentType<{ className?: string }>;
   showPremiumPill?: boolean;
   external?: boolean;
+  // Disable RSC prefetch for internal paths that redirect off-site (e.g. /r/forum
+  // -> forum.jiki.io): the prefetch follows the redirect cross-origin and is
+  // CORS-blocked, so it only produces console noise and a wasted request.
+  prefetch?: boolean;
 }
 
 const navigationGroups: Array<{
@@ -70,7 +74,7 @@ const navigationGroups: Array<{
     items: [
       { id: "videos", href: YOUTUBE_URL, icon: VideoLibIcon, external: true },
       { id: "blog", href: "/blog", icon: RssIcon },
-      { id: "forum", href: "/r/forum", icon: ChatBubbleIcon }
+      { id: "forum", href: "/r/forum", icon: ChatBubbleIcon, prefetch: false }
     ]
   },
   {
@@ -106,6 +110,7 @@ export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
       isActive={activeItem === item.id}
       href={item.external ? item.href : localePath(item.href, locale)}
       external={item.external}
+      prefetch={item.prefetch}
       icon={item.icon}
       showPremiumPill={item.showPremiumPill}
       isUserPremium={Boolean(isPremium)}


### PR DESCRIPTION
## What

Adds `prefetch={false}` to the two `<Link href="/r/forum">` instances (the sidebar's Community item and the articles `FilterSidebar`). Also documents in `AGENTS.md` how to deploy a branch to staging.

## Why

`/r/forum` is an internal path that Next redirects **off-site** to `https://forum.jiki.io` (`next.config.ts`). Next `<Link>`s prefetch by default, so the RSC prefetch (`/r/forum?_rsc=…`) follows the redirect cross-origin to `forum.jiki.io`, which has no CORS headers — so every prefetch is CORS-blocked:

```
Access to fetch at 'https://forum.jiki.io/?_rsc=…' (redirected from 'https://staging.jiki.io/r/forum?_rsc=…')
has been blocked by CORS policy
Failed to fetch RSC payload … Falling back to browser navigation.
```

This is **pre-existing and not staging-specific** — it happens on production too (`jiki.io/r/forum` → `forum.jiki.io` is equally cross-origin). It's benign (clicks already fall back to full navigation), so this is purely removing console noise and a wasted prefetch request. Disabling prefetch is the right layer — **not** adding CORS to the Discourse forum.

## Scope

- `Sidebar.tsx` / `NavigationItem.tsx` — threads an optional `prefetch` prop and sets `prefetch: false` on the forum nav item
- `FilterSidebar.tsx` — `prefetch={false}` directly on the link
- `/r/youtube` and `/r/discord` redirects exist but are **not** rendered via `<Link>` anywhere (the sidebar's YouTube item is already an external `<a>`), so they need no change

## Docs

Adds an `AGENTS.md` note on deploying a branch to staging via the `Deploy Staging` workflow, gated on explicit user request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)