### PR TITLE
i18n: notification-type copy → unsubscribe catalog keys

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -167,7 +167,6 @@ These render English regardless of locale and are intentionally out of the chrom
   `lib/settings/settingsStore.ts` (Zustand store toasts),
   `components/coding-exercise/lib/orchestrator/TestSuiteManager.ts` (class),
   `components/coding-exercise/lib/chatUsage.ts` (usage-limit sentences),
-  `lib/notifications/config.ts` (`NOTIFICATION_TYPES` titles/descriptions),
   `components/guides/GuideDetailPage.tsx` `getGuideMetadata` ("Guide Not Found" — sync `Metadata`
   helper; needs to become async for `getTranslations`), and the "Unknown error" fallback in
   `components/coding-exercise/hooks/useExerciseLoader.tsx`. Localizing these needs the pass-in

--- a/app/components/unsubscribe/ManageNotificationsSection.tsx
+++ b/app/components/unsubscribe/ManageNotificationsSection.tsx
@@ -9,9 +9,7 @@ import CheckCircleIcon from "@/icons/check-circle.svg";
 import styles from "./UnsubscribePage.module.css";
 
 const NOTIFICATION_CONFIGS: NotificationConfig[] = NOTIFICATION_TYPES.map((type) => ({
-  id: type.slug,
-  title: type.title,
-  description: type.description
+  id: type.slug
 }));
 
 interface ManageNotificationsSectionProps {

--- a/app/components/unsubscribe/NotificationItem.tsx
+++ b/app/components/unsubscribe/NotificationItem.tsx
@@ -4,8 +4,6 @@ import styles from "./UnsubscribePage.module.css";
 
 export interface NotificationConfig {
   id: keyof EmailPreferences;
-  title: string;
-  description: string;
 }
 
 interface NotificationItemProps {
@@ -17,17 +15,19 @@ interface NotificationItemProps {
 
 export default function NotificationItem({ config, enabled, loading, onToggle }: NotificationItemProps) {
   const t = useTranslations("unsubscribe");
+  const title = t(`types.${config.id}.title`);
+  const description = t(`types.${config.id}.description`);
   return (
     <div className={styles.notificationItem}>
       <div className={styles.notificationInfo}>
-        <h3>{config.title}</h3>
-        <p>{config.description}</p>
+        <h3>{title}</h3>
+        <p>{description}</p>
       </div>
       <button
         className={`ui-toggle-switch ${enabled ? "active" : ""} ${loading ? "opacity-50" : ""}`}
         onClick={onToggle}
         disabled={loading}
-        aria-label={t("toggleAria", { name: config.title })}
+        aria-label={t("toggleAria", { name: title })}
         aria-checked={enabled}
         role="switch"
       />

--- a/app/components/unsubscribe/UnsubscribeFromEmailSection.tsx
+++ b/app/components/unsubscribe/UnsubscribeFromEmailSection.tsx
@@ -3,7 +3,7 @@ import EmailEnvelopeIcon from "@/icons/email-envelope.svg";
 import CheckCircleIcon from "@/icons/check-circle.svg";
 import AlertCircleIcon from "@/icons/alert-circle.svg";
 import styles from "./UnsubscribePage.module.css";
-import { formatKeyName } from "./utils";
+import { notificationSlugForKey } from "./utils";
 
 interface UnsubscribeFromEmailSectionProps {
   emailKey: string;
@@ -24,7 +24,8 @@ export default function UnsubscribeFromEmailSection({
 }: UnsubscribeFromEmailSectionProps) {
   const t = useTranslations("unsubscribe");
   const tCommon = useTranslations("common");
-  const emailTypeName = formatKeyName(emailKey);
+  const emailSlug = notificationSlugForKey(emailKey);
+  const emailTypeName = emailSlug ? t(`types.${emailSlug}.shortLabel`) : t("email.fallbackType");
   const highlight = (chunks: React.ReactNode) => <span className={styles.emailTypeHighlight}>{chunks}</span>;
 
   if (!isSubscribed && !success) {

--- a/app/components/unsubscribe/utils.ts
+++ b/app/components/unsubscribe/utils.ts
@@ -1,5 +1,6 @@
-import { NOTIFICATION_TYPES } from "@/lib/notifications/config";
+import { NOTIFICATION_TYPES, type NotificationSlug } from "@/lib/notifications/config";
 
-export function formatKeyName(key: string): string {
-  return NOTIFICATION_TYPES.find((type) => type.slug === key)?.shortLabel ?? "these";
+/** Resolve an email-preferences key to a known notification slug, or `null` if unknown. */
+export function notificationSlugForKey(key: string): NotificationSlug | null {
+  return NOTIFICATION_TYPES.find((type) => type.slug === key)?.slug ?? null;
 }

--- a/app/lib/notifications/config.ts
+++ b/app/lib/notifications/config.ts
@@ -7,7 +7,8 @@
  *   - `/external/email_preferences/:token` returns it as `<slug>`
  *
  * Adding a new preference type is a single entry in `NOTIFICATION_TYPES` (plus
- * the settings copy under `settings.notifications` in the message catalogues).
+ * the settings copy under `settings.notifications` and the external unsubscribe
+ * copy under `unsubscribe.types.<slug>` in the message catalogues).
  */
 
 export interface NotificationType {
@@ -15,49 +16,28 @@ export interface NotificationType {
   slug: string;
   /** Key used to build the settings-tab i18n keys (`<id>Title` / `<id>Description`). */
   settingsI18nId: string;
-  /** Title shown on the external (logged-out) unsubscribe page. */
-  title: string;
-  /** Description shown on the external unsubscribe page. */
-  description: string;
-  /** Human label used in the one-click unsubscribe confirmation copy. */
-  shortLabel: string;
 }
 
 export const NOTIFICATION_TYPES = [
   {
     slug: "newsletters",
-    settingsI18nId: "features",
-    title: "Product Updates",
-    description: "Stay informed about new features and improvements.",
-    shortLabel: "product updates"
+    settingsI18nId: "features"
   },
   {
     slug: "event_emails",
-    settingsI18nId: "livestreams",
-    title: "Event Notifications",
-    description: "Get notified about upcoming livestreams and events.",
-    shortLabel: "event notifications"
+    settingsI18nId: "livestreams"
   },
   {
     slug: "milestone_emails",
-    settingsI18nId: "milestones",
-    title: "Achievement Notifications",
-    description: "Receive notifications when you unlock new skills or achievements.",
-    shortLabel: "achievement notifications"
+    settingsI18nId: "milestones"
   },
   {
     slug: "activity_emails",
-    settingsI18nId: "activity",
-    title: "Activity Emails",
-    description: "Activity-based notifications like unlocking badges and completing challenges.",
-    shortLabel: "activity emails"
+    settingsI18nId: "activity"
   },
   {
     slug: "onboarding_emails",
-    settingsI18nId: "onboarding",
-    title: "Getting-Started Emails",
-    description: "Tips and guidance on how to get the most from Jiki.",
-    shortLabel: "getting-started emails"
+    settingsI18nId: "onboarding"
   }
 ] as const satisfies readonly NotificationType[];
 

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1729,7 +1729,35 @@
       "title": "Unsubscribe from This Email",
       "description": "No longer want to receive this type of email? Click below to unsubscribe from <highlight>{emailType}</highlight> emails.",
       "success": "You've been unsubscribed from {emailType}.",
-      "button": "Unsubscribe from {emailType}"
+      "button": "Unsubscribe from {emailType}",
+      "fallbackType": "these"
+    },
+    "types": {
+      "newsletters": {
+        "title": "Product Updates",
+        "description": "Stay informed about new features and improvements.",
+        "shortLabel": "product updates"
+      },
+      "event_emails": {
+        "title": "Event Notifications",
+        "description": "Get notified about upcoming livestreams and events.",
+        "shortLabel": "event notifications"
+      },
+      "milestone_emails": {
+        "title": "Achievement Notifications",
+        "description": "Receive notifications when you unlock new skills or achievements.",
+        "shortLabel": "achievement notifications"
+      },
+      "activity_emails": {
+        "title": "Activity Emails",
+        "description": "Activity-based notifications like unlocking badges and completing challenges.",
+        "shortLabel": "activity emails"
+      },
+      "onboarding_emails": {
+        "title": "Getting-Started Emails",
+        "description": "Tips and guidance on how to get the most from Jiki.",
+        "shortLabel": "getting-started emails"
+      }
     }
   },
   "achievements": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1729,7 +1729,35 @@
       "title": "Unsubscribe from This Email",
       "description": "No longer want to receive this type of email? Click below to unsubscribe from <highlight>{emailType}</highlight> emails.",
       "success": "You've been unsubscribed from {emailType}.",
-      "button": "Unsubscribe from {emailType}"
+      "button": "Unsubscribe from {emailType}",
+      "fallbackType": "these"
+    },
+    "types": {
+      "newsletters": {
+        "title": "Product Updates",
+        "description": "Stay informed about new features and improvements.",
+        "shortLabel": "product updates"
+      },
+      "event_emails": {
+        "title": "Event Notifications",
+        "description": "Get notified about upcoming livestreams and events.",
+        "shortLabel": "event notifications"
+      },
+      "milestone_emails": {
+        "title": "Achievement Notifications",
+        "description": "Receive notifications when you unlock new skills or achievements.",
+        "shortLabel": "achievement notifications"
+      },
+      "activity_emails": {
+        "title": "Activity Emails",
+        "description": "Activity-based notifications like unlocking badges and completing challenges.",
+        "shortLabel": "activity emails"
+      },
+      "onboarding_emails": {
+        "title": "Getting-Started Emails",
+        "description": "Tips and guidance on how to get the most from Jiki.",
+        "shortLabel": "getting-started emails"
+      }
     }
   },
   "achievements": {


### PR DESCRIPTION
## What

Moves the external unsubscribe page's per-notification display strings out of `NOTIFICATION_TYPES` (`app/lib/notifications/config.ts`) and into the message catalog under `unsubscribe.types.<slug>`.

- `NOTIFICATION_TYPES` now carries only `slug` + `settingsI18nId`; the `NotificationType` interface and doc comments are trimmed to match. All type machinery (`NotificationSlug`, `NotificationField`, `notificationField`, `EmailPreferences`, `buildEmailPreferences`, the `as const satisfies` shape) is unchanged.
- Added `unsubscribe.types.<slug>.{title,description,shortLabel}` for the five slugs (`newsletters`, `event_emails`, `milestone_emails`, `activity_emails`, `onboarding_emails`) to both `messages/en.json` and `messages/hu.json` (hu = English verbatim), copied verbatim from the config.
- Added `unsubscribe.email.fallbackType` (`"these"`) so the unknown-slug fallback previously hardcoded in `utils.ts` is also localized.

## Consumers updated

- `components/unsubscribe/NotificationItem.tsx` — translates title/description from `types.${config.id}.{title,description}`; `NotificationConfig` is now just `{ id }`.
- `components/unsubscribe/ManageNotificationsSection.tsx` — builds configs from slug only.
- `components/unsubscribe/UnsubscribeFromEmailSection.tsx` — keeps the `t.rich` `{emailType}` ICU interpolation, sourcing the short label from `types.${slug}.shortLabel` (or `email.fallbackType`).
- `components/unsubscribe/utils.ts` — `formatKeyName` replaced by `notificationSlugForKey` (resolves a key to a known slug or `null`).
- `/dev/unsubscribe` page consumes only `buildEmailPreferences` + `emailKey`, so it needed no changes.

Rendered English output is byte-identical everywhere.

## Docs

- `app/.context/i18n.md` deferred list no longer mentions `lib/notifications/config.ts`.

## Verification

- `pnpm typecheck` (monorepo root) — passes; dynamic template-literal message keys typecheck against the catalog.
- Full app Jest suite — 166 suites / 2044 tests pass (via pre-commit hook).
- `messages.test.ts` guard (en/hu parity + ICU) — passes.
- ESLint + Prettier on all touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)