### PR TITLE
i18n: fire toasts by translation key

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -148,8 +148,9 @@ Top-level namespaces in `messages/en.json` (and `hu.json`, which is structurally
 `common`, `layout`, `auth`, `settings`, `toasts`, `premium`, `roadmap`, `landing`, `seo`, `modals`,
 `misc`, `concepts`, `build`, `codingExercise`, `lesson`, `quizCard`, `videoExercise`, `challenge`,
 `challenges`, `dashboard`, `projects`, `guides`, `unsubscribe`, `achievements`. `seo.*` backs page
-`generateMetadata` (titles/descriptions); `toasts.*` covers the component/hook-reachable toast
-messages; `challenge` is the single-challenge screen while `challenges` is the listing pages;
+`generateMetadata` (titles/descriptions); `toasts.*` covers toast messages, fired by key via the
+`lib/toast.tsx` helpers from any context (components, stores, plain classes); `challenge` is the
+single-challenge screen while `challenges` is the listing pages;
 `unsubscribe` is the preference-management UI while `auth.unsubscribe` is the one-click token flow.
 
 ### Never localized (by design)
@@ -162,16 +163,16 @@ messages; `challenge` is the single-challenge screen while `challenges` is the l
 These render English regardless of locale and are intentionally out of the chrome sweep:
 
 - **Plain-`.ts` strings with no hook/await context**: `lib/pricing.ts` (`PRICING_TIERS` names,
-  descriptions, feature lists — consumed across many components), `lib/subscriptions/handlers.ts`
-  and `components/settings/subscription/handlers.ts` (toast strings in plain async functions),
-  `lib/settings/settingsStore.ts` (Zustand store toasts),
-  `components/coding-exercise/lib/orchestrator/TestSuiteManager.ts` (class),
+  descriptions, feature lists — consumed across many components),
   `components/coding-exercise/lib/chatUsage.ts` (usage-limit sentences),
   `lib/notifications/config.ts` (`NOTIFICATION_TYPES` titles/descriptions),
   `components/guides/GuideDetailPage.tsx` `getGuideMetadata` ("Guide Not Found" — sync `Metadata`
   helper; needs to become async for `getTranslations`), and the "Unknown error" fallback in
   `components/coding-exercise/hooks/useExerciseLoader.tsx`. Localizing these needs the pass-in
   pattern (translate at the call site and pass the string down) or a follow-up.
+  Toasts fired from these plain contexts are already localized via the keyed
+  `lib/toast.tsx` helpers (`toastError`/`toastSuccess`/…), which resolve the copy
+  when the toast paints inside the provider — see `.context/toasts.md`.
 - **`app/global-error.tsx`** — replaces the entire HTML tree (no `NextIntlClientProvider` in scope),
   so it keeps hardcoded English.
 - **Content** (out of scope by design): blog/article/concept bodies, exercise/curriculum text,

--- a/app/.context/toasts.md
+++ b/app/.context/toasts.md
@@ -20,18 +20,67 @@ Configuration:
 
 ## Usage
 
