### PR TITLE
i18n: chat usage copy → ICU messages in ChatUsageNotice

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -165,7 +165,6 @@ These render English regardless of locale and are intentionally out of the chrom
 
 - **Plain-`.ts` strings with no hook/await context**: `lib/pricing.ts` (`PRICING_TIERS` names,
   descriptions, feature lists — consumed across many components),
-  `components/coding-exercise/lib/chatUsage.ts` (usage-limit sentences),
   `lib/notifications/config.ts` (`NOTIFICATION_TYPES` titles/descriptions),
   `components/guides/GuideDetailPage.tsx` `getGuideMetadata` ("Guide Not Found" — sync `Metadata`
   helper; needs to become async for `getTranslations`), and the "Unknown error" fallback in

--- a/app/components/coding-exercise/lib/chatErrorHandler.ts
+++ b/app/components/coding-exercise/lib/chatErrorHandler.ts
@@ -1,27 +1,14 @@
+import type { useTranslations } from "next-intl";
 import { ChatApiError, ChatRateLimitedError, ChatTokenExpiredError, ChatUsageLimitError } from "./chatApi";
 import { ChatTokenError, ChatTokenInvalidCaptchaError } from "./chatTokenApi";
 
-// Message keys relative to the `codingExercise` namespace. The caller (useChat)
-// translates with `useTranslations("codingExercise")`, so next-intl's typed `t`
-// validates every member of this union against the catalog.
-// The usage-limit entries reuse the ChatUsageNotice cap copy — same meaning,
-// same message.
-export type ChatErrorKey =
-  | "chatError.sessionExpired"
-  | "chatError.verificationFailed"
-  | "chatError.authFailed"
-  | "chatError.tokenServerError"
-  | "chatError.tokenInitFailed"
-  | "chatError.exerciseMismatch"
-  | "chatError.authExpired"
-  | "chatError.tooManyRequests"
-  | "chatError.serviceUnavailable"
-  | "chatError.serverError"
-  | "chatError.networkError"
-  | "chatError.timeout"
-  | "chatError.unexpected"
-  | "chatUsageNotice.limitReached.daily"
-  | "chatUsageNotice.limitReached.monthly";
+// Message keys relative to the `codingExercise` namespace, derived from the
+// catalog via next-intl's typing (the ToastKey pattern in lib/toast.tsx) so
+// every `key(...)` call is validated at typecheck — the catalog is the single
+// source of truth. The caller (useChat) translates with
+// `useTranslations("codingExercise")`. The usage-limit branches reuse the
+// ChatUsageNotice cap keys — same meaning, same message.
+export type ChatErrorKey = Parameters<ReturnType<typeof useTranslations<"codingExercise">>>[0];
 
 // The translatable result of classifying a chat error: either a catalog key
 // (plus ICU params) for copy we own, or verbatim text for copy the proxy/server

--- a/app/components/coding-exercise/lib/chatErrorHandler.ts
+++ b/app/components/coding-exercise/lib/chatErrorHandler.ts
@@ -1,48 +1,82 @@
 import { ChatApiError, ChatRateLimitedError, ChatTokenExpiredError, ChatUsageLimitError } from "./chatApi";
 import { ChatTokenError, ChatTokenInvalidCaptchaError } from "./chatTokenApi";
 
