### PR TITLE
Fix landing-page hero header offset (72px)

### DIFF
--- a/app/app/styles/theme/spacing.css
+++ b/app/app/styles/theme/spacing.css
@@ -44,7 +44,7 @@
     --z-index-notification: 1300;
 
     /* Layout tokens */
-    --header-height: 70px;
+    --header-height: 72px;
     --sticky-offset: 24px;
 
     /* Spacing tokens */

--- a/app/components/landing-page/Hero.module.css
+++ b/app/components/landing-page/Hero.module.css
@@ -14,7 +14,7 @@
     background-size: 20px, 100%;
     color: white;
     overflow: hidden;
-    min-height: calc(100vh - 70px);
+    min-height: calc(100vh - var(--header-height));
     display: flex;
     flex-direction: column;
 


### PR DESCRIPTION
The hero used a hardcoded `calc(100vh - 70px)` that never picked up the real 72px header height synced into `--header-height` by `HeaderHeightSync`.

## Changes
- `Hero.module.css`: point the hero `min-height` at `var(--header-height)` so it tracks the real header (including the locale banner), instead of a hardcoded `70px`.
- `spacing.css`: bump the pre-JS `--header-height` fallback from `70px` to `72px` to match the actual header height (`Header.module.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)