### PR TITLE
Reduce landing hero bottom padding to 40px

### DIFF
--- a/app/components/landing-page/Hero.module.css
+++ b/app/components/landing-page/Hero.module.css
@@ -23,8 +23,7 @@
         align-items: flex-start;
         flex: 1;
         padding-top: 24px;
-        padding-bottom: 80px;
-        margin-bottom: 40px;
+        padding-bottom: 40px;
         background-image: linear-gradient(
             to right,
             transparent 0%,

--- a/app/components/landing-page/Hero.module.css
+++ b/app/components/landing-page/Hero.module.css
@@ -24,6 +24,7 @@
         flex: 1;
         padding-top: 24px;
         padding-bottom: 80px;
+        margin-bottom: 40px;
         background-image: linear-gradient(
             to right,
             transparent 0%,


### PR DESCRIPTION
Changes the landing-page Hero `.container` (hashed class `Hero_container__g15qc`) bottom padding from 80px to 40px.

**Before:**
```css
.container {
    display: flex;
    align-items: flex-start;
    flex: 1;
    padding-top: 24px;
    padding-bottom: 80px;
    ...
}
```

**After:**
```css
.container {
    display: flex;
    align-items: flex-start;
    flex: 1;
    padding-top: 24px;
    padding-bottom: 40px;
    ...
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)