-### Basic Toast Types
+### Fire toasts by translation key (default)
+
+User-facing toasts are localized. Fire them with the keyed helpers in
+`lib/toast.tsx` instead of passing a hardcoded string to react-hot-toast:
+
+```typescript
+import { toastError, toastSuccess, toastMessage, toastLoading } from "@/lib/toast";
+
+toastSuccess("subscription.reactivated");
+toastError("settings.updateFailed");
+toastLoading("logout.loading");
+
+// ICU interpolation — pass values as the second argument:
+toastSuccess("subscription.canceled", { date: new Date().toLocaleDateString() });
+
+// react-hot-toast options (e.g. dedup id, duration) go in the third argument:
+toastError("exercise.submissionFailed", undefined, { id: "exercise-submission-error" });
+```
+
+Keys live under the `toasts` namespace in `messages/{locale}.json`, grouped by
+area (`subscription.*`, `settings.*`, `avatar.*`, `logout.*`, `auth.*`,
+`exercise.*`). The `ToastKey` type is derived from that namespace, so
+`pnpm typecheck` rejects an unknown key.
+
+**How it works:** each helper hands react-hot-toast a small `<ToastMessage>`
+element that runs `useTranslations("toasts")` and renders the resolved copy when
+the toast paints. Because `<Toaster>` is mounted inside the
+`NextIntlClientProvider` (via `ClientLocaleProvider`) in the root layout, this
+resolves against the active locale — so the helpers work from **anywhere**,
+including Zustand stores and plain classes with no hook or locale in scope
+(e.g. `settingsStore`, `TestSuiteManager`).
+
+For rich content (a link inside the message), render a small component that
+calls `t.rich(...)` and pass its element to `toast.error`; see
+`lib/toasts/lessonSaveError.tsx`.
+
+### Dynamic server messages
+
+API error toasts show the server-provided `error.message` when present (it is
+dynamic and not translatable client-side) and fall back to a translated key
+otherwise:
+
+```typescript
+if (error instanceof Error) {
+  toast.error(error.message);
+} else {
+  toastError("settings.updateFailed");
+}
+```
+
+### Raw react-hot-toast (dev-only / non-localized)
+
+Dev-only tooling (e.g. the Stripe-history handlers) and the `/dev` and `/test`
+routes may still call react-hot-toast directly with hardcoded strings, since
+they are never shown to students:
 
 ```typescript
 import toast from "react-hot-toast";
 
-// Standard notification
 toast("Message");
-
-// Success notification
 toast.success("Operation completed");
-
-// Error notification
 toast.error("Something went wrong");
 
 // Loading state

--- a/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
+++ b/app/components/coding-exercise/lib/orchestrator/TestSuiteManager.ts
@@ -1,7 +1,7 @@
 import { ApiError, AuthenticationError, NetworkError, RateLimitError } from "@/lib/api/client";
 import type { ExerciseDefinition, Messages as CurriculumMessages } from "@jiki/curriculum";
 import type { Messages as InterpreterMessages, SyntaxError } from "@jiki/interpreters";
-import toast from "react-hot-toast";
+import { toastError } from "@/lib/toast";
 import type { StoreApi } from "zustand/vanilla";
 import { ERROR_HIGHLIGHT_COLOR } from "../../ui/codemirror/extensions/lineHighlighter";
 import { processMessageContent } from "../../ui/messageUtils";
@@ -94,7 +94,7 @@ export class TestSuiteManager {
       }
       if (error instanceof ApiError) {
         console.warn("Failed to submit exercise:", error);
-        toast.error("Couldn't save your submission. Please try again.", { id: "exercise-submission-error" });
+        toastError("exercise.submissionFailed", undefined, { id: "exercise-submission-error" });
         return;
       }
       console.warn("Failed to submit exercise:", error);

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from "react";
-import toast from "react-hot-toast";
+import { toastError } from "@/lib/toast";
 import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { useTurnstile } from "@/lib/turnstile/useTurnstile";
 import { useChatState } from "./useChatState";
@@ -92,11 +92,13 @@ export function useChat(orchestrator: Orchestrator) {
                 chatState.setSignature(signature);
                 saveConversation(context.context, message, fullResponse, signature).catch((error: unknown) => {
                   console.error("Failed to save conversation:", error);
-                  const toastMessage =
+                  toastError(
                     error instanceof ConversationSaveCaptchaError
-                      ? "Verification failed while saving. This message won't be here when you come back."
-                      : "Couldn't save this message. It won't be here when you come back.";
-                  toast.error(toastMessage, { duration: 8000 });
+                      ? "exercise.chatSaveCaptchaFailed"
+                      : "exercise.chatSaveFailed",
+                    undefined,
+                    { duration: 8000 }
+                  );
                 });
               }
 

--- a/app/components/settings/lib/useLogoutActions.ts
+++ b/app/components/settings/lib/useLogoutActions.ts
@@ -1,12 +1,11 @@
 import { useAuthStore } from "@/lib/auth/authStore";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
-import { useTranslations } from "next-intl";
+import { toastError, toastLoading, toastSuccess } from "@/lib/toast";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
 
 export function useLogoutActions() {
-  const t = useTranslations("toasts.logout");
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const { logout: logoutFromStore } = useAuthStore();
   const router = useRouter();
@@ -18,15 +17,15 @@ export function useLogoutActions() {
     }
 
     setIsLoggingOut(true);
-    toast.loading(t("loading"));
+    toastLoading("logout.loading");
 
     const result = await logoutFromStore();
     toast.dismiss();
     if (result.success) {
-      toast.success(t("success"));
+      toastSuccess("logout.success");
       router.push(routes.authLogin());
     } else {
-      toast.error(t("failed"));
+      toastError("logout.failed");
     }
     setIsLoggingOut(false);
   };

--- a/app/components/settings/modals/AvatarEditModal.tsx
+++ b/app/components/settings/modals/AvatarEditModal.tsx
@@ -10,7 +10,7 @@ import { getCroppedImage } from "@/lib/utils/cropImage";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { ApiError } from "@/lib/api/client";
 import { useTranslations } from "next-intl";
-import toast from "react-hot-toast";
+import { toastError, toastSuccess } from "@/lib/toast";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import UploadIcon from "@/icons/upload.svg";
 import ZoomOutIcon from "@/icons/zoom-out.svg";
@@ -22,7 +22,6 @@ const MIN_ZOOM = 0.9;
 const MAX_ZOOM = 3;
 
 export function AvatarEditModal() {
-  const t = useTranslations("toasts.avatar");
   const ts = useTranslations("settings.avatarEdit");
   const tCommon = useTranslations("common");
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -59,7 +58,7 @@ export function AvatarEditModal() {
     }
     const validationError = validateImageFile(file);
     if (validationError) {
-      toast.error(validationError);
+      toastError(validationError);
       return;
     }
     setImageSrc(URL.createObjectURL(file));
@@ -78,10 +77,10 @@ export function AvatarEditModal() {
       if (user) {
         setUser({ ...user, avatar_url: url });
       }
-      toast.success(t("updated"));
+      toastSuccess("avatar.updated");
       hideModal();
     } catch (err) {
-      toast.error(err instanceof ApiError ? t("uploadFailed") : t("networkError"));
+      toastError(err instanceof ApiError ? "avatar.uploadFailed" : "avatar.networkError");
       setIsSaving(false);
     }
   };

--- a/app/components/settings/subscription/useSubscription.ts
+++ b/app/components/settings/subscription/useSubscription.ts
@@ -1,8 +1,7 @@
 import { useState } from "react";
-import { useTranslations } from "next-intl";
 import { showModal } from "@/lib/modal";
 import { PRICING_TIERS } from "@/lib/pricing";
-import toast from "react-hot-toast";
+import { toastError } from "@/lib/toast";
 import { getSubscriptionState } from "./utils";
 import * as handlers from "./handlers";
 import type { User, SubscriptionData } from "./types";
@@ -13,7 +12,6 @@ interface UseSubscriptionProps {
 }
 
 export function useSubscription({ user, refreshUser }: UseSubscriptionProps) {
-  const tToast = useTranslations("toasts.subscription");
   const [isLoading, setIsLoading] = useState(false);
 
   // Get subscription state and data
@@ -78,7 +76,7 @@ export function useSubscription({ user, refreshUser }: UseSubscriptionProps) {
         });
       } else {
         // Already on premium - this shouldn't happen if UI is correct
-        toast.error(tToast("alreadyPremium"));
+        toastError("subscription.alreadyPremium");
       }
     });
 

--- a/app/lib/auth/useAuth.tsx
+++ b/app/lib/auth/useAuth.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
-import toast from "react-hot-toast";
+import { toastError } from "@/lib/toast";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { storeReturnTo, getPostAuthRedirect } from "@/lib/auth/return-to";
 import type { LoginResponse } from "@/types/auth";
@@ -21,7 +20,6 @@ interface UseAuthReturn {
 }
 
 export function useAuth(): UseAuthReturn {
-  const tToast = useTranslations("toasts.auth");
   const router = useRouter();
   const searchParams = useSearchParams();
   const { googleLogin } = useAuthStore();
@@ -82,7 +80,7 @@ export function useAuth(): UseAuthReturn {
 
   const handleSessionExpired = () => {
     setTwoFactorState({ type: "none" });
-    toast.error(tToast("sessionExpired"));
+    toastError("auth.sessionExpired");
   };
 
   let TwoFactorForm: React.ReactNode | null = null;

--- a/app/lib/modal/modals/PremiumUpgradeModal/useUpgradeFlow.ts
+++ b/app/lib/modal/modals/PremiumUpgradeModal/useUpgradeFlow.ts
@@ -1,7 +1,6 @@
 import { useAuthStore } from "@/lib/auth/authStore";
 import { handleSubscribe } from "@/lib/subscriptions/handlers";
-import { useTranslations } from "next-intl";
-import toast from "react-hot-toast";
+import { toastError } from "@/lib/toast";
 
 interface UseUpgradeFlowProps {
   setIsLoading: (loading: boolean) => void;
@@ -10,12 +9,11 @@ interface UseUpgradeFlowProps {
 }
 
 export function useUpgradeFlow({ setIsLoading, onSuccess: _onSuccess, onCancel: _onCancel }: UseUpgradeFlowProps) {
-  const t = useTranslations("toasts.subscription");
   const user = useAuthStore((state: any) => state.user);
 
   const handleUpgrade = async () => {
     if (!user) {
-      toast.error(t("loginRequired"));
+      toastError("subscription.loginRequired");
       return;
     }
 
@@ -30,7 +28,7 @@ export function useUpgradeFlow({ setIsLoading, onSuccess: _onSuccess, onCancel: 
       });
     } catch (error) {
       console.error("Subscription error:", error);
-      toast.error(t("checkoutFailed"));
+      toastError("subscription.checkoutFailed");
       setIsLoading(false);
     }
   };

--- a/app/lib/modal/modals/SubscriptionModal.tsx
+++ b/app/lib/modal/modals/SubscriptionModal.tsx
@@ -8,7 +8,7 @@ import { PRICING_TIERS } from "@/lib/pricing";
 import { PremiumPrice } from "@/components/common/PremiumPrice";
 import SubscriptionButton from "@/components/settings/ui/SubscriptionButton";
 import { useTranslations } from "next-intl";
-import toast from "react-hot-toast";
+import { toastError } from "@/lib/toast";
 
 interface SubscriptionModalProps {
   // Entry context for analytics and flow optimization
@@ -41,7 +41,6 @@ export function SubscriptionModal({
 }: SubscriptionModalProps) {
   const t = useTranslations("modals.subscription");
   const tCommon = useTranslations("common");
-  const tToast = useTranslations("toasts.subscription");
   const [isLoading, setIsLoading] = useState(false);
   const user = useAuthStore((state: any) => state.user);
 
@@ -82,7 +81,7 @@ export function SubscriptionModal({
 
   const handleTierSelection = async () => {
     if (!user) {
-      toast.error(tToast("loginRequired"));
+      toastError("subscription.loginRequired");
       return;
     }
 
@@ -99,7 +98,7 @@ export function SubscriptionModal({
       });
     } catch (error) {
       console.error("Subscription error:", error);
-      toast.error(tToast("checkoutFailed"));
+      toastError("subscription.checkoutFailed");
     } finally {
       setIsLoading(false);
     }

--- a/app/lib/settings/settingsStore.ts
+++ b/app/lib/settings/settingsStore.ts
@@ -11,6 +11,7 @@ import { setLocaleCookie } from "@/lib/i18n/localeCookie";
 import type { UserSettings, UpdateSettingParams, UpdateNotificationParams } from "@/lib/api/types/settings";
 import { notificationField } from "@/lib/notifications/config";
 import toast from "react-hot-toast";
+import { toastError, toastSuccess } from "@/lib/toast";
 
 interface SettingsState {
   settings: UserSettings | null;
@@ -49,7 +50,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     } catch (error) {
       const errorObj = error instanceof Error ? error : new Error("Failed to fetch settings");
       set({ error: errorObj, loading: false });
-      toast.error(errorObj.message);
+      // Surface the server-provided message when we have one (it's dynamic and
+      // not translatable client-side); otherwise show a translated fallback.
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toastError("settings.fetchFailed");
+      }
     }
   },
 
@@ -89,24 +96,19 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       const updatedSettings = await settingsApi.updateSetting(params);
       set({ settings: updatedSettings });
 
-      // Show success message
-      const fieldLabels: Record<string, string> = {
-        name: "Name",
-        email: "Email",
-        password: "Password",
-        locale: "Language preference",
-        handle: "Handle"
-      };
-
-      toast.success(`${fieldLabels[params.field] || params.field} updated successfully`);
+      // The field label is translated in the catalog via an ICU select.
+      toastSuccess("settings.settingUpdated", { field: params.field });
     } catch (error) {
       // Rollback optimistic update on error
       if (!requiresSudo) {
         set({ settings: currentSettings });
       }
 
-      const errorMessage = error instanceof Error ? error.message : "Update failed";
-      toast.error(errorMessage);
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toastError("settings.updateFailed");
+      }
       throw error; // Re-throw for component-level handling
     }
   },
@@ -156,8 +158,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       // Rollback on error
       set({ settings: currentSettings });
 
-      const errorMessage = error instanceof Error ? error.message : "Failed to update notification preference";
-      toast.error(errorMessage);
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toastError("settings.notificationUpdateFailed");
+      }
       throw error;
     }
   },
@@ -184,8 +189,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       // Rollback on error
       set({ settings: currentSettings });
 
-      const errorMessage = error instanceof Error ? error.message : "Failed to update streaks setting";
-      toast.error(errorMessage);
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toastError("settings.streaksUpdateFailed");
+      }
       throw error;
     }
   },

--- a/app/lib/subscriptions/handlers.ts
+++ b/app/lib/subscriptions/handlers.ts
@@ -15,6 +15,7 @@ import { getApiUrl } from "@/lib/api/config";
 import { hideModal } from "@/lib/modal";
 import { showSubscriptionCheckout } from "@/lib/modal/app";
 import toast from "react-hot-toast";
+import { toastError, toastSuccess } from "@/lib/toast";
 
 // Types for handler functions
 export interface SubscribeParams {
@@ -58,7 +59,7 @@ export async function handleSubscribe({ interval, userEmail, returnPath, priorEr
       }
     });
   } catch (error) {
-    toast.error("Failed to create checkout session");
+    toastError("subscription.checkoutSessionFailed");
     console.error(error);
     throw error; // Re-throw so caller can handle loading state
   }
@@ -69,7 +70,7 @@ export async function handleOpenPortal() {
     const response = await createPortalSession();
     window.location.href = response.url;
   } catch (error) {
-    toast.error("Failed to open customer portal");
+    toastError("subscription.portalFailed");
     console.error(error);
   }
 }
@@ -77,13 +78,15 @@ export async function handleOpenPortal() {
 export async function handleCancelSubscription(refreshUser: RefreshUserFn) {
   try {
     const response = await cancelSubscription();
-    toast.success(
-      `Subscription canceled. You'll keep access until ${new Date(response.cancels_at).toLocaleDateString()}`
-    );
+    toastSuccess("subscription.canceled", { date: new Date(response.cancels_at).toLocaleDateString() });
     await refreshUser();
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Failed to cancel subscription";
-    toast.error(errorMessage);
+    // Show the server message when present (dynamic); else a translated fallback.
+    if (error instanceof Error) {
+      toast.error(error.message);
+    } else {
+      toastError("subscription.cancelFailed");
+    }
     console.error(error);
   }
 }
