### PR TITLE
Fetch llm-chat exercise content from assets cache tree

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -163,8 +163,8 @@ If you need an arbitrary color, always confirm with the user first, explaining w
 Exercise content (title, description, instructions, stubs, solutions) is served as static JSON files, separate from the exercise modules in `@jiki/curriculum`.
 
 - **Build script**: `scripts/generate-exercise-cache.js` reads curriculum source files and produces:
-  - `public/static/exercises/{locale}-{hash}.json` — metadata index (all exercises, slug/title/description/contentHashes)
-  - `public/static/exercises/{slug}/{locale}-{language}-{hash}.json` — content files (instructions, stub, solution)
+  - `public/static/exercises/{locale}/index-{hash}.json` — metadata index (all exercises, slug/title/description/contentHashes)
+  - `public/static/exercises/{slug}/{locale}/{language}/content-{hash}.json` — content files (instructions, stub, solution)
   - `lib/generated/exercise-hashes.ts` — hash manifest for the app to construct index URLs
 - **Client API**: `lib/api/exercise-meta.ts` provides `getExerciseMeta()`, `getExerciseMetaBySlugs()`, and `fetchExerciseContent()` with module-level caching
 - **Exercise loading**: `useExerciseLoader` loads the exercise module (ExerciseCore) and static content in parallel, then assembles into `ExerciseDefinition`

