### PR TITLE
i18n: inline locale dictionary for global-error

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -158,6 +158,13 @@ single-challenge screen while `challenges` is the listing pages;
 
 - **`/dev` and `/test` routes** and the components that exist only for them: development-only
   tooling, never shown to students. Do not extract their strings into the catalog.
+- **`app/global-error.tsx`** — replaces the entire HTML tree when the app crashes hard, so it must
+  render with ZERO loadable dependencies (no `NextIntlClientProvider`, no catalog import, no fetch).
+  Its strings therefore live in an inline `COPY` dictionary keyed by locale inside the file, and are
+  deliberately kept out of `messages/*.json`. A tiny dependency-free `resolveGlobalErrorLocale()` in
+  the same file mirrors `resolveLocale`'s precedence client-side (URL locale segment → `NEXT_LOCALE`
+  cookie → default), and `<html lang>` follows it. Adding a locale here is a manual, per-locale edit;
+  the translation repo knows about this deliberate exception.
 
 ### Not yet localized (deferred)
 
@@ -174,8 +181,6 @@ These render English regardless of locale and are intentionally out of the chrom
   Toasts fired from these plain contexts are already localized via the keyed
   `lib/toast.tsx` helpers (`toastError`/`toastSuccess`/…), which resolve the copy
   when the toast paints inside the provider — see `.context/toasts.md`.
-- **`app/global-error.tsx`** — replaces the entire HTML tree (no `NextIntlClientProvider` in scope),
-  so it keeps hardcoded English.
 - **Content** (out of scope by design): blog/article/concept bodies, exercise/curriculum text,
   `components/testimonials/testimonials.json`, and the blog/articles `[locale]` routing.
 - **In-app language switcher**: no settings UI to change locale yet (and no live catalog swap on a

--- a/app/app/global-error.tsx
+++ b/app/app/global-error.tsx
@@ -6,6 +6,35 @@ import { ErrorPageContent } from "../components/error-page/ErrorPage";
 // so it must import globals.css directly to have any styles
 import "./globals.css";
 import styles from "../components/error-page/ErrorPage.module.css";
+import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, isSupportedLocale, type Locale } from "@/lib/i18n/config";
+
+// This page replaces the entire HTML tree when the app crashes hard, so it must
+// render with ZERO loadable dependencies: no NextIntlClientProvider, no message
+// catalog, no fetch. Its strings are therefore DELIBERATELY kept out of
+// messages/*.json and live in the inline COPY dictionary below.
+//
+// IMPORTANT: because this bypasses the catalog, every new locale must be added
+// here BY HAND. The translation repo knows about this deliberate exception.
+// New locales' entries start as the English copy verbatim (never machine-translated).
+interface GlobalErrorCopy {
+  title: string;
+  message: string;
+  actionLabel: string;
+}
+
+const COPY: Record<Locale, GlobalErrorCopy> = {
+  en: {
+    title: "Something went wrong",
+    message: "We encountered an unexpected error. Sorry about that!",
+    actionLabel: "Try again"
+  },
+  // hu intentionally mirrors the English copy verbatim; translated by hand later.
+  hu: {
+    title: "Something went wrong",
+    message: "We encountered an unexpected error. Sorry about that!",
+    actionLabel: "Try again"
+  }
+};
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
@@ -20,19 +49,57 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
     }
   }, [error]);
 
+  const locale = resolveGlobalErrorLocale();
+  const copy = getGlobalErrorCopy(locale);
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body className={styles.wrapper}>
         <div className={styles.container}>
           <ErrorPageContent
             variant="serverError"
-            title="Something went wrong"
-            message="We encountered an unexpected error. Sorry about that!"
-            actionLabel="Try again"
+            title={copy.title}
+            message={copy.message}
+            actionLabel={copy.actionLabel}
             onAction={reset}
           />
         </div>
       </body>
     </html>
   );
+}
+
+// Dependency-free locale resolution for the crash page. Mirrors the precedence of
+// lib/i18n/resolveLocale.ts (URL locale segment, then NEXT_LOCALE cookie, else
+// default) but without next/headers, since it must run purely client-side after a
+// hard crash. SSR-safe: returns the default locale if evaluated without a DOM
+// (global-error only renders client-side in practice, but this must never throw).
+export function resolveGlobalErrorLocale(): Locale {
+  if (typeof document === "undefined" || typeof location === "undefined") {
+    return DEFAULT_LOCALE;
+  }
+
+  const urlSegment = location.pathname.split("/")[1];
+  if (isSupportedLocale(urlSegment)) {
+    return urlSegment;
+  }
+
+  const cookieLocale = readCookie(LOCALE_COOKIE_NAME);
+  if (isSupportedLocale(cookieLocale)) {
+    return cookieLocale;
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+// Selects the inline copy for a locale, falling back to English for any locale
+// not present in the dictionary.
+export function getGlobalErrorCopy(locale: string): GlobalErrorCopy {
+  const dictionary: Record<string, GlobalErrorCopy | undefined> = COPY;
+  return dictionary[locale] ?? COPY[DEFAULT_LOCALE];
+}
+
+function readCookie(name: string): string | undefined {
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : undefined;
 }

--- a/app/tests/unit/app/global-error.test.tsx
+++ b/app/tests/unit/app/global-error.test.tsx
@@ -1,0 +1,73 @@
+import { resolveGlobalErrorLocale, getGlobalErrorCopy } from "@/app/global-error";
+import { LOCALE_COOKIE_NAME } from "@/lib/i18n/config";
+
+// jsdom exposes a mutable location.pathname and document.cookie; the resolver reads
+// both directly (it has no next/headers to mock), so we drive it via those globals.
+function setPathname(pathname: string) {
+  window.history.replaceState({}, "", pathname);
+}
+
+function clearCookies() {
+  for (const cookie of document.cookie.split(";")) {
+    const name = cookie.split("=")[0].trim();
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    }
+  }
+}
+
+describe("resolveGlobalErrorLocale", () => {
+  beforeEach(() => {
+    setPathname("/");
+    clearCookies();
+  });
+
+  it("uses the URL locale segment when present, ignoring the cookie", () => {
+    setPathname("/hu/blog");
+    document.cookie = `${LOCALE_COOKIE_NAME}=en`;
+    expect(resolveGlobalErrorLocale()).toBe("hu");
+  });
+
+  it("falls back to the NEXT_LOCALE cookie when the URL has no locale segment", () => {
+    setPathname("/dashboard");
+    document.cookie = `${LOCALE_COOKIE_NAME}=hu`;
+    expect(resolveGlobalErrorLocale()).toBe("hu");
+  });
+
+  it("returns the default locale when neither URL nor cookie carry a supported locale", () => {
+    setPathname("/dashboard");
+    expect(resolveGlobalErrorLocale()).toBe("en");
+  });
+
+  it("ignores an unsupported URL locale segment and falls through to the default", () => {
+    setPathname("/de/blog");
+    expect(resolveGlobalErrorLocale()).toBe("en");
+  });
+
+  it("ignores an unsupported NEXT_LOCALE cookie value", () => {
+    setPathname("/dashboard");
+    document.cookie = `${LOCALE_COOKIE_NAME}=de`;
+    expect(resolveGlobalErrorLocale()).toBe("en");
+  });
+});
+
+describe("getGlobalErrorCopy", () => {
+  it("returns the English copy for en", () => {
+    expect(getGlobalErrorCopy("en")).toEqual({
+      title: "Something went wrong",
+      message: "We encountered an unexpected error. Sorry about that!",
+      actionLabel: "Try again"
+    });
+  });
+
+  it("returns a full copy entry for hu", () => {
+    const copy = getGlobalErrorCopy("hu");
+    expect(copy.title).toBeTruthy();
+    expect(copy.message).toBeTruthy();
+    expect(copy.actionLabel).toBeTruthy();
+  });
+
+  it("falls back to the English copy for an unknown locale", () => {
+    expect(getGlobalErrorCopy("de")).toEqual(getGlobalErrorCopy("en"));
+  });
+});


### PR DESCRIPTION
## What

`app/global-error.tsx` replaces the entire HTML tree when the app crashes hard, so it must render with **zero loadable dependencies**: no `NextIntlClientProvider`, no message-catalog import, no fetch. Previously it hardcoded English and `<html lang="en">`.

This gives it an **inline per-locale `COPY` dictionary** (deliberately kept out of `messages/*.json`) plus a tiny dependency-free client-side locale resolver, so the crash page localizes without any loadable machinery.

## Shape

- **`COPY`** — inline dictionary keyed by locale (`en`, `hu`) with `title` / `message` / `actionLabel`. `hu` mirrors the English copy verbatim (translated by hand later, never machine-translated). A file comment documents that this is a deliberate catalog exception and new locales are added here by hand.
- **`resolveGlobalErrorLocale()`** — dependency-free, SSR-safe (returns the default locale without a DOM, never throws). Mirrors `resolveLocale`'s precedence client-side: URL locale segment → `NEXT_LOCALE` cookie → default. Only lightweight constants are imported from the dependency-free `lib/i18n/config`.
- **`getGlobalErrorCopy(locale)`** — selects the copy, falling back to English for any locale not in the dictionary.
- `<html lang>` and the `ErrorPageContent` props are now driven by the resolved locale.

## Tests

`tests/unit/app/global-error.test.tsx` covers the resolver (URL wins over cookie, cookie fallback, unsupported URL/cookie → default) and the dictionary fallback (unknown locale → English).

## Docs

`.context/i18n.md` documents the inline dictionary under "Never localized (by design)".

## Verification

- Full app jest suite: 167 suites / 2052 tests pass
- `tsc --noEmit` (app) clean
- eslint + prettier clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)