@@ -91,11 +94,14 @@ export async function handleCancelSubscription(refreshUser: RefreshUserFn) {
 export async function handleReactivateSubscription(refreshUser: RefreshUserFn) {
   try {
     await reactivateSubscription();
-    toast.success("Subscription reactivated!");
+    toastSuccess("subscription.reactivated");
     await refreshUser();
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Failed to reactivate subscription";
-    toast.error(errorMessage);
+    if (error instanceof Error) {
+      toast.error(error.message);
+    } else {
+      toastError("subscription.reactivateFailed");
+    }
     console.error(error);
   }
 }
@@ -107,8 +113,11 @@ export async function handleRetryPayment(_refreshUser: RefreshUserFn) {
     // Note: We don't call refreshUser here since user will be redirected
     // The page will refresh when they return from the portal
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Failed to open payment portal";
-    toast.error(errorMessage);
+    if (error instanceof Error) {
+      toast.error(error.message);
+    } else {
+      toastError("subscription.paymentPortalFailed");
+    }
     console.error(error);
   }
 }

--- a/app/lib/toast.tsx
+++ b/app/lib/toast.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Keyed toast helpers.
+ *
+ * Fire toasts by translation key instead of a hardcoded string. Each helper
+ * hands react-hot-toast a small `<ToastMessage>` element; that element runs
+ * `useTranslations("toasts")` and renders the resolved copy. This works from
+ * anywhere — components, hooks, Zustand stores, plain classes — because the
+ * element only resolves its text when react-hot-toast renders it inside the
+ * `<Toaster>`, which is mounted within the `NextIntlClientProvider` in the root
+ * layout. Callers never need a hook or the current locale.
+ *
+ * Keys live under the `toasts` namespace in `messages/{locale}.json`. The
+ * `ToastKey` type is derived from that namespace, so `pnpm typecheck` rejects
+ * unknown keys.
+ */
+
+import { useTranslations } from "next-intl";
+import toast, { type ToastOptions } from "react-hot-toast";
+
+// Valid dotted keys of the `toasts` namespace, sourced from next-intl's own
+// translator typing (which is generated from messages/en.json via global.d.ts).
+export type ToastKey = Parameters<ReturnType<typeof useTranslations<"toasts">>>[0];
+export type ToastValues = Record<string, string | number>;
+
+function ToastMessage({ id, values }: { id: ToastKey; values?: ToastValues }) {
+  const t = useTranslations("toasts");
+  return <>{t(id, values)}</>;
+}
+
+export function toastError(id: ToastKey, values?: ToastValues, options?: ToastOptions) {
+  return toast.error(<ToastMessage id={id} values={values} />, options);
+}
+
+export function toastSuccess(id: ToastKey, values?: ToastValues, options?: ToastOptions) {
+  return toast.success(<ToastMessage id={id} values={values} />, options);
+}
+
+export function toastMessage(id: ToastKey, values?: ToastValues, options?: ToastOptions) {
+  return toast(<ToastMessage id={id} values={values} />, options);
+}
+
+export function toastLoading(id: ToastKey, values?: ToastValues, options?: ToastOptions) {
+  return toast.loading(<ToastMessage id={id} values={values} />, options);
+}