--- a/app/app/dev/llm-chat/page.tsx
+++ b/app/app/dev/llm-chat/page.tsx
@@ -43,6 +43,7 @@ export default function LLMChatTestPage() {
   const [selectedExercise, setSelectedExercise] = useState<string>("maze-solve-basic");
   const [selectedLanguage, setSelectedLanguage] = useState<"javascript" | "python" | "jikiscript">("jikiscript");
   const [code, setCode] = useState<string>("");
+  const [contentHash, setContentHash] = useState<string>("");
   const [isLoadingExercise, setIsLoadingExercise] = useState(false);
   const [availableTasks, setAvailableTasks] = useState<Array<{ id: string; name: string }>>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string>("");
@@ -73,6 +74,7 @@ export default function LLMChatTestPage() {
         const content = await fetchExerciseContent(slug, "en", selectedLanguage);
         const starterCode = content.stub || "// Write your code here";
         setCode(starterCode);
+        setContentHash(content.contentHash);
 
         // Load available tasks
         const tasks = exercise.tasks.map((task) => ({
@@ -85,6 +87,7 @@ export default function LLMChatTestPage() {
       } catch (err) {
         console.error("Failed to load exercise:", err);
         setCode("// Failed to load exercise code");
+        setContentHash("");
         setAvailableTasks([]);
         setSelectedTaskId("");
       } finally {
@@ -142,7 +145,8 @@ export default function LLMChatTestPage() {
       history: history.slice(-5), // Last 5 messages
       nextTaskId: selectedTaskId || undefined, // Only include if set
       language: selectedLanguage,
-      contentHash: ""
+      locale: "en",
+      contentHash
     };
 
     addDebugEvent("request", requestPayload);

--- a/app/components/coding-exercise/lib/chatApi.ts
+++ b/app/components/coding-exercise/lib/chatApi.ts
@@ -10,7 +10,8 @@ export interface ChatRequestPayload {
   language: string;
   history: ChatMessage[];
   nextTaskId?: string;
-  contentHash: string; // Hash for Worker to fetch exercise content from app's static files
+  locale: string; // Locale segment of the content path the Worker fetches
+  contentHash: string; // Hash for Worker to fetch exercise content from the assets cache tree
 }
 
 export interface StreamCallbacks {

--- a/app/components/coding-exercise/lib/useChat.ts
+++ b/app/components/coding-exercise/lib/useChat.ts
@@ -66,6 +66,7 @@ export function useChat(orchestrator: Orchestrator) {
           language: context.language,
           history: chatState.messages,
           nextTaskId: context.currentTaskId || undefined,
+          locale: context.locale,
           contentHash: context.contentHash
         },
         {

--- a/app/components/coding-exercise/lib/useChatContext.ts
+++ b/app/components/coding-exercise/lib/useChatContext.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useLocale } from "next-intl";
 import type Orchestrator from "./Orchestrator";
 import type { ExerciseContext } from "./types";
 
@@ -9,11 +10,16 @@ export interface ChatContext {
   exerciseInstructions: string;
   currentTaskId: string | null;
   language: string;
+  locale: string; // Locale the exercise content was loaded for (path segment of the content URL)
   contentHash: string; // Hash for fetching exercise content from static files
   exercise: any; // Full exercise object
 }
 
 export function useChatContext(orchestrator: Orchestrator): ChatContext {
+  // The orchestrator's contentHash was resolved for the active UI locale (see
+  // useExerciseLoader), so the same locale must accompany it to the proxy.
+  const locale = useLocale();
+
   return useMemo(() => {
     const exercise = orchestrator.getExercise();
     const storeState = orchestrator.getStore().getState();
@@ -25,8 +31,9 @@ export function useChatContext(orchestrator: Orchestrator): ChatContext {
       exerciseInstructions: orchestrator.getExerciseInstructions(),
       currentTaskId: storeState.currentTaskId,
       language: storeState.language,
+      locale,
       contentHash: orchestrator.contentHash,
       exercise
     };
-  }, [orchestrator]);
+  }, [orchestrator, locale]);
 }

--- a/app/tests/unit/components/coding-exercise/chatApi-refresh.test.ts
+++ b/app/tests/unit/components/coding-exercise/chatApi-refresh.test.ts
@@ -54,6 +54,7 @@ describe("Chat API JWT Authentication", () => {
     question: "How does this work?",
     language: "javascript",
     history: [],
+    locale: "en",
     contentHash: "test-hash"
   };
 

--- a/app/tests/unit/components/coding-exercise/useChat-token.test.tsx
+++ b/app/tests/unit/components/coding-exercise/useChat-token.test.tsx
@@ -57,6 +57,7 @@ describe("useChat token management", () => {
       language: "javascript",
       exerciseTitle: "Test Exercise",
       exerciseInstructions: "Test instructions",
+      locale: "en",
       contentHash: "test-hash",
       exercise: { slug: "test-exercise", tasks: [] }
     });

--- a/llm-chat-proxy/src/index.ts
+++ b/llm-chat-proxy/src/index.ts
@@ -115,7 +115,7 @@ app.post("/chat", async (c) => {
 
     // 2. Parse request
     const body = await c.req.json<ChatRequest>();
-    const { exerciseSlug, code, question, history = [], nextTaskId, language, contentHash } = body;
+    const { exerciseSlug, code, question, history = [], nextTaskId, language, contentHash, locale = "en" } = body;
 
     if (exerciseSlug === undefined || code === undefined || question === undefined || language === undefined) {
       return c.json({ error: "Missing required fields: exerciseSlug, code, question, language" }, 400);
@@ -137,16 +137,25 @@ app.post("/chat", async (c) => {
       );
     }
 
-    // 3. Fetch exercise content from app's static files and build prompt.
+    // 2c. Validate locale/hash shape. Both are interpolated into the content URL,
+    // so reject anything that could smuggle in path segments or query strings.
+    if (!/^[a-z0-9-]{2,20}$/i.test(locale) || !/^[a-f0-9]{6,64}$/i.test(contentHash)) {
+      return c.json({ error: "Invalid locale or contentHash" }, 400);
+    }
+
+    // 3. Fetch exercise content from the assets cache tree and build prompt.
     //
-    // In production we ALWAYS fetch from our own static bucket. The Origin header
-    // is client-controlled (only browsers are forced to send a truthful value),
-    // so trusting it in production would let a direct API caller point us at
-    // arbitrary/oversized JSON. The header is only honoured in development so
-    // local testing can hit localhost.
+    // In production we ALWAYS fetch from the persistent R2 asset host
+    // (assets.jiki.io) that serves the content-hashed cache tree — the same
+    // files the app itself loads (see app/lib/assets-paths.ts for the layout).
+    // The Origin header is client-controlled (only browsers are forced to send
+    // a truthful value), so trusting it in production would let a direct API
+    // caller point us at arbitrary/oversized JSON. The header is only honoured
+    // in development so local testing can hit the local Next server, which
+    // serves the same paths relatively from public/.
     const isDev = process.env.NODE_ENV === "development";
-    const origin = isDev ? c.req.header("Origin") || "https://jiki.io" : "https://jiki.io";
-    const contentUrl = `${origin}/static/exercises/${exerciseSlug}/en-${language}-${contentHash}.json`;
+    const origin = isDev ? c.req.header("Origin") || "https://assets.jiki.io" : "https://assets.jiki.io";
+    const contentUrl = `${origin}/static/exercises/${exerciseSlug}/${locale}/${language}/content-${contentHash}.json`;
 
     const { systemInstruction, prompt } = await buildPrompt({
       exerciseSlug,

--- a/llm-chat-proxy/src/types.ts
+++ b/llm-chat-proxy/src/types.ts
@@ -7,7 +7,8 @@ export interface ChatRequest {
   history?: ChatMessage[];
   nextTaskId?: string;
   language: Language;
-  contentHash: string; // Hash for fetching exercise content from app's static files
+  contentHash: string; // Hash for fetching exercise content from the assets cache tree
+  locale?: string; // Locale segment of the content path; defaults to "en" for older clients
 }
 
 export interface ChatMessage {

--- a/llm-chat-proxy/tests/prompt-builder.test.ts
+++ b/llm-chat-proxy/tests/prompt-builder.test.ts
@@ -8,7 +8,7 @@ const mockContent = {
   solution: "move_right()\nmove_down()\nmove_right()"
 };
 
-const CONTENT_URL = "https://jiki.io/static/exercises/maze-solve-basic/en-jikiscript-abc123.json";
+const CONTENT_URL = "https://assets.jiki.io/static/exercises/maze-solve-basic/en/jikiscript/content-abc123def456.json";
 
 // Mock global fetch for content URL requests
 beforeEach(() => {


### PR DESCRIPTION
## Problem

Ask Jiki chat requests were 500ing:

```
Failed to fetch exercise content from https://jiki.io/static/exercises/space-invaders-solve-basic/en-javascript-6b2676ca320d.json: 404
```

The llm-chat proxy still built the pre-R2 flat content URL (`jiki.io/static/exercises/{slug}/en-{language}-{hash}.json`). The exercise cache tree has since moved to the persistent R2 asset host with a directory-per-dimension layout (see `app/lib/assets-paths.ts`). The hash the client sent was correct, only the proxy's URL construction was stale.

## Changes

- **Proxy** now fetches `https://assets.jiki.io/static/exercises/{slug}/{locale}/{language}/content-{hash}.json`. In dev it still honours the Origin header so it hits the local Next server. Locale and hash are shape-validated before being interpolated into the URL.
- **App** sends the active UI locale alongside `contentHash` (the hash is locale-specific, resolved in `useExerciseLoader`). The proxy defaults to `en` for older clients that don't send it.
- **/dev/llm-chat** now sends the real `contentHash` it already fetched instead of an empty string (which the proxy rejects with a 400).
- Updated the stale cache-layout paths in `app/AGENTS.md`.

## Verification

- Regenerated the local cache: the hash for `space-invaders-solve-basic` en/javascript is `6b2676ca320d`, matching the failing request.
- Fetched `https://assets.jiki.io/static/exercises/space-invaders-solve-basic/en/javascript/content-6b2676ca320d.json` and confirmed the body is the real content JSON.
- `llm-chat-proxy` tests (86), chat-related app tests, and `tsc` all pass.

## Deploy note

The Worker deploys separately (`pnpm deploy` in `llm-chat-proxy/`) - merging this does not ship the proxy fix on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwcKcSTEcJWijemy2r7nRi