### PR TITLE
i18n: localize guide-not-found metadata fallback

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -166,8 +166,7 @@ These render English regardless of locale and are intentionally out of the chrom
 - **Plain-`.ts` strings with no hook/await context**: `lib/pricing.ts` (`PRICING_TIERS` names,
   descriptions, feature lists — consumed across many components),
   `components/coding-exercise/lib/chatUsage.ts` (usage-limit sentences),
-  `components/guides/GuideDetailPage.tsx` `getGuideMetadata` ("Guide Not Found" — sync `Metadata`
-  helper; needs to become async for `getTranslations`), and the "Unknown error" fallback in
+  and the "Unknown error" fallback in
   `components/coding-exercise/hooks/useExerciseLoader.tsx`. Localizing these needs the pass-in
   pattern (translate at the call site and pass the string down) or a follow-up.
   Toasts fired from these plain contexts are already localized via the keyed

--- a/app/app/(hybrid)/[locale]/guides/[slug]/page.tsx
+++ b/app/app/(hybrid)/[locale]/guides/[slug]/page.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
-  return getGuideMetadata(slug, locale);
+  return await getGuideMetadata(slug, locale);
 }
 
 export default async function AuthenticatedLocaleGuidePage({ params }: Props) {

--- a/app/components/guides/GuideDetailPage.tsx
+++ b/app/components/guides/GuideDetailPage.tsx
@@ -1,5 +1,6 @@
 import { getGuide, getAllGuides, getAllProjects, getProject, getRelatedGuides } from "@/lib/content";
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import GuideDetailContent from "./GuideDetailContent";
 import type { FeaturedInEpisode } from "./FeaturedInProjects";
@@ -10,12 +11,13 @@ interface GuideDetailPageProps {
 }
 
 // Helper for generateMetadata
-export function getGuideMetadata(slug: string, locale: string = "en"): Metadata {
+export async function getGuideMetadata(slug: string, locale: string = "en"): Promise<Metadata> {
+  const t = await getTranslations({ locale, namespace: "guides.metadata" });
   try {
     const allGuides = getAllGuides(locale);
     const guide = allGuides.find((g) => g.slug === slug);
     if (!guide) {
-      return { title: "Guide Not Found" };
+      return { title: t("notFoundTitle") };
     }
 
     return {
@@ -24,7 +26,7 @@ export function getGuideMetadata(slug: string, locale: string = "en"): Metadata 
       keywords: guide.seo.keywords.join(", ")
     };
   } catch {
-    return { title: "Guide Not Found" };
+    return { title: t("notFoundTitle") };
   }
 }
 

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1711,6 +1711,9 @@
     },
     "featuredInProjects": {
       "heading": "Featured in Projects"
+    },
+    "metadata": {
+      "notFoundTitle": "Guide Not Found"
     }
   },
   "unsubscribe": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1711,6 +1711,9 @@
     },
     "featuredInProjects": {
       "heading": "Featured in Projects"
+    },
+    "metadata": {
+      "notFoundTitle": "Guide Not Found"
     }
   },
   "unsubscribe": {


### PR DESCRIPTION
## What

`getGuideMetadata(slug, locale)` in `app/components/guides/GuideDetailPage.tsx` returned a hardcoded `{ title: "Guide Not Found" }` in both its not-found and catch paths. This localizes that fallback.

- Made `getGuideMetadata` async and now translates the fallback title via next-intl's `getTranslations({ locale, namespace: "guides.metadata" })` (the sanctioned generateMetadata-context API).
- Added `guides.metadata.notFoundTitle` to `messages/en.json` and `messages/hu.json` (hu = English copy verbatim, to be translated separately).
- Awaited the helper at its sole call site (`generateMetadata` in `app/(hybrid)/[locale]/guides/[slug]/page.tsx`), passing the locale already in scope.
- Removed `getGuideMetadata` from the "Not yet localized (deferred)" list in `.context/i18n.md`.

## Verification

- Full app jest suite: 2044 passed (via pre-commit hook).
- `pnpm typecheck` (monorepo root): clean.
- eslint + prettier on touched files: clean.
- `tests/unit/messages.test.ts` (en/hu parity + ICU): passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)