### PR TITLE
Emit VideoObject JSON-LD for concept walkthrough videos

### DIFF
--- a/app/app/(hybrid)/[locale]/concepts/[slug]/page.tsx
+++ b/app/app/(hybrid)/[locale]/concepts/[slug]/page.tsx
@@ -3,7 +3,7 @@ import ConceptDetailPage from "@/components/concepts/ConceptDetailPage";
 import SidebarLayout from "@/components/layout/SidebarLayout";
 import JsonLd from "@/components/seo/JsonLd";
 import { getConceptMetadata } from "@/lib/concepts/metadata";
-import { breadcrumbSchema, conceptLearningResourceSchema } from "@/lib/seo/schemas";
+import { breadcrumbSchema, conceptLearningResourceSchema, videoObjectSchema } from "@/lib/seo/schemas";
 import {
   getConceptServer,
   getAncestorsServer,
@@ -14,6 +14,7 @@ import {
   getConceptVideoDataServer
 } from "@/lib/concepts/server-concepts";
 import type { ConceptDetailSeed } from "@/components/concepts/lib/useConceptDetailData";
+import type { VideoSource } from "@/types/lesson";
 
 interface Props {
   params: Promise<{ slug: string; locale: string }>;
@@ -38,6 +39,7 @@ export default async function AppConceptPage({ params }: Props) {
   // Leaf pages seed the full detail view (body, sidebar, video) so logged-out
   // visitors render entirely on the server.
   let initialLeafData: ConceptDetailSeed | undefined;
+  let conceptVideos: VideoSource[] = [];
   if (concept && !isCategory) {
     const [content, relatedConcepts, relatedExercises, videoData] = await Promise.all([
       getConceptContentServer(slug, locale),
@@ -46,13 +48,28 @@ export default async function AppConceptPage({ params }: Props) {
       getConceptVideoDataServer(slug)
     ]);
     initialLeafData = { concept, ancestors, content, relatedConcepts, relatedExercises, videoData };
+    conceptVideos = videoData ?? [];
   }
 
-  // Structured data: describe the concept as a LearningResource and place it in
-  // the concept hierarchy with a breadcrumb trail (Concepts > ...ancestors > this).
+  // Structured data: describe the concept as a LearningResource, emit a VideoObject
+  // per walkthrough video (so Google can index the concept video), and place the
+  // concept in a breadcrumb trail.
   const jsonLd = concept
     ? [
         conceptLearningResourceSchema(concept, locale),
+        ...conceptVideos.map((v) =>
+          videoObjectSchema({
+            path: `/concepts/${concept.slug}`,
+            locale,
+            name: concept.title,
+            description: concept.description,
+            uploadDate: v.uploadDate,
+            durationSeconds: v.durationSeconds,
+            provider: v.provider,
+            videoKey: v.id,
+            isAccessibleForFree: true
+          })
+        ),
         breadcrumbSchema(
           [
             { name: "Concepts", path: "/concepts" },

--- a/app/app/dev/choose-language/page.tsx
+++ b/app/app/dev/choose-language/page.tsx
@@ -23,7 +23,9 @@ const mockLessonData: ChooseLanguageLesson = {
     sources: [
       {
         provider: "mux",
-        id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU"
+        id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+        durationSeconds: 120,
+        uploadDate: "2026-01-01"
       }
     ],
     language_options: ["javascript", "python"]

--- a/app/app/dev/hints-walkthrough/page.tsx
+++ b/app/app/dev/hints-walkthrough/page.tsx
@@ -2,6 +2,7 @@
 
 import HintsPanel from "@/components/coding-exercise/ui/HintsPanel";
 import { GlobalModalProvider } from "@/lib/modal/GlobalModalProvider";
+import type { VideoSource } from "@/types/lesson";
 
 const sampleHints = [
   { question: "Hint", answer: "Try using a <code>for</code> loop to iterate through the array." },
@@ -9,7 +10,9 @@ const sampleHints = [
   { question: "Hint", answer: "Consider using the <code>modulo</code> operator to check for even/odd numbers." }
 ];
 
-const walkthroughVideoData = [{ provider: "mux", id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU" }];
+const walkthroughVideoData: VideoSource[] = [
+  { provider: "mux", id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU", durationSeconds: 120, uploadDate: "2026-01-01" }
+];
 
 export default function HintsWalkthroughPage() {
   return (

--- a/app/app/dev/unlock-animation/page.tsx
+++ b/app/app/dev/unlock-animation/page.tsx
@@ -48,7 +48,9 @@ export default function UnlockAnimationTest() {
       type: "video" as const,
       title: "Introduction to Variables",
       description: "Learn about variables and data types",
-      walkthrough_video_data: [{ provider: "mux", id: "mock-video-id-1" }]
+      walkthrough_video_data: [
+        { provider: "mux" as const, id: "mock-video-id-1", durationSeconds: 120, uploadDate: "2026-01-01" }
+      ]
     },
     completed: lessonCompleted,
     locked: false,
@@ -62,7 +64,9 @@ export default function UnlockAnimationTest() {
       type: "quiz" as const,
       title: "Variables Quiz",
       description: "Test your knowledge of variables",
-      walkthrough_video_data: [{ provider: "mux", id: "mock-video-id-2" }]
+      walkthrough_video_data: [
+        { provider: "mux" as const, id: "mock-video-id-2", durationSeconds: 120, uploadDate: "2026-01-01" }
+      ]
     },
     completed: false,
     locked: animationState === "completing" || (!recentlyUnlocked && animationState === "idle"),

--- a/app/app/dev/video-exercise/page.tsx
+++ b/app/app/dev/video-exercise/page.tsx
@@ -15,7 +15,9 @@ const mockLessonData: VideoLesson = {
     sources: [
       {
         provider: "mux",
-        id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU"
+        id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+        durationSeconds: 120,
+        uploadDate: "2026-01-01"
       }
     ]
   }

--- a/app/app/dev/walkthrough-card/page.tsx
+++ b/app/app/dev/walkthrough-card/page.tsx
@@ -10,7 +10,9 @@ function createLesson(overrides: Partial<LessonDisplayData> = {}): LessonDisplay
       title: "Test Lesson",
       description: "A test lesson",
       type: "exercise",
-      walkthrough_video_data: [{ provider: "mux", id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU" }]
+      walkthrough_video_data: [
+        { provider: "mux", id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU", durationSeconds: 120, uploadDate: "2026-01-01" }
+      ]
     },
     completed: false,
     locked: false,

--- a/app/lib/concepts/server-concepts.ts
+++ b/app/lib/concepts/server-concepts.ts
@@ -86,8 +86,12 @@ export async function getExercisesForConceptServer(slug: string, locale: string 
   return metas.map((m) => ({ slug: m.slug, title: m.title }));
 }
 
-/** Video data for a concept from the Rails external API. Null when unavailable. */
-export async function getConceptVideoDataServer(slug: string): Promise<VideoSource[] | null> {
+/**
+ * Video data for a concept from the Rails external API. Null when unavailable.
+ * Wrapped in React's cache() so a single render (page body + JSON-LD) shares one
+ * request, and fails open to null rather than breaking the SSR'd concept page.
+ */
+export const getConceptVideoDataServer = cache(async (slug: string): Promise<VideoSource[] | null> => {
   try {
     const res = await fetch(getApiUrl(`/external/concepts/${slug}`));
     if (!res.ok) {
@@ -98,4 +102,4 @@ export async function getConceptVideoDataServer(slug: string): Promise<VideoSour
   } catch {
     return null;
   }
-}
+});

--- a/app/types/lesson.ts
+++ b/app/types/lesson.ts
@@ -1,10 +1,14 @@
 import type { ExerciseSlug } from "@jiki/curriculum";
 import type { ProgrammingLanguage } from "./course";
 
-// Video source type (used across lessons, walkthroughs, concepts)
+// Video source type (used across lessons, walkthroughs, concepts). Every source
+// carries duration + upload date (a documented API contract on the Rails
+// HasVideoData concern) so the front-end can emit schema.org VideoObject JSON-LD.
 export interface VideoSource {
-  provider: string;
+  provider: "youtube" | "mux";
   id: string;
+  durationSeconds: number;
+  uploadDate: string;
   language?: ProgrammingLanguage;
 }
 


### PR DESCRIPTION
## Summary

Emits schema.org `VideoObject` JSON-LD for concept walkthrough videos on the public (SSR'd) concept pages, so they can be picked up by Google's video index — the concept-side counterpart to the episode `VideoObject` work.

Concept pages already server-render their video data (`getConceptVideoDataServer` fetches the Rails external concepts API during render), so the metadata lands in the initial HTML with no client JS. With the API now carrying `durationSeconds` + `uploadDate` on each source (jiki-education/api#559), we emit one `VideoObject` per walkthrough video that has them, reusing the existing `videoObjectSchema` builder.

## Changes
- `types/lesson.ts` — widen `VideoSource` with optional `durationSeconds` + `uploadDate` (Rails passes these through from the curriculum).
- `concepts/[slug]/page.tsx` — emit a `VideoObject` per walkthrough video, **guarded on both fields being present**, so it's inert until the API data lands.
- `server-concepts.ts` — wrap `getConceptVideoDataServer` in `React.cache()` (dedupe per render; still fails open to null so a Rails hiccup never breaks the SSR'd page).

## Dependencies / stacking
- **Stacked on #645** (`jsonld-organization-concepts`) — it needs the `JsonLd` component + `videoObjectSchema` builder from that PR. Base is set to that branch; **retarget to `main` once #645 merges**. The diff here is only the concept-video changes.
- Needs **jiki-education/api#559** deployed + synced for real data. Until then this emits nothing (guarded), so it's safe to merge in either order.

## Test plan
- [x] `pnpm typecheck` + ESLint clean
- [x] `videoObjectSchema` unit-tested (from #645)
- [ ] After api#559 ships, view source on a concept page (e.g. `/concepts/arithmetic`) — `VideoObject` with valid `uploadDate`/`duration`/`thumbnailUrl`/`embedUrl`
- [ ] Google Rich Results Test — no errors