--- a/app/lib/toasts/lessonSaveError.tsx
+++ b/app/lib/toasts/lessonSaveError.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import toast from "react-hot-toast";
 
 const FORUM_URL = "https://forum.jiki.io";
@@ -8,17 +9,25 @@ const FORUM_URL = "https://forum.jiki.io";
  * persistent failure gets reported rather than silently swallowed.
  */
 export function showLessonSaveErrorToast() {
-  toast.error(
+  toast.error(<LessonSaveErrorMessage />);
+}
+
+function LessonSaveErrorMessage() {
+  const t = useTranslations("toasts");
+  return (
     <span>
-      Sorry, the lesson could not be completed. Please try again. If this continues, please report on{" "}
-      <a
-        href={FORUM_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ fontWeight: 500, textDecoration: "underline", textUnderlineOffset: "1px" }}
-      >
-        {FORUM_URL}
-      </a>
+      {t.rich("exercise.lessonSaveError", {
+        link: (chunks) => (
+          <a
+            href={FORUM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontWeight: 500, textDecoration: "underline", textUnderlineOffset: "1px" }}
+          >
+            {chunks}
+          </a>
+        )
+      })}
     </span>
   );
 }

--- a/app/lib/utils/validateImageFile.ts
+++ b/app/lib/utils/validateImageFile.ts
@@ -1,12 +1,16 @@
 const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
