### PR TITLE
Guard empty-editor code submissions against 422

### DIFF
--- a/app/components/coding-exercise/lib/Orchestrator.ts
+++ b/app/components/coding-exercise/lib/Orchestrator.ts
@@ -332,7 +332,7 @@ class Orchestrator {
 
   async runCode() {
     // Get the current code from the editor
-    const currentCode = this.getCurrentEditorValue() || this.store.getState().code;
+    const currentCode = this.getCurrentEditorValue() || this.store.getState().code || "";
 
     // Delegate to TestSuiteManager with exercise definition
     // This automatically plays the first scenario.

--- a/app/tests/unit/components/coding-exercise/orchestrator/Orchestrator.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/Orchestrator.test.ts
@@ -848,5 +848,34 @@ describe("Orchestrator", () => {
       // Should use store code
       expect(mockRunCode).toHaveBeenCalledWith("store code", exercise);
     });
+
+    it("should submit an empty string (never undefined) when both editor value and store code are empty", async () => {
+      // Regression test for JIKI-FRONT-END-3S: hammering run with an empty editor
+      // before the store code was populated sent `code: undefined`, which JSON.stringify
+      // drops, so the API received no `code` and returned 422. runCode() must always
+      // pass a string to the submission pipeline.
+      const exercise = createMockExercise({
+        slug: "test-uuid",
+        stubs: { javascript: "", python: "", jikiscript: "" }
+      });
+      const orchestrator = makeTestOrchestrator(exercise);
+
+      // Editor manager not mounted -> undefined; store code forced to undefined to
+      // reproduce the pre-initialisation state seen in production.
+      jest.spyOn(orchestrator as any, "getCurrentEditorValue").mockReturnValue(undefined);
+      orchestrator.getStore().setState({ code: undefined as unknown as string });
+
+      const testSuiteManager = (orchestrator as any).testSuiteManager;
+      const mockRunCode = jest.spyOn(testSuiteManager, "runCode").mockResolvedValue(undefined);
+      jest.spyOn(orchestrator, "play").mockImplementation(() => {});
+
+      await orchestrator.runCode();
+
+      expect(mockRunCode).toHaveBeenCalledWith("", exercise);
+      const submittedCode = mockRunCode.mock.calls[0][0];
+      expect(submittedCode).toBe("");
+      expect(submittedCode).not.toBeUndefined();
+      expect(submittedCode).not.toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Problem

Students hammering the run button with an empty editor could trigger a 422 from the exercise submission endpoint (motivating report: JIKI-FRONT-END-3S).

Root cause in `Orchestrator.runCode()`:

```ts
const currentCode = this.getCurrentEditorValue() || this.store.getState().code;
```

`getCurrentEditorValue()` returns `string | undefined` (undefined when the editor manager isn't mounted; `""` for an empty editor). An empty `""` is falsey, so it falls through to `store.getState().code`, which can itself be `undefined` before the store's code is initialised. `currentCode` then becomes `undefined`, flows into `TestSuiteManager.submitExerciseFiles`, and `JSON.stringify` drops the undefined value so the request arrives with no `code` — the API returns 422.

## Fix

Append `|| ""` so `currentCode` is always a string, matching the guard already used in `useChat.ts`:

```ts
const currentCode = this.getCurrentEditorValue() || this.store.getState().code || "";
```

Both the lesson and challenge submission paths funnel through `runCode()` -> `TestSuiteManager.submitExerciseFiles`, so this single guard covers both. `useChat.ts` already had the equivalent guard, and no other caller of `submitExerciseFiles`/`runCode` has the gap.

## Tests

Adds an Orchestrator regression test asserting that when both the editor value and store code are empty/undefined, `runCode()` submits `code: ""` (never `undefined`/`null`).

- `pnpm typecheck` passes
- Orchestrator + TestSuiteManager suites pass (49 tests)
- ESLint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)