### PR TITLE
Landing price skeleton, /articles redirect fix, last i18n stragglers

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -194,14 +194,15 @@ single-challenge screen while `challenges` is the listing pages;
 
 ### Not yet localized (deferred)
 
-These render English regardless of locale and are intentionally out of the chrome sweep:
+The chrome sweep is complete: every component-reachable UI string resolves through the catalog.
+What remains deferred is out of that sweep by design:
 
-- **Plain-`.ts` strings with no hook/await context**: the "Unknown error" fallback in
-  `components/coding-exercise/hooks/useExerciseLoader.tsx`. Localizing it needs the pass-in
-  pattern (translate at the call site and pass the string down) or a follow-up.
-  Toasts fired from plain contexts are already localized via the keyed
-  `lib/toast.tsx` helpers (`toastError`/`toastSuccess`/…), which resolve the copy
-  when the toast paints inside the provider — see `.context/toasts.md`.
+- **Plain-`.ts` strings with no hook/await context**: none remain in the chrome surface. Anything
+  fired from a plain (non-hook) context uses a keyed indirection so the copy still resolves in the
+  right locale — toasts go through the `lib/toast.tsx` helpers (`toastError`/`toastSuccess`/…),
+  which resolve when the toast paints inside the provider (see `.context/toasts.md`). A string that
+  genuinely needs translating from a plain module should adopt the same pass-a-key pattern rather
+  than hardcoding English.
 - **Content** (out of scope by design): blog/article/concept bodies, exercise/curriculum text,
   `components/testimonials/testimonials.json` (the `/testimonials` page), and the blog/articles
   `[locale]` routing.

--- a/app/components/blog/RecentBlogPosts.tsx
+++ b/app/components/blog/RecentBlogPosts.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { useFormatter } from "next-intl";
 import type { BlogPostMeta } from "@/lib/content/types";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import styles from "./RecentBlogPosts.module.css";