-export function validateImageFile(file: File): string | null {
+/**
+ * Validate an uploaded image file. Returns a `toasts` translation key describing
+ * the problem (for a keyed error toast), or null when the file is acceptable.
+ */
+export function validateImageFile(file: File): "avatar.invalidImageType" | "avatar.imageTooLarge" | null {
   if (!ACCEPTED_TYPES.includes(file.type)) {
-    return "Please select a JPEG, PNG, GIF, or WebP image";
+    return "avatar.invalidImageType";
   }
   if (file.size > MAX_FILE_SIZE) {
-    return "Image must be less than 5MB";
+    return "avatar.imageTooLarge";
   }
   return null;
 }

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1083,7 +1083,14 @@
     "subscription": {
       "loginRequired": "Please log in to upgrade your account",
       "checkoutFailed": "Failed to start checkout process. Please try again.",
-      "alreadyPremium": "Already on Premium tier"
+      "alreadyPremium": "Already on Premium tier",
+      "checkoutSessionFailed": "Failed to create checkout session",
+      "portalFailed": "Failed to open customer portal",
+      "canceled": "Subscription canceled. You'll keep access until {date}",
+      "cancelFailed": "Failed to cancel subscription",
+      "reactivated": "Subscription reactivated!",
+      "reactivateFailed": "Failed to reactivate subscription",
+      "paymentPortalFailed": "Failed to open payment portal"
     },
     "auth": {
       "sessionExpired": "Your session has expired. Please sign in again."
@@ -1096,7 +1103,22 @@
     "avatar": {
       "updated": "Avatar updated",
       "uploadFailed": "Failed to upload avatar",
-      "networkError": "Network error. Please try again."
+      "networkError": "Network error. Please try again.",
+      "invalidImageType": "Please select a JPEG, PNG, GIF, or WebP image",
+      "imageTooLarge": "Image must be less than 5MB"
+    },
+    "settings": {
+      "fetchFailed": "Failed to fetch settings",
+      "settingUpdated": "{field, select, name {Name} email {Email} password {Password} locale {Language preference} handle {Handle} other {{field}}} updated successfully",
+      "updateFailed": "Update failed",
+      "notificationUpdateFailed": "Failed to update notification preference",
+      "streaksUpdateFailed": "Failed to update streaks setting"
+    },
+    "exercise": {
+      "submissionFailed": "Couldn't save your submission. Please try again.",
+      "chatSaveFailed": "Couldn't save this message. It won't be here when you come back.",
+      "chatSaveCaptchaFailed": "Verification failed while saving. This message won't be here when you come back.",
+      "lessonSaveError": "Sorry, the lesson could not be completed. Please try again. If this continues, please report on <link>https://forum.jiki.io</link>"
     }
   },
   "modals": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1083,7 +1083,14 @@
     "subscription": {
       "loginRequired": "Please log in to upgrade your account",
       "checkoutFailed": "Failed to start checkout process. Please try again.",
-      "alreadyPremium": "Already on Premium tier"
+      "alreadyPremium": "Already on Premium tier",
+      "checkoutSessionFailed": "Failed to create checkout session",
+      "portalFailed": "Failed to open customer portal",
+      "canceled": "Subscription canceled. You'll keep access until {date}",
+      "cancelFailed": "Failed to cancel subscription",
+      "reactivated": "Subscription reactivated!",
+      "reactivateFailed": "Failed to reactivate subscription",
+      "paymentPortalFailed": "Failed to open payment portal"
     },
     "auth": {
       "sessionExpired": "Your session has expired. Please sign in again."
@@ -1096,7 +1103,22 @@
     "avatar": {
       "updated": "Avatar updated",
       "uploadFailed": "Failed to upload avatar",
-      "networkError": "Network error. Please try again."
+      "networkError": "Network error. Please try again.",
+      "invalidImageType": "Please select a JPEG, PNG, GIF, or WebP image",
+      "imageTooLarge": "Image must be less than 5MB"
+    },
+    "settings": {
+      "fetchFailed": "Failed to fetch settings",
+      "settingUpdated": "{field, select, name {Name} email {Email} password {Password} locale {Language preference} handle {Handle} other {{field}}} updated successfully",
+      "updateFailed": "Update failed",
+      "notificationUpdateFailed": "Failed to update notification preference",
+      "streaksUpdateFailed": "Failed to update streaks setting"
+    },
+    "exercise": {
+      "submissionFailed": "Couldn't save your submission. Please try again.",
+      "chatSaveFailed": "Couldn't save this message. It won't be here when you come back.",
+      "chatSaveCaptchaFailed": "Verification failed while saving. This message won't be here when you come back.",
+      "lessonSaveError": "Sorry, the lesson could not be completed. Please try again. If this continues, please report on <link>https://forum.jiki.io</link>"
     }
   },
   "modals": {

--- a/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/TestSuiteManager.test.ts
@@ -15,9 +15,8 @@ jest.mock("@/lib/api/challenges", () => ({
   submitChallengeExercise: jest.fn().mockResolvedValue(undefined)
 }));
 
-jest.mock("react-hot-toast", () => ({
-  __esModule: true,
-  default: { error: jest.fn() }
+jest.mock("@/lib/toast", () => ({
+  toastError: jest.fn()
 }));
 
 function flushMicrotasks() {
@@ -133,13 +132,15 @@ describe("TestSuiteManager", () => {
       const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
       (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
 
-      const toast = (await import("react-hot-toast")).default;
+      const { toastError } = await import("@/lib/toast");
 
       await manager.runCode(mockCode, mockExercise);
       await flushMicrotasks();
 
-      expect(toast.error).toHaveBeenCalledTimes(1);
-      expect((toast.error as jest.Mock).mock.calls[0][0]).toMatch(/submission|attempt/i);
+      expect(toastError).toHaveBeenCalledTimes(1);
+      expect(toastError).toHaveBeenCalledWith("exercise.submissionFailed", undefined, {
+        id: "exercise-submission-error"
+      });
     });
 
     it("does not toast on NetworkError (handled globally)", async () => {
@@ -151,18 +152,18 @@ describe("TestSuiteManager", () => {
       const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
       (runTests as jest.Mock).mockReturnValue({ tests: [], passed: true });
 
-      const toast = (await import("react-hot-toast")).default;
+      const { toastError } = await import("@/lib/toast");
 
       await manager.runCode(mockCode, mockExercise);
       await flushMicrotasks();
 
-      expect(toast.error).not.toHaveBeenCalled();
+      expect(toastError).not.toHaveBeenCalled();
     });
 
     it("does not toast on AuthenticationError or RateLimitError (handled globally)", async () => {
       const { submitLessonExercise } = await import("@/lib/api/lessons");
       const { runTests } = await import("@/components/coding-exercise/lib/test-runner/runTests");
-      const toast = (await import("react-hot-toast")).default;
+      const { toastError } = await import("@/lib/toast");
 
       for (const error of [new AuthenticationError("Unauthorized"), new RateLimitError("Too Many Requests", 1)]) {
         const manager = buildManager({ type: "lesson", slug: "solve-a-maze" });
@@ -173,7 +174,7 @@ describe("TestSuiteManager", () => {
         await flushMicrotasks();
       }
 
-      expect(toast.error).not.toHaveBeenCalled();
+      expect(toastError).not.toHaveBeenCalled();
     });
   });
 

--- a/app/tests/unit/components/settings/subscription/handlers.test.ts
+++ b/app/tests/unit/components/settings/subscription/handlers.test.ts
@@ -5,6 +5,7 @@ import * as subscriptionApi from "@/lib/api/subscriptions";
 import * as checkoutUtils from "@/lib/subscriptions/checkout";
 import * as handlers from "@/components/settings/subscription/handlers";
 import { showSubscriptionCheckout } from "@/lib/modal/app";
+import { toastError, toastSuccess } from "@/lib/toast";
 import toast from "react-hot-toast";
 
 // Mock the external dependencies
@@ -12,11 +13,15 @@ jest.mock("@/lib/api/subscriptions");
 jest.mock("@/lib/subscriptions/checkout");
 jest.mock("@/lib/modal");
 jest.mock("@/lib/modal/app");
+jest.mock("@/lib/toast");
 jest.mock("react-hot-toast");
 
 const mockSubscriptionApi = subscriptionApi as jest.Mocked<typeof subscriptionApi>;
 const mockCheckoutUtils = checkoutUtils as jest.Mocked<typeof checkoutUtils>;
 const mockShowSubscriptionCheckout = showSubscriptionCheckout as jest.MockedFunction<typeof showSubscriptionCheckout>;
+const mockToastError = toastError as jest.MockedFunction<typeof toastError>;
+const mockToastSuccess = toastSuccess as jest.MockedFunction<typeof toastSuccess>;
+// Raw react-hot-toast is still used directly for dynamic server error messages.
 const mockToast = toast as jest.Mocked<typeof toast>;
 
 describe("Subscription handlers", () => {
@@ -65,7 +70,7 @@ describe("Subscription handlers", () => {
 
       await expect(handlers.handleSubscribe(mockParams)).rejects.toThrow("Network error");
 
-      expect(mockToast.error).toHaveBeenCalledWith("Failed to create checkout session");
+      expect(mockToastError).toHaveBeenCalledWith("subscription.checkoutSessionFailed");
       expect(console.error).toHaveBeenCalledWith(mockError);
     });
   });
@@ -87,7 +92,7 @@ describe("Subscription handlers", () => {
 
       await handlers.handleOpenPortal();
 
-      expect(mockToast.error).toHaveBeenCalledWith("Failed to open customer portal");
+      expect(mockToastError).toHaveBeenCalledWith("subscription.portalFailed");
       expect(console.error).toHaveBeenCalledWith(mockError);
     });
   });
@@ -104,9 +109,7 @@ describe("Subscription handlers", () => {
       await handlers.handleCancelSubscription(mockRefreshUser);
 
       expect(mockSubscriptionApi.cancelSubscription).toHaveBeenCalled();
-      expect(mockToast.success).toHaveBeenCalledWith(
-        expect.stringContaining("Subscription canceled. You'll keep access until")
-      );
+      expect(mockToastSuccess).toHaveBeenCalledWith("subscription.canceled", { date: expect.any(String) });
       expect(mockRefreshUser).toHaveBeenCalled();
     });
 
@@ -133,7 +136,7 @@ describe("Subscription handlers", () => {
       await handlers.handleReactivateSubscription(mockRefreshUser);
 
       expect(mockSubscriptionApi.reactivateSubscription).toHaveBeenCalled();
-      expect(mockToast.success).toHaveBeenCalledWith("Subscription reactivated!");
+      expect(mockToastSuccess).toHaveBeenCalledWith("subscription.reactivated");
       expect(mockRefreshUser).toHaveBeenCalled();
     });
   });
@@ -158,7 +161,7 @@ describe("Subscription handlers", () => {
 
       await handlers.handleRetryPayment(mockRefreshUser);
 
-      expect(mockToast.error).toHaveBeenCalledWith("Failed to open customer portal");
+      expect(mockToastError).toHaveBeenCalledWith("subscription.portalFailed");
       expect(console.error).toHaveBeenCalledWith(mockError);
     });
   });

--- a/app/tests/unit/lib/toast.test.tsx
+++ b/app/tests/unit/lib/toast.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import toast from "react-hot-toast";
+import { toastError, toastSuccess } from "@/lib/toast";
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: Object.assign(jest.fn(), {
+    error: jest.fn(),
+    success: jest.fn(),
+    loading: jest.fn()
+  })
+}));
+
+describe("keyed toast helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the translated message for a key", () => {
+    toastError("subscription.checkoutSessionFailed");
+    const element = (toast.error as jest.Mock).mock.calls[0][0];
+    const { getByText } = render(element);
+    expect(getByText("Failed to create checkout session")).toBeInTheDocument();
+  });
+
+  it("interpolates ICU values into the message", () => {
+    toastSuccess("subscription.canceled", { date: "1/2/2030" });
+    const element = (toast.success as jest.Mock).mock.calls[0][0];
+    const { getByText } = render(element);
+    expect(getByText(/keep access until 1\/2\/2030/)).toBeInTheDocument();
+  });
+
+  it("forwards toast options such as the dedup id", () => {
+    toastError("exercise.submissionFailed", undefined, { id: "exercise-submission-error" });
+    expect((toast.error as jest.Mock).mock.calls[0][1]).toEqual({ id: "exercise-submission-error" });
+  });
+});


