### PR TITLE
Deploy Staging: ship the dispatched ref, not a main-defaulting input

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,16 +1,13 @@
 name: Deploy Staging
 
-# Manual-only. Pick the branch/ref to ship to staging.jiki.io.
+# Manual-only. The branch/tag you dispatch from (the "Use workflow from" ref) is
+# what ships to staging.jiki.io — there is deliberately no separate `ref` input,
+# so the branch selector can't disagree with what actually deploys.
 # Staging is a full production build (NODE_ENV=production) that talks to the same
 # API and shares the .jiki.io cookie; it differs from prod only via ENVIRONMENT=staging
 # (set in wrangler.staging.jsonc), which disables indexing and caching.
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch, tag or SHA to deploy to staging"
-        required: true
-        default: "main"
 
 concurrency:
   group: deploy-staging
@@ -24,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref_name }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -91,7 +91,7 @@ This is the frontend for Jiki, a learn-to-code platform.
 
 **Staging**: `staging.jiki.io` (`jiki-app-staging` Worker) must be deployed via the Deploy Staging GitHub Action **before** the Terraform custom-domain apply — the domain can't attach to a Worker service that doesn't exist yet.
 
-**Deploying a branch/PR to staging**: run the `Deploy Staging` workflow (`gh workflow run deploy-staging.yml -f ref=<branch>`), which deploys that ref to `staging.jiki.io`. **Only ever do this if the user explicitly asks** — it publishes real, working code to a live environment against the production API.
+**Deploying a branch/PR to staging**: run the `Deploy Staging` workflow (`gh workflow run deploy-staging.yml --ref <branch>`) — the dispatched ref is what deploys to `staging.jiki.io` (there is no separate `ref` input). **Only ever do this if the user explicitly asks, and treat each run as needing its own fresh explicit request** — it publishes real, working code to a live environment against the production API.
 
 ### Organizational Patterns
 


### PR DESCRIPTION
## Problem

The `Deploy Staging` workflow is `workflow_dispatch` with a `ref` input that **defaults to `main`**. GitHub's dispatch UI (and `gh workflow run --ref`) has a *separate* "Use workflow from" branch selector. Picking a branch there only chooses which workflow file runs — the checkout still uses `inputs.ref`, which stays `main` unless you also type the branch into the input box.

Net effect: selecting a branch and leaving the input at its default **silently deploys `main`** to `staging.jiki.io`.

## Fix

Drop the `ref` input and check out `${{ github.ref_name }}`, so the dispatched ref is always exactly what deploys. The branch selector becomes the single source of truth.

- Dispatch is now simply: `gh workflow run deploy-staging.yml --ref <branch>`
- Updated the `app/AGENTS.md` staging note to match.

Same fix landed on the giki repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)