### PR TITLE
Allow *.jiki.io in CSP media-src so landing-page videos load

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -18,7 +18,7 @@ function setCSP(response: NextResponse): void {
     style-src 'self' 'unsafe-inline' https://*.jiki.io https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self' https://*.jiki.io;
-    media-src 'self' blob: https://*.mux.com;
+    media-src 'self' blob: https://*.jiki.io https://*.mux.com;
     connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
     frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
     worker-src 'self' blob:;


### PR DESCRIPTION
## Problem

All `<video>` elements on https://jiki.io/ are blocked with:

> Loading media from 'https://assets.jiki.io/...' violates the following Content Security Policy directive: "media-src 'self' blob: https://*.mux.com"

The landing-page MP4s are served from the fingerprinted asset host (`assets.jiki.io`), but `media-src` was never updated when assets moved there. The files themselves are fine (200, `video/mp4`, byte-identical to the repo). `img-src` already allows `https://*.jiki.io`, which is why images work.

## Fix

Add `https://*.jiki.io` to `media-src` in `app/middleware.ts`, matching the other directives.

## Test plan

- [ ] Load https://jiki.io/ after deploy and confirm the hero/landing videos autoplay with no CSP errors in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyqyVMmwD5Zax9iTxdTTwo