### PR DESCRIPTION
## What

Introduces a thin keyed wrapper over react-hot-toast (`app/lib/toast.tsx`) so user-facing toasts are fired by **translation key** instead of hardcoded English strings.

`toastError` / `toastSuccess` / `toastMessage` / `toastLoading` each hand react-hot-toast a small `<ToastMessage>` element that runs `useTranslations("toasts")` and renders the resolved copy when the toast paints. Because `<Toaster>` is mounted inside the `NextIntlClientProvider` (via `ClientLocaleProvider`) in the root layout, this works from **anywhere** — components, hooks, Zustand stores, and plain classes with no hook or locale in scope (e.g. `settingsStore`, `TestSuiteManager`).

The `ToastKey` type is derived from the `toasts` namespace, so `pnpm typecheck` rejects unknown keys.

## Converted call sites

- `lib/subscriptions/handlers.ts` — checkout/portal/cancel/reactivate/payment toasts
- `lib/settings/settingsStore.ts` — fetch/update/notification/streaks toasts (+ the `{field} updated successfully` message, now an ICU `select`)
- `components/coding-exercise/lib/orchestrator/TestSuiteManager.ts` — submission-failed toast (dedup `id` preserved)
- `components/coding-exercise/lib/useChat.ts` — chat-save failures
- `lib/toasts/lessonSaveError.tsx` — rich message with forum link, via `t.rich`
- `components/settings/modals/AvatarEditModal.tsx` + `lib/utils/validateImageFile.ts` — avatar validation/upload
- `components/settings/lib/useLogoutActions.ts`, `components/settings/subscription/useSubscription.ts`, `lib/auth/useAuth.tsx`, `lib/modal/modals/SubscriptionModal.tsx`, `lib/modal/modals/PremiumUpgradeModal/useUpgradeFlow.ts` — moved from scattered `useTranslations("toasts.*")` + `toast.*` onto the keyed helpers

New keys live under `messages/{en,hu}.json` `toasts.*` (hu = English copy, not machine-translated), grouped by area.

## Deliberately left as-is

- **Dynamic server `error.message`** strings still show through raw `react-hot-toast` (they are not translatable client-side); only the hardcoded fallbacks became keys.
- **Dev-only handlers** (`handleCheckoutCancel`, `handleDeleteStripeHistory`) and the `/dev` / `/test` routes keep hardcoded strings — never shown to students.

## Verification

- `pnpm typecheck` — clean
- Full app jest suite — 2047 passed
- ESLint + Prettier on touched files — clean
- Docs updated: `.context/toasts.md`, `.context/i18n.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)