### PR TITLE
Filter five noise-only Sentry issues

### DIFF
--- a/app/components/ui/JikiMuxPlayer.tsx
+++ b/app/components/ui/JikiMuxPlayer.tsx
@@ -14,6 +14,17 @@ const MEDIA_ERR_NETWORK = 2;
 // like — rather than genuinely corrupt media or an actionable app bug.
 const MEDIA_ERR_DECODE = 3;
 
+// Mux's HTML5 media error code for an unsupported source (see
+// MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED). Mux's own message spells out the two
+// causes — "The server or network failed, or your browser does not support this
+// format." — and both are the viewer's environment, not our upload: a dropped
+// HLS manifest/segment fetch (transient network, same class as code 2) or a client
+// with no compatible rendition/codec (same class as code 3). A genuinely broken
+// asset fails Mux's encode step and never reaches the player, and would hit
+// effectively every viewer rather than one — asset health is tracked by Mux Data
+// dashboards, not Sentry. So treat code 4 like 2/3: log, but don't report.
+const MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
+
 // A Mux MediaError, carried on the error event's `detail`. It extends the native
 // MediaError with Mux-specific fields. Typed locally so we don't depend on the
 // playback-core internals just to read a few properties.
@@ -57,6 +68,15 @@ function defaultOnError(event: Event) {
   // H.264, in-app webviews) rather than corrupt media or an actionable app bug — log
   // them but keep them out of Sentry.
   if (code === MEDIA_ERR_DECODE) {
+    console.error(error);
+    return;
+  }
+
+  // Unsupported-source failures are a per-viewer environment problem (a dropped
+  // HLS fetch or a client with no compatible codec/rendition), not a broken upload —
+  // log them but keep them out of Sentry. See MEDIA_ERR_SRC_NOT_SUPPORTED above.
+  // JIKI-FRONT-END-3X (6 events / 1 user on a lesson video).
+  if (code === MEDIA_ERR_SRC_NOT_SUPPORTED) {
     console.error(error);
     return;
   }

--- a/app/instrumentation-client.ts
+++ b/app/instrumentation-client.ts
@@ -49,6 +49,27 @@ if (process.env.NODE_ENV === "production") {
       // A script download truncated by a dropped connection.
       "Unexpected end of script",
 
+      // Transient client-side fetch failures where the request never completed:
+      // the user navigated away mid-request, a mobile connection dropped, the device
+      // was offline, or an ad/tracking blocker killed the request. These carry no
+      // HTTP status and are not server bugs. Anchored so our own explicit
+      // HTTP-status errors — e.g. "Failed to fetch external pricing (500)" from
+      // lib/api/externalPricing.ts — still report.
+      // JIKI-FRONT-END-5 (Chromium wording, 423 events / 162 users).
+      /^Failed to fetch$/,
+      // JIKI-FRONT-END-9 (Firefox wording of the same failure, 40 events / 40 users).
+      /^NetworkError when attempting to fetch resource\.$/,
+
+      // A browser extension / password manager patches the WebAuthn API and tries to
+      // redefine a non-configurable property. Origin is <anonymous code>, not ours.
+      // JIKI-FRONT-END-3V (1 event, Firefox).
+      /can't redefine non-configurable property "isConditionalMediationAvailable"/,
+
+      // Firefox-internal media/network abort with no stack trace, raised from the
+      // browser's own input-stream handling rather than our code.
+      // JIKI-FRONT-END-3T (1 event, Firefox).
+      /^Error in input stream$/,
+
       // Injected document-level touch handlers; no first-party code reads .touches
       // (the scrubber uses pointer/mouse events).
       "Cannot read properties of undefined (reading 'touches')",

--- a/app/tests/unit/components/ui/JikiMuxPlayer.test.tsx
+++ b/app/tests/unit/components/ui/JikiMuxPlayer.test.tsx
@@ -47,13 +47,34 @@ describe("JikiMuxPlayer defaultOnError", () => {
     expect((logged as Error).message).toContain("muxCode 2000002");
   });
 
-  it("reports non-network errors with rich detail to Sentry", () => {
-    fireMuxError({ code: 4, muxCode: 2404000, message: "Source not supported." });
+  it("reports errors with rich detail (code, muxCode, message) to Sentry", () => {
+    // code 1 (MEDIA_ERR_ABORTED) is not one of the suppressed classes, so it takes
+    // the reporting path and exercises the full rich-detail message formatting.
+    fireMuxError({ code: 1, muxCode: 2400000, message: "Playback aborted." });
 
     expect(mockReportError).toHaveBeenCalledTimes(1);
     const reported = mockReportError.mock.calls[0][0] as Error;
     expect(reported).toBeInstanceOf(Error);
-    expect(reported.message).toBe("MuxPlayer error: code 4: muxCode 2404000: Source not supported.");
+    expect(reported.message).toBe("MuxPlayer error: code 1: muxCode 2400000: Playback aborted.");
+  });
+
+  it("does not report unsupported-source errors (code 4) to Sentry but still logs them", () => {
+    // code 4 (MEDIA_ERR_SRC_NOT_SUPPORTED) is a per-viewer environment problem
+    // (dropped HLS fetch or a client with no compatible codec/rendition), not a
+    // broken upload, so it stays out of Sentry. JIKI-FRONT-END-3X.
+    fireMuxError({
+      code: 4,
+      muxCode: 2404000,
+      message:
+        "An unsupported error occurred. The server or network failed, or your browser does not support this format."
+    });
+
+    expect(mockReportError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const [logged] = consoleErrorSpy.mock.calls[0];
+    expect(logged).toBeInstanceOf(Error);
+    expect((logged as Error).message).toContain("code 4");
+    expect((logged as Error).message).toContain("muxCode 2404000");
   });
 
   it("does not report decode errors to Sentry but still logs them", () => {
@@ -106,7 +127,25 @@ describe("JikiMuxPlayer defaultOnError", () => {
   });
 
   it("reads error info from event.target.error on the native-video fallback path", () => {
-    // No detail; the error hangs off the media element instead.
+    // No detail; the error hangs off the media element instead. code 1 (aborted)
+    // is not a suppressed class, so it takes the reporting path.
+    const target = document.createElement("video");
+    Object.defineProperty(target, "error", {
+      configurable: true,
+      value: { code: 1, message: "Playback aborted." }
+    });
+    const event = new Event("error");
+    Object.defineProperty(event, "target", { value: target });
+
+    capturedOnError?.(event);
+
+    expect(mockReportError).toHaveBeenCalledTimes(1);
+    expect((mockReportError.mock.calls[0][0] as Error).message).toBe("MuxPlayer error: code 1: Playback aborted.");
+  });
+
+  it("silences unsupported-source errors that arrive via event.target.error (native fallback path)", () => {
+    // The code-4 skip keys off the HTML5 `code`, present on both the Mux detail
+    // payload and the native MediaError, so this path is silenced too.
     const target = document.createElement("video");
     Object.defineProperty(target, "error", {
       configurable: true,
@@ -117,8 +156,8 @@ describe("JikiMuxPlayer defaultOnError", () => {
 
     capturedOnError?.(event);
 
-    expect(mockReportError).toHaveBeenCalledTimes(1);
-    expect((mockReportError.mock.calls[0][0] as Error).message).toBe("MuxPlayer error: code 4: Source not supported.");
+    expect(mockReportError).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
   });
 
   it("silences network errors that arrive via event.target.error (native fallback path)", () => {

--- a/app/tests/unit/instrumentation-client.test.ts
+++ b/app/tests/unit/instrumentation-client.test.ts
@@ -1,0 +1,71 @@
+// Verifies the noise filters wired into Sentry's client init. We mock Sentry.init
+// to capture the config it's given, then assert that the ignoreErrors matchers
+// catch the specific noise messages while leaving genuine, similar-looking errors
+// (e.g. our own HTTP-status fetch failures) reportable.
+
+type IgnoreMatcher = string | RegExp;
+
+const capturedInit: { options?: { ignoreErrors?: IgnoreMatcher[] } } = {};
+
+jest.mock("@sentry/nextjs", () => ({
+  init: (options: { ignoreErrors?: IgnoreMatcher[] }) => {
+    capturedInit.options = options;
+  },
+  captureException: jest.fn(),
+  captureRouterTransitionStart: jest.fn()
+}));
+
+// Replicates how Sentry's ignoreErrors decides whether a message is dropped: a
+// string entry is a substring match, a RegExp entry is a `.test()` match.
+function isIgnored(message: string, matchers: IgnoreMatcher[]): boolean {
+  return matchers.some((m) => (typeof m === "string" ? message.includes(m) : m.test(message)));
+}
+
+describe("instrumentation-client Sentry ignoreErrors", () => {
+  let ignoreErrors: IgnoreMatcher[];
+
+  beforeAll(async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    // Sentry.init only runs in production, so force it for this import.
+    Object.defineProperty(process.env, "NODE_ENV", { value: "production", configurable: true });
+    await jest.isolateModulesAsync(async () => {
+      await import("@/instrumentation-client");
+    });
+    Object.defineProperty(process.env, "NODE_ENV", { value: originalNodeEnv, configurable: true });
+    ignoreErrors = capturedInit.options?.ignoreErrors ?? [];
+  });
+
+  it("initialises Sentry with an ignoreErrors list", () => {
+    expect(ignoreErrors.length).toBeGreaterThan(0);
+  });
+
+  // JIKI-FRONT-END-5 (Chromium) and JIKI-FRONT-END-9 (Firefox): transient
+  // client-side fetch failures where the request never completed.
+  it("ignores transient fetch failures (Chromium and Firefox wording)", () => {
+    expect(isIgnored("Failed to fetch", ignoreErrors)).toBe(true);
+    expect(isIgnored("NetworkError when attempting to fetch resource.", ignoreErrors)).toBe(true);
+  });
+
+  it("still reports our own HTTP-status fetch errors", () => {
+    // externalPricing.ts throws this on a real server error; the anchored matcher
+    // must not swallow it.
+    expect(isIgnored("Failed to fetch external pricing (500)", ignoreErrors)).toBe(false);
+  });
+
+  // JIKI-FRONT-END-3V: extension/password-manager patching the WebAuthn API.
+  it("ignores the WebAuthn non-configurable-property redefinition", () => {
+    expect(
+      isIgnored('TypeError: can\'t redefine non-configurable property "isConditionalMediationAvailable"', ignoreErrors)
+    ).toBe(true);
+  });
+
+  // JIKI-FRONT-END-3T: Firefox-internal media/network abort.
+  it("ignores the Firefox internal input-stream error", () => {
+    expect(isIgnored("Error in input stream", ignoreErrors)).toBe(true);
+  });
+
+  it("does not ignore unrelated genuine errors", () => {
+    expect(isIgnored("Cannot read properties of undefined (reading 'user')", ignoreErrors)).toBe(false);
+    expect(isIgnored("Something in the input stream broke unexpectedly for real", ignoreErrors)).toBe(false);
+  });
+});


### PR DESCRIPTION
Stops five production Sentry issues that are noise — transient client network failures, browser-extension injection, and unsupported-media errors — from being reported. These are the viewer's environment, not actionable app bugs. Deliberately scoped to just these five; handled-4xx capture, ApiError fingerprinting, and the 1E/3S issues are a separate follow-up.

## Filtered issues

Message-based `ignoreErrors` matchers in `app/instrumentation-client.ts` (matches the existing pattern in that file), each anchored so it can't swallow unrelated genuine errors:

| Issue | Message | Events / Users | Rationale |
| --- | --- | --- | --- |
| JIKI-FRONT-END-5 | `TypeError: Failed to fetch` (Chromium) | 423 / 162 | Transient client-side fetch that never completed (navigated away, mobile drop, offline, ad/tracking blocker). No HTTP status; not a server bug. |
| JIKI-FRONT-END-9 | `TypeError: NetworkError when attempting to fetch resource.` (Firefox) | 40 / 40 | Same root cause as #5, Firefox wording; no stacktrace. |
| JIKI-FRONT-END-3V | `can't redefine non-configurable property "isConditionalMediationAvailable"` | 1 / — | A browser extension / password manager patching the WebAuthn API. Origin is `<anonymous code>`, not our code. |
| JIKI-FRONT-END-3T | `Error in input stream` | 1 / — | Firefox-internal media/network abort with no stacktrace, from the browser's own input-stream handling. |
| JIKI-FRONT-END-3X | `MuxPlayer error: code 4: ...unsupported error...` | 6 / 1 | Mux code 4 (`MEDIA_ERR_SRC_NOT_SUPPORTED`) — see below. |

The `Failed to fetch` matcher is anchored (`/^Failed to fetch$/`) so our own explicit HTTP-status errors — e.g. `Failed to fetch external pricing (500)` from `lib/api/externalPricing.ts` — still report.

## The 3X decision (Mux code 4)

`JikiMuxPlayer.tsx` already keeps transient Mux **network** (code 2) and **decode** (code 3) failures out of Sentry. Code 4 (`MEDIA_ERR_SRC_NOT_SUPPORTED`) slipped through because it wasn't classified. I concluded it **should** be suppressed too, and implemented it alongside 2/3 (log to console, don't report):

- Mux's own message documents code 4's two causes: *"The server or network failed, or your browser does not support this format."* Both are the viewer's environment — a dropped HLS manifest/segment fetch (same class as code 2) or a client with no compatible rendition/codec (same class as code 3).
- A genuinely broken upload fails Mux's encode step and never reaches the player, and would hit essentially **every** viewer. The observed signature here (6 events / 1 user) is a single viewer's environment, not a broken asset.
- Asset health is tracked by Mux Data dashboards, not Sentry, and the client has no HTTP status to distinguish transient from permanent — so a nuanced "only if transient" split isn't feasible. Suppressing code 4 consistently with 2/3 is the most defensible call.

## Tests

- Extended `app/tests/unit/components/ui/JikiMuxPlayer.test.tsx`: code 4 (via detail and via native `target.error`) is suppressed + logged; the rich-detail reporting path is re-pointed at code 1 (an unsuppressed class).
- New `app/tests/unit/instrumentation-client.test.ts`: asserts the four message matchers catch their noise strings and do **not** swallow our `(500)` fetch error or unrelated errors.

`pnpm typecheck` (root) passes; full app unit suite (2090 tests) passes via the pre-commit hook; ESLint clean on changed files.

Fixes JIKI-FRONT-END-5
Fixes JIKI-FRONT-END-9
Fixes JIKI-FRONT-END-3V
Fixes JIKI-FRONT-END-3T
Fixes JIKI-FRONT-END-3X

🤖 Generated with [Claude Code](https://claude.com/claude-code)