@@ -10,6 +11,7 @@ interface RecentBlogPostsProps {
 
 export default function RecentBlogPosts({ posts }: RecentBlogPostsProps) {
   const routes = useLocaleRoutes();
+  const format = useFormatter();
   if (posts.length === 0) {
     return null;
   }
@@ -25,7 +27,7 @@ export default function RecentBlogPosts({ posts }: RecentBlogPostsProps) {
             )}
             <div className={styles.meta}>
               <span className={styles.date}>
-                {new Date(post.date).toLocaleDateString("en-US", {
+                {format.dateTime(new Date(post.date), {
                   day: "numeric",
                   month: "short",
                   year: "numeric"

--- a/app/components/coding-exercise/hooks/useExerciseLoader.tsx
+++ b/app/components/coding-exercise/hooks/useExerciseLoader.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { exercises, type ExerciseSlug, type ExerciseDefinition, type Language } from "@jiki/curriculum";
 import Orchestrator from "../lib/Orchestrator";
 import type { ExerciseContext } from "../lib/types";
@@ -36,6 +36,7 @@ export function useExerciseLoader({
   // (instructions/stub/solution). No fallback: an exercise without a content blob
   // for this locale fails to load (only dnd-roll ships non-en content in the pilot).
   const uiLocale = useLocale();
+  const t = useTranslations("codingExercise");
 
   useEffect(() => {
     const loadExercise = async () => {
@@ -123,7 +124,7 @@ export function useExerciseLoader({
 
         setIsLoading(false);
       } catch (error) {
-        setLoadError(error instanceof Error ? error.message : "Unknown error");
+        setLoadError(error instanceof Error ? error.message : t("unknownError"));
         setIsLoading(false);
       }
     };

--- a/app/components/landing-page/MonthlyPrice.module.css
+++ b/app/components/landing-page/MonthlyPrice.module.css
@@ -1,0 +1,31 @@
+@keyframes shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}
+
+/*
+ * Inline placeholder shown until the geolocated price resolves. Sized like a
+ * price ("$9.99") so the surrounding sentence doesn't reflow when the real
+ * value arrives.
+ */
+.skeleton {
+    display: inline-block;
+    width: 3.5em;
+    height: 1em;
+    vertical-align: middle;
+    border-radius: 4px;
+    background: linear-gradient(
+        90deg,
+        var(--color-gray-100) 0%,
+        var(--color-gray-50) 25%,
+        var(--color-gray-100) 50%,
+        var(--color-gray-50) 75%,
+        var(--color-gray-100) 100%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+}

--- a/app/components/landing-page/MonthlyPrice.tsx
+++ b/app/components/landing-page/MonthlyPrice.tsx
@@ -1,20 +1,24 @@
 "use client";
 
-import { useTranslations } from "next-intl";
 import { useExternalPremiumPrices } from "@/lib/hooks/useExternalPremiumPrices";
 import { formatMonthlyPrice } from "@/lib/pricing";
+import styles from "./MonthlyPrice.module.css";
 
 /**
  * Renders the Premium monthly price.
  *
- * SSR / first paint shows the USD full price ($9.99) so the page is fully
- * usable on first byte. After hydration we hit the public /external/pricing
- * endpoint, which Cloudflare-geolocates the visitor and returns the PPP
- * price for their country (or USD if unmapped / no Cloudflare locally).
+ * SSR / first paint shows a skeleton placeholder rather than a hardcoded price,
+ * so a possibly-wrong value is never shown. After hydration we hit the public
+ * /external/pricing endpoint, which Cloudflare-geolocates the visitor and
+ * returns the PPP price for their country (or USD if unmapped / no Cloudflare
+ * locally). No-JS visitors keep seeing the skeleton.
  */
 export function MonthlyPrice() {
-  const t = useTranslations("landing.monthlyPrice");
   const prices = useExternalPremiumPrices();
 
-  return <>{prices ? formatMonthlyPrice(prices) : t("fallback")}</>;
+  if (!prices) {
+    return <span className={styles.skeleton} aria-hidden="true" data-testid="monthly-price-skeleton" />;
+  }
+
+  return <>{formatMonthlyPrice(prices)}</>;
 }

--- a/app/components/settings/payment-history/PaymentHistoryRow.tsx
+++ b/app/components/settings/payment-history/PaymentHistoryRow.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { useFormatter, useTranslations } from "next-intl";
 import { formatCurrency } from "@/lib/formatCurrency";
 import styles from "./PaymentHistory.module.css";
 import type { Payment } from "./types";
@@ -10,14 +10,13 @@ interface PaymentHistoryRowProps {
 
 export default function PaymentHistoryRow({ payment, onDownloadReceipt }: PaymentHistoryRowProps) {
   const t = useTranslations("settings.paymentHistory");
+  const format = useFormatter();
   const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    const options: Intl.DateTimeFormatOptions = {
+    return format.dateTime(new Date(dateString), {
       month: "short",
       day: "numeric",
       year: "numeric"
-    };
-    return date.toLocaleDateString("en-US", options);
+    });
   };
 
   return (

--- a/app/lib/modal/modals/SubscriptionSuccessModal.tsx
+++ b/app/lib/modal/modals/SubscriptionSuccessModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useFormatter, useTranslations } from "next-intl";
 import { useState } from "react";
 import { hideModal } from "../store";
 import type { MembershipTier } from "@/lib/pricing";
@@ -20,6 +20,7 @@ interface SubscriptionSuccessModalProps {
 
 export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onClose }: SubscriptionSuccessModalProps) {
   const t = useTranslations("modals.subscriptionSuccess");
+  const format = useFormatter();
   const tCommon = useTranslations("common");
   const tTiers = useTranslations("subscription.tiers");
   const tPremium = useTranslations("subscription.tiers.premium");
@@ -31,8 +32,16 @@ export function SubscriptionSuccessModal({ tier, triggerContext, nextSteps, onCl
     tPremium("features.certificates")
   ];
 
-  // Calculate renewal date once at render time to avoid calling Date.now() during render
-  const [renewalDate] = useState(() => new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString());
+  // Calculate the renewal date once at render time to avoid calling Date.now() during render.
+  // Format in the active locale via next-intl's formatter (short month/day/year), matching the
+  // billing-date formatting in components/settings/subscription/useSubscription.ts.
+  const [renewalDate] = useState(() =>
+    format.dateTime(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), {
+      month: "short",
+      day: "numeric",
+      year: "numeric"
+    })
+  );
 
   const getContextualContent = () => {
     switch (triggerContext) {

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -567,9 +567,6 @@
       "byAuthor": "by {name}",
       "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>."
     },
-    "monthlyPrice": {
-      "fallback": "$9.99"
-    },
     "welcome": {
       "para1": "In 2026, anyone can open Cursor and create a fully-functional product in minutes. Maybe you've done it yourself! Something that would have taken you <strong>years to learn</strong> to make in the past is now available in seconds. So what does it mean to be a developer now? What does it mean to have a <strong>career in tech</strong>?",
       "para2": "Here's a secret no-one tells you. <highlight><strong>Software engineering has never been about writing code.</strong></highlight> Coding is how you communicate with the computer, but the real skill has always been in <strong>critical-thinking</strong>, in <strong>problem solving</strong>, in <strong>building and architecting</strong>. It's always been about taking ideas and <strong>turning them into reality</strong>.",
@@ -1407,6 +1404,7 @@
   },
   "codingExercise": {
     "loadError": "Error loading exercise: {error}",
+    "unknownError": "Unknown error",
     "runButton": {
       "run": "Run Code",
       "running": "Running...",

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -567,9 +567,6 @@
       "byAuthor": "by {name}",
       "subheading": "Keep up to date with what's happening at Jiki in <link>our blog</link>."
     },
-    "monthlyPrice": {
-      "fallback": "$9.99"
-    },
     "welcome": {
       "para1": "In 2026, anyone can open Cursor and create a fully-functional product in minutes. Maybe you've done it yourself! Something that would have taken you <strong>years to learn</strong> to make in the past is now available in seconds. So what does it mean to be a developer now? What does it mean to have a <strong>career in tech</strong>?",
       "para2": "Here's a secret no-one tells you. <highlight><strong>Software engineering has never been about writing code.</strong></highlight> Coding is how you communicate with the computer, but the real skill has always been in <strong>critical-thinking</strong>, in <strong>problem solving</strong>, in <strong>building and architecting</strong>. It's always been about taking ideas and <strong>turning them into reality</strong>.",
@@ -1407,6 +1404,7 @@
   },
   "codingExercise": {
     "loadError": "Error loading exercise: {error}",
+    "unknownError": "Unknown error",
     "runButton": {
       "run": "Run Code",
       "running": "Running...",

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -72,9 +72,16 @@ const nextConfig: NextConfig = {
         permanent: false
       },
       {
-        // The Help Center used to live at /articles. :path* also matches zero
-        // segments, so this covers the index too. Only naked paths need
-        // handling: no non-default locale was live before the move.
+        // The Help Center used to live at /articles. Bare "/articles" needs its
+        // own exact rule: :path* does NOT match zero segments here, so without
+        // this the index would 308 to the literal "/help/:path*" and 404.
+        source: "/articles",
+        destination: "/help",
+        permanent: true
+      },
+      {
+        // Sub-paths of the old Help Center. Only naked paths need handling: no
+        // non-default locale was live before the move.
         source: "/articles/:path*",
         destination: "/help/:path*",
         permanent: true

--- a/app/tests/unit/components/landing-page/MonthlyPrice.test.tsx
+++ b/app/tests/unit/components/landing-page/MonthlyPrice.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { MonthlyPrice } from "@/components/landing-page/MonthlyPrice";
+import type { PremiumPrices } from "@/lib/pricing";
+
+// Pin locale to en-US so tests don't depend on the developer's system locale
+const _OriginalNumberFormat = Intl.NumberFormat;
+jest.spyOn(Intl, "NumberFormat").mockImplementation((_, options) => new _OriginalNumberFormat("en-US", options));
+
+let mockPrices: PremiumPrices | null = null;
+
+jest.mock("@/lib/hooks/useExternalPremiumPrices", () => ({
+  useExternalPremiumPrices: () => mockPrices
+}));
+
+describe("MonthlyPrice", () => {
+  beforeEach(() => {
+    mockPrices = null;
+  });
+
+  it("renders a skeleton placeholder while the price is loading", () => {
+    render(<MonthlyPrice />);
+    const skeleton = screen.getByTestId("monthly-price-skeleton");
+    expect(skeleton).toBeInTheDocument();
+    // No possibly-wrong price text is shown before the real price resolves
+    expect(skeleton.textContent).toBe("");
+  });
+
+  it("renders the resolved price once loaded", () => {
+    mockPrices = { currency: "usd", monthly: 999, annual: 9900, country_code: null };
+    render(<MonthlyPrice />);
+    expect(screen.queryByTestId("monthly-price-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByText(/9\.99/)).toBeInTheDocument();
+  });
+});

--- a/app/tests/unit/config/next.config.test.ts
+++ b/app/tests/unit/config/next.config.test.ts
@@ -13,4 +13,24 @@ describe("Next.js Configuration", () => {
     expect(nextConfig).toBeDefined();
     expect(nextConfig.productionBrowserSourceMaps).toBe(false);
   });
+
+  it("redirects bare /articles to /help with an exact permanent rule ordered before the wildcard", async () => {
+    const redirects = await nextConfig.redirects!();
+
+    const exactIndex = redirects.findIndex((r) => r.source === "/articles");
+    const wildcardIndex = redirects.findIndex((r) => r.source === "/articles/:path*");
+
+    expect(exactIndex).toBeGreaterThanOrEqual(0);
+    expect(wildcardIndex).toBeGreaterThanOrEqual(0);
+    // The exact rule must win, so it has to come first: :path* does not match
+    // zero segments, so a bare /articles would otherwise 308 to the literal
+    // "/help/:path*" and 404.
+    expect(exactIndex).toBeLessThan(wildcardIndex);
+
+    expect(redirects[exactIndex]).toMatchObject({
+      source: "/articles",
+      destination: "/help",
+      permanent: true
+    });
+  });
 });


### PR DESCRIPTION
Three small independent fixes bundled together.

## 1. Landing monthly price: skeleton instead of \$9.99 fallback
`MonthlyPrice` previously rendered a hardcoded `landing.monthlyPrice.fallback` ("\$9.99") on SSR/first paint before the geolocated `/external/pricing` API resolved. Since that value can be wrong for the visitor's country, it now renders an inline shimmer skeleton (sized like a price so the sentence doesn't reflow when the real value arrives). No-JS visitors keep seeing the skeleton. Removed the `fallback` key from both `messages/en.json` and `messages/hu.json`.

## 2. Fix the bare /articles redirect
`:path*` does not match zero segments, so in production bare `/articles` 308'd to the literal `/help/:path*` and 404'd. Added an exact `/articles` -> `/help` permanent redirect ahead of the wildcard rule and corrected the stale comment.

## 3. Last i18n stragglers
- **useExerciseLoader**: the "Unknown error" fallback is now a catalog key (`codingExercise.unknownError`) resolved via `useTranslations`; real `Error.message`s still pass through. Updated `.context/i18n.md`'s deferred list (this was the last entry).
- **SubscriptionSuccessModal**: renewal date switched from bare `toLocaleDateString()` to `useFormatter().dateTime(...)` (short month/day/year), matching `useSubscription.ts`.
- **3c sweep** for hardcoded-locale date formatting: converted `PaymentHistoryRow` (`en-US` -> `useFormatter`) and `RecentBlogPosts` (`en-US` -> `useFormatter`, it already has locale context via `useLocaleRoutes`). Left two intentionally: `usePayments.ts` `formatDate` is a plain module-level helper producing a stable machine-parseable intermediate that `PaymentHistoryRow` re-parses (locale-formatting it would break re-parsing), and `lib/subscriptions/handlers.ts` fires from a plain (non-React) module context outside the named payment-history/blog scope.

## Tests
- New `MonthlyPrice.test.tsx` asserting the skeleton (testid) while loading and the resolved price once loaded.
- Extended `next.config.test.ts` to assert the exact `/articles` -> `/help` rule exists and is ordered before the wildcard.
- `hu` = English verbatim for new keys; the messages parity guard passes.

## Verification
- `pnpm typecheck` (monorepo root): passes
- Full app jest: 173 suites / 2085 tests pass
- ESLint + Prettier on touched files: clean
- Pre-commit hooks ran (never `--no-verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)