-export function formatChatError(error: unknown): string {
+// Message keys relative to the `codingExercise` namespace. The caller (useChat)
+// translates with `useTranslations("codingExercise")`, so next-intl's typed `t`
+// validates every member of this union against the catalog.
+// The usage-limit entries reuse the ChatUsageNotice cap copy — same meaning,
+// same message.
+export type ChatErrorKey =
+  | "chatError.sessionExpired"
+  | "chatError.verificationFailed"
+  | "chatError.authFailed"
+  | "chatError.tokenServerError"
+  | "chatError.tokenInitFailed"
+  | "chatError.exerciseMismatch"
+  | "chatError.authExpired"
+  | "chatError.tooManyRequests"
+  | "chatError.serviceUnavailable"
+  | "chatError.serverError"
+  | "chatError.networkError"
+  | "chatError.timeout"
+  | "chatError.unexpected"
+  | "chatUsageNotice.limitReached.daily"
+  | "chatUsageNotice.limitReached.monthly";
+
+// The translatable result of classifying a chat error: either a catalog key
+// (plus ICU params) for copy we own, or verbatim text for copy the proxy/server
+// provides pre-formatted.
+export type ChatErrorMessage =
+  | { type: "key"; key: ChatErrorKey; params?: Record<string, string | number> }
+  | { type: "text"; text: string };
+
+function key(k: ChatErrorKey, params?: Record<string, string | number>): ChatErrorMessage {
+  return { type: "key", key: k, params };
+}
+
+export function formatChatError(error: unknown): ChatErrorMessage {
   // ChatTokenExpiredError should rarely show (auto-retry handles it)
   if (error instanceof ChatTokenExpiredError) {
-    return "Session expired. Please try again.";
+    return key("chatError.sessionExpired");
   }
 
   // Quota cap — terminal until the daily/monthly reset. Copy is built from the
   // scope and limit since the proxy intentionally omits a human-readable message.
   if (error instanceof ChatUsageLimitError) {
     const limit = error.scope === "monthly" ? error.usage.monthlyLimit : error.usage.dailyLimit;
-    if (error.scope === "monthly") {
-      return `You've used all ${limit} messages this month. They reset on the 1st.`;
-    }
-    return `You've used all ${limit} of today's messages. They reset at midnight UTC.`;
+    return key(
+      error.scope === "monthly" ? "chatUsageNotice.limitReached.monthly" : "chatUsageNotice.limitReached.daily",
+      { limit }
+    );
   }
 
-  // Burst throttle — transient. The proxy provides the user-facing copy.
+  // Burst throttle — transient. The proxy provides the user-facing copy, so it
+  // passes through untranslated.
   if (error instanceof ChatRateLimitedError) {
-    return error.message;
+    return { type: "text", text: error.message };
   }
 
   // Captcha failure — distinct from access-denied so the user is told to
   // retry rather than nudged to upgrade.
   if (error instanceof ChatTokenInvalidCaptchaError) {
-    return "Verification failed. Please try again.";
+    return key("chatError.verificationFailed");
   }
 
   // ChatTokenError - errors fetching the token
   if (error instanceof ChatTokenError) {
     if (error.status === 401) {
-      return "Authentication failed. Please sign in again.";
+      return key("chatError.authFailed");
     }
     if (error.status && error.status >= 500) {
-      return "Server error while initializing chat. Please try again.";
+      return key("chatError.tokenServerError");
     }
-    return "Failed to initialize chat. Please try again.";
+    return key("chatError.tokenInitFailed");
   }
 
   if (error instanceof ChatApiError) {
     if (error.status === 403) {
       // Exercise mismatch - token was for a different exercise
-      return "Exercise mismatch. Please refresh and try again.";
+      return key("chatError.exerciseMismatch");
     }
     if (error.status === 401) {
       // Check specific error type for better user messaging
@@ -50,37 +84,39 @@ export function formatChatError(error: unknown): string {
         const errorData = error.data as { error?: string };
         if (errorData.error === "token_expired") {
           // This is shown after auto-retry has failed
-          return "Session expired. Please try again.";
+          return key("chatError.sessionExpired");
         }
         if (errorData.error === "invalid_token") {
-          return "Authentication failed. Please sign in again.";
+          return key("chatError.authFailed");
         }
       }
-      return "Authentication expired. Please refresh the page.";
+      return key("chatError.authExpired");
     }
     if (error.status === 429) {
-      return "Too many requests. Please wait a moment and try again.";
+      return key("chatError.tooManyRequests");
     }
     if (error.status === 503) {
-      return "Chat service is temporarily unavailable. Please try again later.";
+      return key("chatError.serviceUnavailable");
     }
     if (error.status && error.status >= 500) {
-      return "Server error. Please try again in a few moments.";
+      return key("chatError.serverError");
     }
-    return error.message;
+    // Server-provided message for statuses we don't classify — passes through.
+    return { type: "text", text: error.message };
   }
 
   if (error instanceof Error) {
     if (error.message.includes("Failed to fetch")) {
-      return "Network error. Please check your connection and try again.";
+      return key("chatError.networkError");
     }
     if (error.message.includes("timeout")) {
-      return "Request timed out. Please try again.";
+      return key("chatError.timeout");
     }
-    return error.message;
+    // Unclassified runtime error — relay its own message verbatim.
+    return { type: "text", text: error.message };
   }
 
-  return "An unexpected error occurred. Please try again.";
+  return key("chatError.unexpected");
 }
 
 export function shouldRetryError(error: unknown): boolean {

--- a/app/components/coding-exercise/lib/chatErrorHandler.ts
+++ b/app/components/coding-exercise/lib/chatErrorHandler.ts
@@ -1,6 +1,5 @@
 import { ChatApiError, ChatRateLimitedError, ChatTokenExpiredError, ChatUsageLimitError } from "./chatApi";
 import { ChatTokenError, ChatTokenInvalidCaptchaError } from "./chatTokenApi";
-import { usageLimitText } from "./chatUsage";
 
 export function formatChatError(error: unknown): string {
   // ChatTokenExpiredError should rarely show (auto-retry handles it)
@@ -12,7 +11,10 @@ export function formatChatError(error: unknown): string {
   // scope and limit since the proxy intentionally omits a human-readable message.
   if (error instanceof ChatUsageLimitError) {
     const limit = error.scope === "monthly" ? error.usage.monthlyLimit : error.usage.dailyLimit;
-    return usageLimitText(error.scope, limit);
+    if (error.scope === "monthly") {
+      return `You've used all ${limit} messages this month. They reset on the 1st.`;
+    }
+    return `You've used all ${limit} of today's messages. They reset at midnight UTC.`;
   }
 
   // Burst throttle — transient. The proxy provides the user-facing copy.

--- a/app/components/coding-exercise/lib/chatUsage.ts
+++ b/app/components/coding-exercise/lib/chatUsage.ts
@@ -59,19 +59,3 @@ export function deriveUsageStatus(usage: UsageMeta | null): UsageStatus | null {
 
   return { scope, used, limit, atCap, warning };
 }
-
-// Copy for the soft "getting close" warning shown under the composer.
-export function usageWarningText(status: UsageStatus): string {
-  if (status.scope === "monthly") {
-    return `You're getting close to your monthly limit (${status.used}/${status.limit} messages this month).`;
-  }
-  return `You're getting close to your daily limit (${status.used}/${status.limit} messages today).`;
-}
-
-// Copy for the terminal "you've hit the cap" notice. Reset times are UTC.
-export function usageLimitText(scope: UsageScope, limit: number): string {
-  if (scope === "monthly") {
-    return `You've used all ${limit} messages this month. They reset on the 1st.`;
-  }
-  return `You've used all ${limit} of today's messages. They reset at midnight UTC.`;
-}

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { toastError } from "@/lib/toast";
 import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { useTurnstile } from "@/lib/turnstile/useTurnstile";
@@ -12,6 +13,7 @@ import { extractUsage } from "./chatUsage";
 import type Orchestrator from "./Orchestrator";
 
 export function useChat(orchestrator: Orchestrator) {
+  const t = useTranslations("codingExercise");
   const chatState = useChatState();
   const context = useChatContext(orchestrator);
   const turnstile = useTurnstile();
@@ -154,7 +156,7 @@ export function useChat(orchestrator: Orchestrator) {
         }
 
         if (error instanceof ChatTokenInvalidCaptchaError) {
-          chatState.setError("Verification failed, please try again.");
+          chatState.setError(t("chatError.verificationFailed"));
           chatState.setStatus("error");
           return;
         }
@@ -168,12 +170,14 @@ export function useChat(orchestrator: Orchestrator) {
           return;
         }
 
-        const errorMessage = formatChatError(error);
-        chatState.setError(errorMessage);
+        // Translate keyed messages here (the hook has locale context); proxy/
+        // server-provided copy passes through verbatim.
+        const formatted = formatChatError(error);
+        chatState.setError(formatted.type === "key" ? t(formatted.key, formatted.params) : formatted.text);
         chatState.setStatus("error");
       }
     },
-    [chatState, ensureValidToken, performChatRequest, context.context.type, context.context.slug]
+    [chatState, ensureValidToken, performChatRequest, context.context.type, context.context.slug, t]
   );
 
   const clearConversation = useCallback(() => {

--- a/app/components/coding-exercise/ui/ChatUsageNotice.tsx
+++ b/app/components/coding-exercise/ui/ChatUsageNotice.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import type { UsageStatus } from "../lib/chatUsage";
-import { FAIR_USAGE_ARTICLE_SLUG, usageLimitText, usageWarningText } from "../lib/chatUsage";
+import { FAIR_USAGE_ARTICLE_SLUG } from "../lib/chatUsage";
 import styles from "./ChatUsageNotice.module.css";
 
 interface ChatUsageNoticeProps {
@@ -22,7 +22,13 @@ export default function ChatUsageNotice({ status }: ChatUsageNoticeProps) {
     return null;
   }
 
-  const text = status.atCap ? usageLimitText(status.scope, status.limit) : usageWarningText(status);
+  const text = status.atCap
+    ? status.scope === "monthly"
+      ? t("limitReached.monthly", { limit: status.limit })
+      : t("limitReached.daily", { limit: status.limit })
+    : status.scope === "monthly"
+      ? t("warning.monthly", { used: status.used, limit: status.limit })
+      : t("warning.daily", { used: status.used, limit: status.limit });
 
   return (
     <div className={`${styles.bar} ${status.atCap ? styles.cap : ""}`}>

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1561,6 +1561,14 @@
       "learnMoreFairUse": "Learn more about fair use limits"
     },
     "chatUsageNotice": {
+      "warning": {
+        "daily": "You're getting close to your daily limit ({used}/{limit} messages today).",
+        "monthly": "You're getting close to your monthly limit ({used}/{limit} messages this month)."
+      },
+      "limitReached": {
+        "daily": "You've used all {limit} of today's messages. They reset at midnight UTC.",
+        "monthly": "You've used all {limit} messages this month. They reset on the 1st."
+      },
       "learnMore": "Learn More"
     },
     "stuckHeader": {

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1571,6 +1571,21 @@
       },
       "learnMore": "Learn More"
     },
+    "chatError": {
+      "sessionExpired": "Session expired. Please try again.",
+      "verificationFailed": "Verification failed. Please try again.",
+      "authFailed": "Authentication failed. Please sign in again.",
+      "tokenServerError": "Server error while initializing chat. Please try again.",
+      "tokenInitFailed": "Failed to initialize chat. Please try again.",
+      "exerciseMismatch": "Exercise mismatch. Please refresh and try again.",
+      "authExpired": "Authentication expired. Please refresh the page.",
+      "tooManyRequests": "Too many requests. Please wait a moment and try again.",
+      "serviceUnavailable": "Chat service is temporarily unavailable. Please try again later.",
+      "serverError": "Server error. Please try again in a few moments.",
+      "networkError": "Network error. Please check your connection and try again.",
+      "timeout": "Request timed out. Please try again.",
+      "unexpected": "An unexpected error occurred. Please try again."
+    },
     "stuckHeader": {
       "title": "Feeling Stuck? Ask Jiki!"
     },

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1561,6 +1561,14 @@
       "learnMoreFairUse": "Learn more about fair use limits"
     },
     "chatUsageNotice": {
+      "warning": {
+        "daily": "You're getting close to your daily limit ({used}/{limit} messages today).",
+        "monthly": "You're getting close to your monthly limit ({used}/{limit} messages this month)."
+      },
+      "limitReached": {
+        "daily": "You've used all {limit} of today's messages. They reset at midnight UTC.",
+        "monthly": "You've used all {limit} messages this month. They reset on the 1st."
+      },
       "learnMore": "Learn More"
     },
     "stuckHeader": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1571,6 +1571,21 @@
       },
       "learnMore": "Learn More"
     },
+    "chatError": {
+      "sessionExpired": "Session expired. Please try again.",
+      "verificationFailed": "Verification failed. Please try again.",
+      "authFailed": "Authentication failed. Please sign in again.",
+      "tokenServerError": "Server error while initializing chat. Please try again.",
+      "tokenInitFailed": "Failed to initialize chat. Please try again.",
+      "exerciseMismatch": "Exercise mismatch. Please refresh and try again.",
+      "authExpired": "Authentication expired. Please refresh the page.",
+      "tooManyRequests": "Too many requests. Please wait a moment and try again.",
+      "serviceUnavailable": "Chat service is temporarily unavailable. Please try again later.",
+      "serverError": "Server error. Please try again in a few moments.",
+      "networkError": "Network error. Please check your connection and try again.",
+      "timeout": "Request timed out. Please try again.",
+      "unexpected": "An unexpected error occurred. Please try again."
+    },
     "stuckHeader": {
       "title": "Feeling Stuck? Ask Jiki!"
     },

--- a/app/tests/unit/components/coding-exercise/ChatUsageNotice.test.tsx
+++ b/app/tests/unit/components/coding-exercise/ChatUsageNotice.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import ChatUsageNotice from "@/components/coding-exercise/ui/ChatUsageNotice";
+import type { UsageStatus } from "@/components/coding-exercise/lib/chatUsage";
+
+function status(overrides: Partial<UsageStatus>): UsageStatus {
+  return { scope: "daily", used: 0, limit: 100, atCap: false, warning: false, ...overrides };
+}
+
+describe("ChatUsageNotice", () => {
+  it("renders nothing when status is null", () => {
+    const { container } = render(<ChatUsageNotice status={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when neither warning nor atCap is set", () => {
+    const { container } = render(<ChatUsageNotice status={status({})} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the daily warning copy", () => {
+    render(<ChatUsageNotice status={status({ scope: "daily", used: 90, limit: 100, warning: true })} />);
+    expect(screen.getByText("You're getting close to your daily limit (90/100 messages today).")).toBeInTheDocument();
+  });
+
+  it("renders the monthly warning copy", () => {
+    render(<ChatUsageNotice status={status({ scope: "monthly", used: 450, limit: 500, warning: true })} />);
+    expect(
+      screen.getByText("You're getting close to your monthly limit (450/500 messages this month).")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the daily limit-reached copy", () => {
+    render(<ChatUsageNotice status={status({ scope: "daily", used: 100, limit: 100, atCap: true })} />);
+    expect(
+      screen.getByText("You've used all 100 of today's messages. They reset at midnight UTC.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the monthly limit-reached copy", () => {
+    render(<ChatUsageNotice status={status({ scope: "monthly", used: 500, limit: 500, atCap: true })} />);
+    expect(screen.getByText("You've used all 500 messages this month. They reset on the 1st.")).toBeInTheDocument();
+  });
+
+  it("links to the fair-usage article", () => {
+    render(<ChatUsageNotice status={status({ scope: "daily", used: 90, limit: 100, warning: true })} />);
+    const link = screen.getByRole("link", { name: "Learn More" });
+    expect(link).toHaveAttribute("href", "/help/fair-usage-jiki-ai-policy");
+  });
+});

--- a/app/tests/unit/components/coding-exercise/chatErrorHandler.test.ts
+++ b/app/tests/unit/components/coding-exercise/chatErrorHandler.test.ts
@@ -5,49 +5,74 @@ const usage = { messagesToday: 100, messagesThisMonth: 480, dailyLimit: 100, mon
 
 describe("chatErrorHandler", () => {
   describe("formatChatError", () => {
-    it("formats generic auth errors", () => {
+    it("keys generic auth errors", () => {
       const error = new ChatApiError("Unauthorized", 401);
-      expect(formatChatError(error)).toBe("Authentication expired. Please refresh the page.");
+      expect(formatChatError(error)).toEqual({ type: "key", key: "chatError.authExpired", params: undefined });
     });
 
-    it("formats token expired errors (shown after auto-retry fails)", () => {
+    it("keys token expired errors (shown after auto-retry fails)", () => {
       const error = new ChatApiError("Token expired", 401, { error: "token_expired", message: "Token has expired" });
-      expect(formatChatError(error)).toBe("Session expired. Please try again.");
+      expect(formatChatError(error)).toEqual({ type: "key", key: "chatError.sessionExpired", params: undefined });
     });
 
-    it("formats exercise mismatch errors", () => {
+    it("keys exercise mismatch errors", () => {
       const error = new ChatApiError("Forbidden", 403, { error: "exercise_mismatch" });
-      expect(formatChatError(error)).toBe("Exercise mismatch. Please refresh and try again.");
+      expect(formatChatError(error)).toEqual({ type: "key", key: "chatError.exerciseMismatch", params: undefined });
     });
 
-    it("formats invalid token errors", () => {
+    it("keys invalid token errors", () => {
       const error = new ChatApiError("Invalid token", 401, { error: "invalid_token", message: "Invalid token" });
-      expect(formatChatError(error)).toBe("Authentication failed. Please sign in again.");
+      expect(formatChatError(error)).toEqual({ type: "key", key: "chatError.authFailed", params: undefined });
     });
 
-    it("formats rate limit errors", () => {
+    it("keys rate limit errors", () => {
       const error = new ChatApiError("Too Many Requests", 429);
-      expect(formatChatError(error)).toBe("Too many requests. Please wait a moment and try again.");
+      expect(formatChatError(error)).toEqual({ type: "key", key: "chatError.tooManyRequests", params: undefined });
     });
 
-    it("formats network errors", () => {
+    it("keys network errors", () => {
       const error = new Error("Failed to fetch");
-      expect(formatChatError(error)).toBe("Network error. Please check your connection and try again.");
+      expect(formatChatError(error)).toEqual({ type: "key", key: "chatError.networkError", params: undefined });
     });
 
-    it("formats daily usage-limit errors with the UTC reset", () => {
+    it("keys daily usage-limit errors to the shared cap message, passing the limit", () => {
       const error = new ChatUsageLimitError("daily", usage);
-      expect(formatChatError(error)).toBe("You've used all 100 of today's messages. They reset at midnight UTC.");
+      expect(formatChatError(error)).toEqual({
+        type: "key",
+        key: "chatUsageNotice.limitReached.daily",
+        params: { limit: 100 }
+      });
     });
 
-    it("formats monthly usage-limit errors with the 1st reset", () => {
+    it("keys monthly usage-limit errors to the shared cap message, passing the limit", () => {
       const error = new ChatUsageLimitError("monthly", usage);
-      expect(formatChatError(error)).toBe("You've used all 500 messages this month. They reset on the 1st.");
+      expect(formatChatError(error)).toEqual({
+        type: "key",
+        key: "chatUsageNotice.limitReached.monthly",
+        params: { limit: 500 }
+      });
     });
 
-    it("formats rate-limited errors using the proxy message", () => {
+    it("passes rate-limited errors through with the proxy's own copy", () => {
       const error = new ChatRateLimitedError("Too many requests. Please wait a moment and try again.");
-      expect(formatChatError(error)).toBe("Too many requests. Please wait a moment and try again.");
+      expect(formatChatError(error)).toEqual({
+        type: "text",
+        text: "Too many requests. Please wait a moment and try again."
+      });
+    });
+
+    it("passes unclassified ChatApiError statuses through with the server message", () => {
+      const error = new ChatApiError("I'm a teapot", 418);
+      expect(formatChatError(error)).toEqual({ type: "text", text: "I'm a teapot" });
+    });
+
+    it("passes unclassified runtime errors through verbatim", () => {
+      const error = new Error("Something odd happened");
+      expect(formatChatError(error)).toEqual({ type: "text", text: "Something odd happened" });
+    });
+
+    it("keys completely unknown errors to the generic fallback", () => {
+      expect(formatChatError("nope")).toEqual({ type: "key", key: "chatError.unexpected", params: undefined });
     });
   });
 

--- a/app/tests/unit/components/coding-exercise/chatUsage.test.ts
+++ b/app/tests/unit/components/coding-exercise/chatUsage.test.ts
@@ -1,9 +1,4 @@
-import {
-  deriveUsageStatus,
-  extractUsage,
-  usageLimitText,
-  usageWarningText
-} from "@/components/coding-exercise/lib/chatUsage";
+import { deriveUsageStatus, extractUsage } from "@/components/coding-exercise/lib/chatUsage";
 import type { SignatureData, UsageMeta } from "@/components/coding-exercise/lib/chat-types";
 
 const baseSignature: SignatureData = {
@@ -91,28 +86,6 @@ describe("chatUsage", () => {
     it("prefers monthly scope when both limits are hit", () => {
       const status = deriveUsageStatus(usage({ messagesToday: 100, messagesThisMonth: 500 }));
       expect(status).toMatchObject({ scope: "monthly", atCap: true });
-    });
-  });
-
-  describe("copy", () => {
-    it("builds daily warning copy", () => {
-      const status = deriveUsageStatus(usage({ messagesToday: 90 }))!;
-      expect(usageWarningText(status)).toBe("You're getting close to your daily limit (90/100 messages today).");
-    });
-
-    it("builds monthly warning copy", () => {
-      const status = deriveUsageStatus(usage({ messagesThisMonth: 450 }))!;
-      expect(usageWarningText(status)).toBe(
-        "You're getting close to your monthly limit (450/500 messages this month)."
-      );
-    });
-
-    it("builds daily cap copy with the UTC reset", () => {
-      expect(usageLimitText("daily", 100)).toBe("You've used all 100 of today's messages. They reset at midnight UTC.");
-    });
-
-    it("builds monthly cap copy with the 1st reset", () => {
-      expect(usageLimitText("monthly", 500)).toBe("You've used all 500 messages this month. They reset on the 1st.");
     });
   });
 });


### PR DESCRIPTION
## What

Moves all chat usage/error copy out of the plain-`.ts` logic modules and into the localized layer via next-intl ICU messages. Rebased onto main after #906/#907.

### Commit 1: chat usage copy → ICU messages in ChatUsageNotice

- **`chatUsage.ts`**: deletes `usageWarningText(status)` and `usageLimitText(scope, limit)`; the module now holds only pure logic (`extractUsage`, `deriveUsageStatus`, `FAIR_USAGE_ARTICLE_SLUG`, types).
- **`ChatUsageNotice.tsx`**: translates directly, selecting the message by `status.scope`. Rendered output (text + fair-usage link) is identical.
- **New ICU messages** under `codingExercise.chatUsageNotice` in both `en.json` and `hu.json` (hu = English verbatim, per policy):
  - `warning.daily` — `You're getting close to your daily limit ({used}/{limit} messages today).`
  - `warning.monthly` — `You're getting close to your monthly limit ({used}/{limit} messages this month).`
  - `limitReached.daily` — `You've used all {limit} of today's messages. They reset at midnight UTC.`
  - `limitReached.monthly` — `You've used all {limit} messages this month. They reset on the 1st.`

### Commit 2: localize chatErrorHandler via keyed messages

- **`chatErrorHandler.ts`**: `formatChatError` now returns a discriminated `ChatErrorMessage`:
  - `{ type: "key", key, params? }` for copy we own — `key` is a union typed against the `codingExercise` namespace, so invalid keys fail typecheck.
  - `{ type: "text", text }` passthrough for copy the proxy/server provides pre-formatted. These branches stay dynamic: `ChatRateLimitedError` (proxy supplies the user-facing throttle copy), unclassified `ChatApiError` statuses (server message relay), and unclassified runtime `Error`s.
- **`useChat.ts`** (sole consumer): translates keyed results via `useTranslations("codingExercise")` before storing in chat state. Its inline captcha-failure literal ("Verification failed, please try again.") now reuses `chatError.verificationFailed` — note this unifies the comma variant to the period variant ("Verification failed. Please try again."), a deliberate tiny copy merge since the two played the same role.
- **New keys** under `codingExercise.chatError` (en + hu, hu = English verbatim): `sessionExpired`, `verificationFailed`, `authFailed`, `tokenServerError`, `tokenInitFailed`, `exerciseMismatch`, `authExpired`, `tooManyRequests`, `serviceUnavailable`, `serverError`, `networkError`, `timeout`, `unexpected`.
- **Usage-limit branches reuse** the existing `codingExercise.chatUsageNotice.limitReached.daily/monthly` messages (same copy, same meaning), passing `{limit}` — removing the duplication flagged in review.

## Tests / docs

- `chatUsage.test.ts` trimmed to the pure-logic functions.
- New `ChatUsageNotice.test.tsx` covers all four message paths plus null/no-notice and the fair-usage link, asserting via text/role (not CSS classes).
- `chatErrorHandler.test.ts` updated to assert keys/params for keyed branches and verbatim text for passthrough branches (plus new passthrough/fallback cases).
- `.context/i18n.md`: removed `chatUsage.ts` from the deferred list (merged with #907's removals during rebase).

## Verification

- Full app jest suite: 168 suites / 2053 tests passing.
- `pnpm typecheck` (monorepo root) + app `tsc --noEmit`: clean.
- eslint + prettier on touched files: clean.
- `messages.test.ts` (en/hu parity + valid ICU): passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)