### PR TITLE
[WIP] Project-builder prototype: agentic browser-based project editor

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -75,3 +75,4 @@ app/test-results/
 
 # Sentry Config File
 .env.sentry-build-plugin
+.envrc

--- a/app/app/dev/layout.tsx
+++ b/app/app/dev/layout.tsx
@@ -1,0 +1,10 @@
+// Tailwind lives in app.css, which is otherwise only loaded by the (app)
+// layout (external/hybrid public pages are deliberately Tailwind-free - see
+// PR #783). The /dev tooling pages sit outside (app) but are built with
+// Tailwind, so pull app.css in here to give every dev page the full utility
+// layer without re-enabling it for the public pages.
+import "../app.css";
+
+export default function DevLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return children;
+}

--- a/app/app/dev/project-builder/api/llm/route.ts
+++ b/app/app/dev/project-builder/api/llm/route.ts
@@ -1,0 +1,35 @@
+// Dev-only streaming relay for LLM providers that don't support browser CORS
+// (OpenCode Zen). The client posts the upstream URL + an OpenAI-compatible
+// body; we forward with the Authorization header and stream the response
+// straight back. Lives under /dev so the middleware's production 404 for
+// /dev/* routes guards it automatically.
+
+const ALLOWED_UPSTREAMS = ["https://opencode.ai/zen/v1/chat/completions"];
+
+export async function POST(request: Request): Promise<Response> {
+  if (process.env.NODE_ENV === "production") {
+    return new Response(null, { status: 404 });
+  }
+
+  const { upstreamUrl, ...body } = (await request.json()) as { upstreamUrl?: string } & Record<string, unknown>;
+  if (!upstreamUrl || !ALLOWED_UPSTREAMS.includes(upstreamUrl)) {
+    return Response.json({ error: { message: `Upstream not allowed: ${upstreamUrl}` } }, { status: 400 });
+  }
+
+  const upstream = await fetch(upstreamUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: request.headers.get("authorization") ?? ""
+    },
+    body: JSON.stringify(body)
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("content-type") ?? "text/event-stream",
+      "Cache-Control": "no-cache"
+    }
+  });
+}

--- a/app/app/dev/project-builder/page.tsx
+++ b/app/app/dev/project-builder/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import ProjectBuilder from "@/components/project-builder/ProjectBuilder";
+import type { LessonConfig } from "@/components/project-builder/lib/types";
+
+const LESSON: LessonConfig = {
+  slug: "dev-personal-homepage",
+  title: "Your personal homepage",
+  instructions: `The learner is building their first personal homepage from a minimal starting point. The arc: a headline about themselves, some styling (colors, fonts, spacing), and a fun interactive button that fires confetti. They have never written code before this course.`,
+  agentGuidance: `Start by asking what they want their homepage to say about them. Good early steps: changing the headline text, picking colors, adding a short "about me" paragraph. The confetti button is a later reward - it needs a main.js wired up as a module and the canvas-confetti library.`,
+  startingFiles: {
+    "index.html": `<!doctype html>
+<html>
+  <head>
+    <title>My homepage</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <h1>Welcome</h1>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>
+`,
+    "style.css": `body {
+  font-family: sans-serif;
+  margin: 40px;
+}
+`,
+    "main.js": `// Your JavaScript will go here.
+`
+  },
+  allowedLibraries: [{ name: "canvas-confetti", path: "/static/vendor/canvas-confetti-1.9.3.mjs" }]
+};
+
+export default function ProjectBuilderDevPage() {
+  return <ProjectBuilder lesson={LESSON} />;
+}

--- a/app/components/project-builder/ProjectBuilder.module.css
+++ b/app/components/project-builder/ProjectBuilder.module.css
@@ -1,0 +1,104 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+}
+
+/* Fixed to the viewport width and clips overflow, so a divider only rebalances
+   its two neighbours - no pane can ever leave the screen. */
+.workspace {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    width: 100%;
+    overflow: hidden;
+}
+
+.files {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    height: 100%;
+    background: var(--color-bg-secondary);
+}
+
+/* Middle group takes the space left over by the two rails; editor + preview
+   split it by percentage so they always sum to 100%. */
+.middle {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+}
+
+.editor {
+    flex: 0 0 50%;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    height: 100%;
+}
+
+.preview {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    height: 100%;
+}
+
+.chat {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    height: 100%;
+    background: var(--color-bg-primary);
+}
+
+/* Resizer: a hairline with a centred grab handle, matching the coding-exercise
+   vertical divider. */
+.divider {
+    flex: 0 0 7px;
+    align-self: stretch;
+    position: relative;
+    cursor: col-resize;
+    background: var(--color-bg-primary);
+}
+
+.divider::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    inset-inline-start: 50%;
+    width: 1px;
+    transform: translateX(-50%);
+    background: var(--color-border-primary);
+}
+
+.divider::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    inset-inline-start: 50%;
+    transform: translate(-50%, -50%);
+    width: 3px;
+    height: 34px;
+    border-radius: 2px;
+    background: var(--color-border-secondary);
+    transition: background 0.15s;
+}
+
+.divider:hover::after {
+    background: var(--color-button-primary-bg);
+}
+
+.dividerDisabled {
+    cursor: default;
+}
+
+.dividerDisabled::after {
+    display: none;
+}

--- a/app/components/project-builder/ProjectBuilder.tsx
+++ b/app/components/project-builder/ProjectBuilder.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+// Root component for the project-builder: creates the orchestrator once and
+// lays out the three panes (files+editor | preview | chat) plus the dev-only
+// debug drawer.
+
+import { useEffect, useRef } from "react";
+import { Orchestrator } from "./lib/Orchestrator";
+import type { LessonConfig } from "./lib/types";
+import { ChatPane } from "./ui/ChatPane";
+import { CodeEditor } from "./ui/CodeEditor";
+import { DebugDrawer } from "./ui/DebugDrawer";
+import { FileTree } from "./ui/FileTree";
+import { PreviewPane } from "./ui/PreviewPane";
+
+export default function ProjectBuilder({ lesson }: { lesson: LessonConfig }) {
+  const orchestratorRef = useRef<Orchestrator | null>(null);
+  orchestratorRef.current ??= new Orchestrator(lesson);
+  const orchestrator = orchestratorRef.current;
+
+  useEffect(() => {
+    return () => {
+      orchestrator.cleanup();
+    };
+  }, [orchestrator]);
+
+  return (
+    <div className="flex h-screen flex-col">
+      <div className="flex min-h-0 flex-1">
+        <aside className="w-48 shrink-0 border-r border-border-primary bg-bg-secondary">
+          <FileTree orchestrator={orchestrator} />
+        </aside>
+        <section className="min-w-0 flex-1 border-r border-border-primary">
+          <CodeEditor orchestrator={orchestrator} />
+        </section>
+        <section className="min-w-0 flex-1 border-r border-border-primary">
+          <PreviewPane orchestrator={orchestrator} />
+        </section>
+        <section className="flex w-96 shrink-0 flex-col">
+          <ChatPane orchestrator={orchestrator} />
+        </section>
+      </div>
+      <DebugDrawer orchestrator={orchestrator} />
+    </div>
+  );
+}

--- a/app/components/project-builder/ProjectBuilder.tsx
+++ b/app/components/project-builder/ProjectBuilder.tsx
@@ -1,22 +1,27 @@
 "use client";
 
 // Root component for the project-builder: creates the orchestrator once and
-// lays out the three panes (files+editor | preview | chat) plus the dev-only
-// debug drawer.
+// lays out the four resizable panes (files | editor | preview | chat) plus the
+// dev-only debug drawer. The middle group (editor + preview) splits the space
+// left over by the fixed-width Files and Jiki rails.
 
 import { useEffect, useRef } from "react";
 import { Orchestrator } from "./lib/Orchestrator";
 import type { LessonConfig } from "./lib/types";
+import styles from "./ProjectBuilder.module.css";
 import { ChatPane } from "./ui/ChatPane";
 import { CodeEditor } from "./ui/CodeEditor";
 import { DebugDrawer } from "./ui/DebugDrawer";
 import { FileTree } from "./ui/FileTree";
 import { PreviewPane } from "./ui/PreviewPane";
+import { useResizablePanels } from "./ui/useResizablePanels";
 
 export default function ProjectBuilder({ lesson }: { lesson: LessonConfig }) {
   const orchestratorRef = useRef<Orchestrator | null>(null);
   orchestratorRef.current ??= new Orchestrator(lesson);
   const orchestrator = orchestratorRef.current;
+
+  const panels = useResizablePanels();
 
   useEffect(() => {
     return () => {
@@ -25,22 +30,54 @@ export default function ProjectBuilder({ lesson }: { lesson: LessonConfig }) {
   }, [orchestrator]);
 
   return (
-    <div className="flex h-screen flex-col">
-      <div className="flex min-h-0 flex-1">
-        <aside className="w-48 shrink-0 border-r border-border-primary bg-bg-secondary">
-          <FileTree orchestrator={orchestrator} />
+    <div className={styles.root}>
+      <div className={styles.workspace} ref={panels.containerRef}>
+        <aside className={styles.files} style={{ width: panels.filesCollapsed ? undefined : panels.filesWidth }}>
+          <FileTree
+            orchestrator={orchestrator}
+            collapsed={panels.filesCollapsed}
+            onToggleCollapsed={panels.toggleFilesCollapsed}
+          />
         </aside>
-        <section className="min-w-0 flex-1 border-r border-border-primary">
-          <CodeEditor orchestrator={orchestrator} />
-        </section>
-        <section className="min-w-0 flex-1 border-r border-border-primary">
-          <PreviewPane orchestrator={orchestrator} />
-        </section>
-        <section className="flex w-96 shrink-0 flex-col">
+
+        <Divider onMouseDown={panels.onDividerMouseDown("files")} disabled={panels.filesCollapsed} />
+
+        <div className={styles.middle} ref={panels.middleRef}>
+          <section className={styles.editor} style={{ flexBasis: `${panels.editorPercent}%` }}>
+            <CodeEditor orchestrator={orchestrator} />
+          </section>
+
+          <Divider onMouseDown={panels.onDividerMouseDown("editor")} />
+
+          <section className={styles.preview}>
+            <PreviewPane orchestrator={orchestrator} />
+          </section>
+        </div>
+
+        <Divider onMouseDown={panels.onDividerMouseDown("jiki")} />
+
+        <section className={styles.chat} style={{ width: panels.jikiWidth }}>
           <ChatPane orchestrator={orchestrator} />
         </section>
       </div>
       <DebugDrawer orchestrator={orchestrator} />
     </div>
+  );
+}
+
+function Divider({
+  onMouseDown,
+  disabled = false
+}: {
+  onMouseDown: (e: React.MouseEvent) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      className={`${styles.divider} ${disabled ? styles.dividerDisabled : ""}`}
+      onMouseDown={onMouseDown}
+    />
   );
 }

--- a/app/components/project-builder/lib/Orchestrator.ts
+++ b/app/components/project-builder/lib/Orchestrator.ts
@@ -1,0 +1,283 @@
+// Facade coordinating the project-builder session: file state, preview
+// lifecycle, console capture, persistence, and the agent turn loop.
+
+import type { StoreApi } from "zustand/vanilla";
+import { runAgentTurn } from "./agentLoop";
+import { debugLog, registerDebugAction } from "./debug/debugBus";
+import { buildPreview, type BuiltPreview } from "./previewBuilder";
+import { createProjectBuilderStore, type ProjectBuilderState } from "./store";
+import type {
+  ChatCompletionMessage,
+  ConsoleLine,
+  LessonConfig,
+  PreviewError,
+  ProjectFiles,
+  TranscriptItem
+} from "./types";
+
+// Omit that distributes over the TranscriptItem union.
+type TranscriptItemInput = TranscriptItem extends infer T ? (T extends TranscriptItem ? Omit<T, "id"> : never) : never;
+
+const STORAGE_VERSION = 1;
+const SAVE_DEBOUNCE_MS = 500;
+const AGENT_RUN_SETTLE_MS = 1000;
+
+interface StoredProject {
+  version: number;
+  storedAt: string;
+  files: ProjectFiles;
+}
+
+export class Orchestrator {
+  readonly lesson: LessonConfig;
+  // Model-facing conversation history (persona/files are rebuilt per call and
+  // never stored here).
+  readonly history: ChatCompletionMessage[] = [];
+
+  private readonly store: StoreApi<ProjectBuilderState>;
+  private builtPreview: BuiltPreview | null = null;
+  private iframeWindow: Window | null = null;
+  private currentRunLines: ConsoleLine[] = [];
+  private currentRunError: PreviewError | null = null;
+  private saveTimeout: ReturnType<typeof setTimeout> | null = null;
+  private transcriptId = 0;
+  private readonly unregisterDebug: (() => void) | null = null;
+  private readonly onWindowMessage = (event: MessageEvent) => {
+    this.handleWindowMessage(event);
+  };
+
+  constructor(lesson: LessonConfig) {
+    this.lesson = lesson;
+    const files = this.loadPersistedFiles() ?? { ...lesson.startingFiles };
+    this.store = createProjectBuilderStore(files, firstFile(files));
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("message", this.onWindowMessage);
+      this.unregisterDebug = registerDebugAction("Reset project", () => {
+        this.resetProject();
+      });
+    }
+  }
+
+  getStore(): StoreApi<ProjectBuilderState> {
+    return this.store;
+  }
+
+  cleanup(): void {
+    if (typeof window !== "undefined") {
+      window.removeEventListener("message", this.onWindowMessage);
+    }
+    this.unregisterDebug?.();
+  }
+
+  // File state (used by the editor, file tree and agent tools)
+
+  getFiles(): ProjectFiles {
+    return this.store.getState().files;
+  }
+
+  setActiveFile(filename: string): void {
+    this.store.setState({ activeFile: filename });
+  }
+
+  updateFileFromEditor(filename: string, content: string): void {
+    this.store.setState((state) => ({ files: { ...state.files, [filename]: content } }));
+    this.scheduleSave();
+  }
+
+  createFile(filename: string): void {
+    if (filename in this.getFiles()) {
+      return;
+    }
+    this.store.setState((state) => ({ files: { ...state.files, [filename]: "" }, activeFile: filename }));
+    this.scheduleSave();
+  }
+
+  deleteFileFromUi(filename: string): void {
+    if (filename === "index.html") {
+      return;
+    }
+    this.removeFile(filename);
+  }
+
+  agentSetFile(filename: string, content: string): void {
+    this.store.setState((state) => ({
+      files: { ...state.files, [filename]: content },
+      agentEditedAt: { ...state.agentEditedAt, [filename]: Date.now() }
+    }));
+    this.scheduleSave();
+  }
+
+  agentDeleteFile(filename: string): void {
+    this.removeFile(filename);
+  }
+
+  resetProject(): void {
+    debugLog("state", "reset project");
+    this.history.length = 0;
+    this.store.setState({
+      files: { ...this.lesson.startingFiles },
+      activeFile: firstFile(this.lesson.startingFiles),
+      transcript: [],
+      previewError: null,
+      consoleLines: [],
+      agentEditedAt: {},
+      srcdoc: null
+    });
+    this.scheduleSave();
+  }
+
+  // Preview
+
+  setIframeWindow(iframeWindow: Window | null): void {
+    this.iframeWindow = iframeWindow;
+  }
+
+  run(): void {
+    this.currentRunLines = [];
+    this.currentRunError = null;
+    this.builtPreview = buildPreview(this.getFiles(), this.lesson.allowedLibraries);
+    this.store.setState((state) => ({
+      srcdoc: this.builtPreview?.srcdoc ?? null,
+      runCounter: state.runCounter + 1,
+      previewError: null,
+      consoleLines: []
+    }));
+    debugLog("preview", "run", { files: Object.keys(this.getFiles()) });
+  }
+
+  async runForAgent(): Promise<{ consoleLines: ConsoleLine[]; error: PreviewError | null }> {
+    this.run();
+    await sleep(AGENT_RUN_SETTLE_MS);
+    return { consoleLines: [...this.currentRunLines], error: this.currentRunError };
+  }
+
+  // Agent
+
+  async sendMessage(text: string): Promise<void> {
+    if (this.store.getState().agentStatus === "running") {
+      return;
+    }
+    await runAgentTurn(this, text);
+  }
+
+  setAgentStatus(status: "idle" | "running"): void {
+    this.store.setState({ agentStatus: status });
+  }
+
+  // Transcript
+
+  appendTranscript(item: TranscriptItemInput): string {
+    const id = `t${++this.transcriptId}`;
+    this.store.setState((state) => ({ transcript: [...state.transcript, { ...item, id }] }));
+    return id;
+  }
+
+  updateTranscript(id: string, update: Partial<TranscriptItem>): void {
+    this.store.setState((state) => ({
+      transcript: state.transcript.map((item) => (item.id === id ? ({ ...item, ...update } as TranscriptItem) : item))
+    }));
+  }
+
+  // Internals
+
+  private removeFile(filename: string): void {
+    this.store.setState((state) => {
+      const files = { ...state.files };
+      delete files[filename];
+      const activeFile = state.activeFile === filename ? firstFile(files) : state.activeFile;
+      return { files, activeFile };
+    });
+    this.scheduleSave();
+  }
+
+  private handleWindowMessage(event: MessageEvent): void {
+    if (this.iframeWindow === null || event.source !== this.iframeWindow) {
+      return;
+    }
+    const data = (event.data as { __jikiProjectBuilder?: Record<string, unknown> } | null)?.__jikiProjectBuilder;
+    if (!data) {
+      return;
+    }
+
+    if (data.kind === "console") {
+      const line: ConsoleLine = {
+        level: data.level as ConsoleLine["level"],
+        text: String(data.text ?? "")
+      };
+      this.currentRunLines.push(line);
+      this.store.setState((state) => ({ consoleLines: [...state.consoleLines, line] }));
+      debugLog("console", `[${line.level}] ${line.text}`);
+      return;
+    }
+
+    if (data.kind === "error") {
+      const error: PreviewError = {
+        message: String(data.message ?? "Unknown error"),
+        filename: this.filenameForSource(String(data.source ?? "")),
+        line: typeof data.line === "number" ? data.line : undefined
+      };
+      this.currentRunError = error;
+      this.store.setState({ previewError: error });
+      debugLog("console", `error: ${error.message}`, error);
+    }
+  }
+
+  private filenameForSource(source: string): string | undefined {
+    return this.builtPreview?.urlToFile[source];
+  }
+
+  private scheduleSave(): void {
+    if (this.saveTimeout) {
+      clearTimeout(this.saveTimeout);
+    }
+    this.saveTimeout = setTimeout(() => {
+      this.persistFiles();
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  private persistFiles(): void {
+    try {
+      const stored: StoredProject = {
+        version: STORAGE_VERSION,
+        storedAt: new Date().toISOString(),
+        files: this.getFiles()
+      };
+      window.localStorage.setItem(this.storageKey(), JSON.stringify(stored));
+    } catch {
+      // quota exceeded or unavailable - saving is best-effort in the prototype
+    }
+  }
+
+  private loadPersistedFiles(): ProjectFiles | null {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    try {
+      const raw = window.localStorage.getItem(this.storageKey());
+      if (!raw) {
+        return null;
+      }
+      // Parse as unknown shape - localStorage contents are untrusted.
+      const parsed = JSON.parse(raw) as { version?: unknown; files?: unknown };
+      if (parsed.version !== STORAGE_VERSION || typeof parsed.files !== "object" || parsed.files === null) {
+        return null;
+      }
+      return parsed.files as ProjectFiles;
+    } catch {
+      return null;
+    }
+  }
+
+  private storageKey(): string {
+    return `jiki_project_builder_${this.lesson.slug}`;
+  }
+}
+
+function firstFile(files: ProjectFiles): string {
+  return "index.html" in files ? "index.html" : (Object.keys(files)[0] ?? "index.html");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/app/components/project-builder/lib/agentLoop.ts
+++ b/app/components/project-builder/lib/agentLoop.ts
@@ -2,9 +2,9 @@
 // execution in a loop, final prose out. The proxy-less BYOK version of the
 // planned production loop - history lives here, the model is stateless.
 
-import { devSettingsStore } from "./debug/devSettingsStore";
+import { devSettingsStore, PROVIDERS } from "./debug/devSettingsStore";
 import type { Orchestrator } from "./Orchestrator";
-import { OpenRouterError, streamChatCompletion } from "./openrouter";
+import { ModelRequestError, streamChatCompletion } from "./llmClient";
 import { buildSystemPrompt } from "./systemPrompt";
 import { executeTool, TOOL_SCHEMAS } from "./tools";
 import type { ChatCompletionMessage } from "./types";
@@ -26,7 +26,7 @@ export async function runAgentTurn(orchestrator: Orchestrator, userText: string)
 }
 
 async function runLoop(orchestrator: Orchestrator): Promise<void> {
-  const { openrouterKey, model } = devSettingsStore.getState();
+  const { llmKey, endpoint, model } = devSettingsStore.getState();
 
   for (let call = 0; call < MAX_MODEL_CALLS_PER_TURN; call++) {
     const messages: ChatCompletionMessage[] = [
@@ -36,7 +36,9 @@ async function runLoop(orchestrator: Orchestrator): Promise<void> {
 
     let assistantItemId: string | null = null;
     const { text, toolCalls, finishReason } = await streamChatCompletion({
-      apiKey: openrouterKey,
+      baseUrl: PROVIDERS[endpoint].baseUrl,
+      viaDevRelay: PROVIDERS[endpoint].viaDevRelay,
+      apiKey: llmKey,
       model,
       messages,
       tools: TOOL_SCHEMAS,
@@ -56,6 +58,9 @@ async function runLoop(orchestrator: Orchestrator): Promise<void> {
     });
 
     if (toolCalls.length === 0) {
+      if (finishReason === "length") {
+        orchestrator.appendTranscript({ kind: "notice", content: "The response was cut off (length limit)." });
+      }
       return;
     }
 
@@ -76,9 +81,11 @@ async function runLoop(orchestrator: Orchestrator): Promise<void> {
       orchestrator.history.push({ role: "tool", tool_call_id: toolCall.id, content: execution.result });
     }
 
-    if (finishReason !== "tool_calls" && finishReason !== null && finishReason !== "stop") {
-      orchestrator.appendTranscript({ kind: "notice", content: `The model stopped unexpectedly (${finishReason}).` });
-      return;
+    if (finishReason === "length") {
+      orchestrator.appendTranscript({
+        kind: "notice",
+        content: "The response was cut off (length limit) - tool results may be incomplete."
+      });
     }
   }
 
@@ -111,15 +118,15 @@ function labelFor(toolName: string): string {
 }
 
 function noticeForError(error: unknown): string {
-  if (error instanceof OpenRouterError) {
+  if (error instanceof ModelRequestError) {
     if (error.status === 401) {
-      return "Your OpenRouter key was rejected - check it in the debug drawer.";
+      return "Your API key was rejected - check it in the debug drawer.";
     }
     if (error.status === 402) {
-      return "OpenRouter says this model needs credits - pick a :free model or top up.";
+      return "The provider says this model needs credits - pick a free model or top up.";
     }
     if (error.status === 429) {
-      return "Rate limited by OpenRouter - wait a moment and try again.";
+      return "Rate limited by the model provider - wait a moment and try again.";
     }
     return `The model request failed: ${error.message}`;
   }

--- a/app/components/project-builder/lib/agentLoop.ts
+++ b/app/components/project-builder/lib/agentLoop.ts
@@ -1,0 +1,127 @@
+// Drives one agent turn: user message in, model calls + client-side tool
+// execution in a loop, final prose out. The proxy-less BYOK version of the
+// planned production loop - history lives here, the model is stateless.
+
+import { devSettingsStore } from "./debug/devSettingsStore";
+import type { Orchestrator } from "./Orchestrator";
+import { OpenRouterError, streamChatCompletion } from "./openrouter";
+import { buildSystemPrompt } from "./systemPrompt";
+import { executeTool, TOOL_SCHEMAS } from "./tools";
+import type { ChatCompletionMessage } from "./types";
+
+export const MAX_MODEL_CALLS_PER_TURN = 12;
+
+export async function runAgentTurn(orchestrator: Orchestrator, userText: string): Promise<void> {
+  orchestrator.setAgentStatus("running");
+  orchestrator.appendTranscript({ kind: "user", content: userText });
+  orchestrator.history.push({ role: "user", content: userText });
+
+  try {
+    await runLoop(orchestrator);
+  } catch (error) {
+    orchestrator.appendTranscript({ kind: "notice", content: noticeForError(error) });
+  } finally {
+    orchestrator.setAgentStatus("idle");
+  }
+}
+
+async function runLoop(orchestrator: Orchestrator): Promise<void> {
+  const { openrouterKey, model } = devSettingsStore.getState();
+
+  for (let call = 0; call < MAX_MODEL_CALLS_PER_TURN; call++) {
+    const messages: ChatCompletionMessage[] = [
+      { role: "system", content: buildSystemPrompt(orchestrator.lesson, orchestrator.getFiles()) },
+      ...orchestrator.history
+    ];
+
+    let assistantItemId: string | null = null;
+    const { text, toolCalls, finishReason } = await streamChatCompletion({
+      apiKey: openrouterKey,
+      model,
+      messages,
+      tools: TOOL_SCHEMAS,
+      onTextDelta: (delta) => {
+        if (assistantItemId === null) {
+          assistantItemId = orchestrator.appendTranscript({ kind: "assistant", content: delta });
+        } else {
+          appendToAssistantItem(orchestrator, assistantItemId, delta);
+        }
+      }
+    });
+
+    orchestrator.history.push({
+      role: "assistant",
+      content: text || null,
+      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {})
+    });
+
+    if (toolCalls.length === 0) {
+      return;
+    }
+
+    for (const toolCall of toolCalls) {
+      const itemId = orchestrator.appendTranscript({
+        kind: "tool",
+        name: toolCall.function.name,
+        label: labelFor(toolCall.function.name),
+        detail: "",
+        status: "running"
+      });
+      const execution = await executeTool(orchestrator, toolCall.function.name, toolCall.function.arguments);
+      orchestrator.updateTranscript(itemId, {
+        label: execution.label,
+        detail: execution.detail,
+        status: execution.isError ? "error" : "done"
+      });
+      orchestrator.history.push({ role: "tool", tool_call_id: toolCall.id, content: execution.result });
+    }
+
+    if (finishReason !== "tool_calls" && finishReason !== null && finishReason !== "stop") {
+      orchestrator.appendTranscript({ kind: "notice", content: `The model stopped unexpectedly (${finishReason}).` });
+      return;
+    }
+  }
+
+  orchestrator.appendTranscript({
+    kind: "notice",
+    content: `Stopped after ${MAX_MODEL_CALLS_PER_TURN} steps - send a message to continue.`
+  });
+}
+
+function appendToAssistantItem(orchestrator: Orchestrator, itemId: string, delta: string): void {
+  const transcript = orchestrator.getStore().getState().transcript;
+  const item = transcript.find((entry) => entry.id === itemId);
+  if (item && item.kind === "assistant") {
+    orchestrator.updateTranscript(itemId, { content: item.content + delta });
+  }
+}
+
+function labelFor(toolName: string): string {
+  const labels: Record<string, string> = {
+    list_files: "Listing files",
+    glob: "Finding files",
+    read_file: "Reading",
+    write_file: "Writing",
+    edit_file: "Editing",
+    delete_file: "Deleting",
+    grep: "Searching",
+    run_code: "Running the code"
+  };
+  return labels[toolName] ?? toolName;
+}
+
+function noticeForError(error: unknown): string {
+  if (error instanceof OpenRouterError) {
+    if (error.status === 401) {
+      return "Your OpenRouter key was rejected - check it in the debug drawer.";
+    }
+    if (error.status === 402) {
+      return "OpenRouter says this model needs credits - pick a :free model or top up.";
+    }
+    if (error.status === 429) {
+      return "Rate limited by OpenRouter - wait a moment and try again.";
+    }
+    return `The model request failed: ${error.message}`;
+  }
+  return `Something went wrong: ${error instanceof Error ? error.message : String(error)}`;
+}

--- a/app/components/project-builder/lib/consoleShim.ts
+++ b/app/components/project-builder/lib/consoleShim.ts
@@ -1,0 +1,45 @@
+// Source for the script injected into every preview iframe. Captures console
+// output and uncaught errors and posts them to the parent window. Kept as a
+// string so previewBuilder can inline it into the srcdoc document.
+
+export const CONSOLE_SHIM_SOURCE = `
+(function () {
+  function serialize(value) {
+    if (typeof value === "string") return value;
+    try {
+      return JSON.stringify(value);
+    } catch (e) {
+      return String(value);
+    }
+  }
+
+  function post(kind, payload) {
+    try {
+      window.parent.postMessage({ __jikiProjectBuilder: { kind: kind, ...payload } }, "*");
+    } catch (e) {
+      // parent gone - nothing to do
+    }
+  }
+
+  ["log", "warn", "error", "info"].forEach(function (level) {
+    var original = console[level];
+    console[level] = function () {
+      var args = Array.prototype.slice.call(arguments);
+      post("console", { level: level, text: args.map(serialize).join(" ") });
+      original.apply(console, args);
+    };
+  });
+
+  window.addEventListener("error", function (event) {
+    post("error", {
+      message: event.message,
+      source: event.filename || "",
+      line: event.lineno || undefined
+    });
+  });
+
+  window.addEventListener("unhandledrejection", function (event) {
+    post("error", { message: "Unhandled promise rejection: " + serialize(event.reason), source: "", line: undefined });
+  });
+})();
+`;

--- a/app/components/project-builder/lib/debug/debugBus.ts
+++ b/app/components/project-builder/lib/debug/debugBus.ts
@@ -1,0 +1,58 @@
+// App-wide debug bus (development only). Features push events onto named
+// channels; the DebugDrawer renders them. Kept as a plain zustand vanilla store
+// so non-React code (orchestrators, API clients) can push without hooks.
+
+import { createStore } from "zustand/vanilla";
+
+export interface DebugEvent {
+  id: number;
+  at: string;
+  channel: string;
+  label: string;
+  payload?: unknown;
+}
+
+export interface DebugAction {
+  name: string;
+  run: () => void;
+}
+
+interface DebugBusState {
+  events: DebugEvent[];
+  actions: DebugAction[];
+}
+
+const MAX_EVENTS = 500;
+let nextId = 1;
+
+export const debugBusStore = createStore<DebugBusState>(() => ({
+  events: [],
+  actions: []
+}));
+
+export function debugLog(channel: string, label: string, payload?: unknown): void {
+  if (process.env.NODE_ENV === "production") {
+    return;
+  }
+  debugBusStore.setState((state) => ({
+    events: [
+      ...state.events.slice(-(MAX_EVENTS - 1)),
+      { id: nextId++, at: new Date().toISOString(), channel, label, payload }
+    ]
+  }));
+}
+
+// Features register actions (e.g. "Reset project") that appear as buttons in
+// the drawer's Controls tab. Returns an unregister function for unmount.
+export function registerDebugAction(name: string, run: () => void): () => void {
+  debugBusStore.setState((state) => ({
+    actions: [...state.actions.filter((a) => a.name !== name), { name, run }]
+  }));
+  return () => {
+    debugBusStore.setState((state) => ({ actions: state.actions.filter((a) => a.name !== name) }));
+  };
+}
+
+export function clearDebugEvents(): void {
+  debugBusStore.setState({ events: [] });
+}

--- a/app/components/project-builder/lib/debug/devSettingsStore.ts
+++ b/app/components/project-builder/lib/debug/devSettingsStore.ts
@@ -1,46 +1,79 @@
-// Development-only settings (BYOK key, agent model), persisted to localStorage
-// and editable from the DebugDrawer's Controls tab.
+// Development-only settings (BYOK key, provider endpoint, agent model),
+// persisted to localStorage and editable from the DebugDrawer's Controls tab.
 
 import { createStore } from "zustand/vanilla";
 
+export type LlmEndpoint = "opencode-zen" | "openrouter";
+
 interface DevSettings {
-  openrouterKey: string;
+  llmKey: string;
+  endpoint: LlmEndpoint;
   model: string;
 }
 
-const STORAGE_KEY = "jiki_dev_settings_v1";
+interface ProviderConfig {
+  label: string;
+  baseUrl: string;
+  // Providers without browser CORS support are routed through the dev-only
+  // same-origin relay at /dev/project-builder/api/llm.
+  viaDevRelay: boolean;
+  suggestedModels: string[];
+}
 
-export const DEFAULT_MODEL = "qwen/qwen3-coder:free";
+const STORAGE_KEY = "jiki_dev_settings_v2";
 
-export const SUGGESTED_MODELS = [
-  "qwen/qwen3-coder:free",
-  "anthropic/claude-haiku-4.5",
-  "anthropic/claude-sonnet-4.5",
-  "google/gemini-2.5-flash",
-  "google/gemini-2.5-flash-lite",
-  "deepseek/deepseek-chat-v3.1"
-];
+export const PROVIDERS: Record<LlmEndpoint, ProviderConfig> = {
+  "opencode-zen": {
+    label: "OpenCode Zen",
+    baseUrl: "https://opencode.ai/zen/v1/chat/completions",
+    viaDevRelay: true,
+    suggestedModels: [
+      "deepseek-v4-flash-free",
+      "mimo-v2.5-free",
+      "nemotron-3-ultra-free",
+      "north-mini-code-free",
+      "claude-haiku-4-5",
+      "claude-sonnet-4-6",
+      "gemini-3-flash"
+    ]
+  },
+  openrouter: {
+    label: "OpenRouter",
+    baseUrl: "https://openrouter.ai/api/v1/chat/completions",
+    viaDevRelay: false,
+    suggestedModels: [
+      "qwen/qwen3-coder:free",
+      "anthropic/claude-haiku-4.5",
+      "anthropic/claude-sonnet-4.5",
+      "google/gemini-2.5-flash",
+      "deepseek/deepseek-chat-v3.1"
+    ]
+  }
+};
+
+const DEFAULTS: DevSettings = {
+  llmKey: process.env.NEXT_PUBLIC_LLM_API_KEY ?? "",
+  endpoint: "opencode-zen",
+  model: "deepseek-v4-flash-free"
+};
 
 function load(): DevSettings {
-  const defaults: DevSettings = {
-    openrouterKey: process.env.NEXT_PUBLIC_OPENROUTER_API_KEY ?? "",
-    model: DEFAULT_MODEL
-  };
   if (typeof window === "undefined") {
-    return defaults;
+    return DEFAULTS;
   }
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) {
-      return defaults;
+      return DEFAULTS;
     }
     const parsed = JSON.parse(raw) as Partial<DevSettings>;
     return {
-      openrouterKey: parsed.openrouterKey || defaults.openrouterKey,
-      model: parsed.model || defaults.model
+      llmKey: parsed.llmKey || DEFAULTS.llmKey,
+      endpoint: parsed.endpoint && parsed.endpoint in PROVIDERS ? parsed.endpoint : DEFAULTS.endpoint,
+      model: parsed.model || DEFAULTS.model
     };
   } catch {
-    return defaults;
+    return DEFAULTS;
   }
 }
 

--- a/app/components/project-builder/lib/debug/devSettingsStore.ts
+++ b/app/components/project-builder/lib/debug/devSettingsStore.ts
@@ -1,0 +1,56 @@
+// Development-only settings (BYOK key, agent model), persisted to localStorage
+// and editable from the DebugDrawer's Controls tab.
+
+import { createStore } from "zustand/vanilla";
+
+interface DevSettings {
+  openrouterKey: string;
+  model: string;
+}
+
+const STORAGE_KEY = "jiki_dev_settings_v1";
+
+export const DEFAULT_MODEL = "qwen/qwen3-coder:free";
+
+export const SUGGESTED_MODELS = [
+  "qwen/qwen3-coder:free",
+  "anthropic/claude-haiku-4.5",
+  "anthropic/claude-sonnet-4.5",
+  "google/gemini-2.5-flash",
+  "google/gemini-2.5-flash-lite",
+  "deepseek/deepseek-chat-v3.1"
+];
+
+function load(): DevSettings {
+  const defaults: DevSettings = {
+    openrouterKey: process.env.NEXT_PUBLIC_OPENROUTER_API_KEY ?? "",
+    model: DEFAULT_MODEL
+  };
+  if (typeof window === "undefined") {
+    return defaults;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return defaults;
+    }
+    const parsed = JSON.parse(raw) as Partial<DevSettings>;
+    return {
+      openrouterKey: parsed.openrouterKey || defaults.openrouterKey,
+      model: parsed.model || defaults.model
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+export const devSettingsStore = createStore<DevSettings>(() => load());
+
+export function updateDevSettings(update: Partial<DevSettings>): void {
+  devSettingsStore.setState(update);
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(devSettingsStore.getState()));
+  } catch {
+    // localStorage unavailable - settings just won't persist
+  }
+}

--- a/app/components/project-builder/lib/llmClient.ts
+++ b/app/components/project-builder/lib/llmClient.ts
@@ -1,11 +1,9 @@
-// Minimal streaming client for OpenRouter's OpenAI-compatible
-// chat/completions API, with tool-calling support. BYOK: the key is the
-// user's own OpenRouter key, sent directly from the browser.
+// Minimal streaming client for OpenAI-compatible chat/completions APIs
+// (OpenRouter, OpenCode Zen) with tool-calling support. BYOK: the key is the
+// user's own, sent directly from the browser.
 
 import { debugLog } from "./debug/debugBus";
 import type { ChatCompletionMessage, ChatToolCall } from "./types";
-
-const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
 export interface ToolSchema {
   type: "function";
@@ -22,7 +20,7 @@ export interface StreamResult {
   finishReason: string | null;
 }
 
-export class OpenRouterError extends Error {
+export class ModelRequestError extends Error {
   status: number;
 
   constructor(status: number, message: string) {
@@ -31,7 +29,12 @@ export class OpenRouterError extends Error {
   }
 }
 
+const DEV_RELAY_URL = "/dev/project-builder/api/llm";
+
 interface StreamOptions {
+  baseUrl: string;
+  // Route through the same-origin dev relay (for providers without CORS)
+  viaDevRelay: boolean;
   apiKey: string;
   model: string;
   messages: ChatCompletionMessage[];
@@ -43,28 +46,31 @@ interface StreamOptions {
 export async function streamChatCompletion(options: StreamOptions): Promise<StreamResult> {
   debugLog("agent", `request → ${options.model}`, { messageCount: options.messages.length });
 
-  const response = await fetch(OPENROUTER_URL, {
+  const payload = {
+    model: options.model,
+    messages: options.messages,
+    tools: options.tools,
+    stream: true,
+    stream_options: { include_usage: true }
+  };
+
+  const response = await fetch(options.viaDevRelay ? DEV_RELAY_URL : options.baseUrl, {
     method: "POST",
     signal: options.signal,
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${options.apiKey}`,
+      // OpenRouter attribution headers; harmless on other providers
       "HTTP-Referer": "https://jiki.io",
       "X-Title": "Jiki Project Builder (dev)"
     },
-    body: JSON.stringify({
-      model: options.model,
-      messages: options.messages,
-      tools: options.tools,
-      stream: true,
-      stream_options: { include_usage: true }
-    })
+    body: JSON.stringify(options.viaDevRelay ? { upstreamUrl: options.baseUrl, ...payload } : payload)
   });
 
   if (!response.ok || !response.body) {
     const message = await extractErrorMessage(response);
     debugLog("agent", `error ${response.status}`, message);
-    throw new OpenRouterError(response.status, message);
+    throw new ModelRequestError(response.status, message);
   }
 
   return readStream(response.body, options.onTextDelta);
@@ -79,6 +85,7 @@ async function readStream(
 
   let buffer = "";
   let text = "";
+  let reasoning = "";
   let finishReason: string | null = null;
   const toolCallsByIndex = new Map<number, ChatToolCall>();
 
@@ -127,6 +134,9 @@ async function readStream(
         text += delta.content;
         onTextDelta(delta.content);
       }
+      if (delta.reasoning_content) {
+        reasoning += delta.reasoning_content;
+      }
       for (const toolDelta of delta.tool_calls ?? []) {
         accumulateToolCall(toolCallsByIndex, toolDelta);
       }
@@ -138,6 +148,9 @@ async function readStream(
     textLength: text.length,
     toolCalls: toolCalls.map((c) => c.function.name)
   });
+  if (reasoning) {
+    debugLog("agent", "reasoning", reasoning);
+  }
   return { text, toolCalls, finishReason };
 }
 
@@ -147,6 +160,8 @@ interface StreamChunk {
     finish_reason?: string | null;
     delta?: {
       content?: string | null;
+      // Some providers (e.g. DeepSeek via OpenCode Zen) stream thinking here
+      reasoning_content?: string | null;
       tool_calls?: Array<{
         index: number;
         id?: string;

--- a/app/components/project-builder/lib/openrouter.ts
+++ b/app/components/project-builder/lib/openrouter.ts
@@ -1,0 +1,195 @@
+// Minimal streaming client for OpenRouter's OpenAI-compatible
+// chat/completions API, with tool-calling support. BYOK: the key is the
+// user's own OpenRouter key, sent directly from the browser.
+
+import { debugLog } from "./debug/debugBus";
+import type { ChatCompletionMessage, ChatToolCall } from "./types";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+export interface ToolSchema {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+export interface StreamResult {
+  text: string;
+  toolCalls: ChatToolCall[];
+  finishReason: string | null;
+}
+
+export class OpenRouterError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+interface StreamOptions {
+  apiKey: string;
+  model: string;
+  messages: ChatCompletionMessage[];
+  tools: ToolSchema[];
+  onTextDelta: (delta: string) => void;
+  signal?: AbortSignal;
+}
+
+export async function streamChatCompletion(options: StreamOptions): Promise<StreamResult> {
+  debugLog("agent", `request → ${options.model}`, { messageCount: options.messages.length });
+
+  const response = await fetch(OPENROUTER_URL, {
+    method: "POST",
+    signal: options.signal,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${options.apiKey}`,
+      "HTTP-Referer": "https://jiki.io",
+      "X-Title": "Jiki Project Builder (dev)"
+    },
+    body: JSON.stringify({
+      model: options.model,
+      messages: options.messages,
+      tools: options.tools,
+      stream: true,
+      stream_options: { include_usage: true }
+    })
+  });
+
+  if (!response.ok || !response.body) {
+    const message = await extractErrorMessage(response);
+    debugLog("agent", `error ${response.status}`, message);
+    throw new OpenRouterError(response.status, message);
+  }
+
+  return readStream(response.body, options.onTextDelta);
+}
+
+async function readStream(
+  body: ReadableStream<Uint8Array>,
+  onTextDelta: (delta: string) => void
+): Promise<StreamResult> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+
+  let buffer = "";
+  let text = "";
+  let finishReason: string | null = null;
+  const toolCallsByIndex = new Map<number, ChatToolCall>();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) {
+        continue;
+      }
+      const data = trimmed.slice(5).trim();
+      if (data === "[DONE]") {
+        continue;
+      }
+
+      const parsed = parseChunk(data);
+      if (!parsed) {
+        continue;
+      }
+
+      if (parsed.usage) {
+        debugLog("agent", "usage", parsed.usage);
+      }
+
+      const choice = parsed.choices?.[0];
+      if (!choice) {
+        continue;
+      }
+      if (choice.finish_reason) {
+        finishReason = choice.finish_reason;
+      }
+
+      const delta = choice.delta;
+      if (!delta) {
+        continue;
+      }
+      if (delta.content) {
+        text += delta.content;
+        onTextDelta(delta.content);
+      }
+      for (const toolDelta of delta.tool_calls ?? []) {
+        accumulateToolCall(toolCallsByIndex, toolDelta);
+      }
+    }
+  }
+
+  const toolCalls = [...toolCallsByIndex.entries()].sort(([a], [b]) => a - b).map(([, call]) => call);
+  debugLog("agent", `response (${finishReason ?? "?"})`, {
+    textLength: text.length,
+    toolCalls: toolCalls.map((c) => c.function.name)
+  });
+  return { text, toolCalls, finishReason };
+}
+
+interface StreamChunk {
+  usage?: unknown;
+  choices?: Array<{
+    finish_reason?: string | null;
+    delta?: {
+      content?: string | null;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+  }>;
+}
+
+function parseChunk(data: string): StreamChunk | null {
+  try {
+    return JSON.parse(data) as StreamChunk;
+  } catch {
+    return null;
+  }
+}
+
+function accumulateToolCall(
+  byIndex: Map<number, ChatToolCall>,
+  delta: { index: number; id?: string; function?: { name?: string; arguments?: string } }
+): void {
+  const existing = byIndex.get(delta.index) ?? {
+    id: "",
+    type: "function" as const,
+    function: { name: "", arguments: "" }
+  };
+  if (delta.id) {
+    existing.id = delta.id;
+  }
+  if (delta.function?.name) {
+    existing.function.name = delta.function.name;
+  }
+  if (delta.function?.arguments) {
+    existing.function.arguments += delta.function.arguments;
+  }
+  byIndex.set(delta.index, existing);
+}
+
+async function extractErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: { message?: string } };
+    return body.error?.message ?? `Request failed with status ${response.status}`;
+  } catch {
+    return `Request failed with status ${response.status}`;
+  }
+}

--- a/app/components/project-builder/lib/previewBuilder.ts
+++ b/app/components/project-builder/lib/previewBuilder.ts
@@ -1,0 +1,99 @@
+// Builds the srcdoc document for the preview iframe from the project's files.
+// No bundler: each .js file becomes a data: URL, an import map translates the
+// project's own paths (and allowed library names) to those URLs, and CSS links
+// are inlined. The console shim is injected so output reaches the parent.
+//
+// data: URLs (not blob:) are load-bearing - the iframe runs sandboxed WITHOUT
+// allow-same-origin, so it has an opaque origin, and blob URLs are scoped to
+// the creating origin: Chromium refuses to load them in the sandboxed frame.
+// data: URLs are origin-less and work everywhere (and need no revocation).
+
+import { CONSOLE_SHIM_SOURCE } from "./consoleShim";
+import type { AllowedLibrary, ProjectFiles } from "./types";
+
+export interface BuiltPreview {
+  srcdoc: string;
+  // Maps generated data: URLs back to project filenames so runtime errors can
+  // be attributed to the file the learner knows.
+  urlToFile: Record<string, string>;
+}
+
+export function buildPreview(files: ProjectFiles, allowedLibraries: AllowedLibrary[]): BuiltPreview {
+  const urlToFile: Record<string, string> = {};
+  const importMapEntries: Record<string, string> = {};
+
+  for (const [filename, content] of Object.entries(files)) {
+    if (!filename.endsWith(".js")) {
+      continue;
+    }
+    const url = moduleDataUrl(content);
+    urlToFile[url] = filename;
+    for (const specifier of specifierFormsFor(filename)) {
+      importMapEntries[specifier] = url;
+    }
+  }
+
+  for (const library of allowedLibraries) {
+    importMapEntries[library.name] = library.path;
+  }
+
+  const html = "index.html" in files ? files["index.html"] : missingIndexDocument();
+  const srcdoc = assembleDocument(html, files, importMapEntries);
+
+  return { srcdoc, urlToFile };
+}
+
+function moduleDataUrl(content: string): string {
+  return `data:text/javascript;base64,${base64EncodeUtf8(content)}`;
+}
+
+// btoa only handles latin1 - percent-encode to UTF-8 bytes first so emoji etc
+// survive. (encodeURIComponent-based rather than TextEncoder so it also runs
+// in the jsdom test environment, which lacks TextEncoder.)
+function base64EncodeUtf8(text: string): string {
+  const utf8 = encodeURIComponent(text).replace(/%([0-9A-F]{2})/g, (_, hex: string) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+  return btoa(utf8);
+}
+
+// A file can be imported as "./main.js", "main.js" or "/main.js" - map all
+// three so beginners' (and models') import styles all resolve.
+function specifierFormsFor(filename: string): string[] {
+  return [`./${filename}`, filename, `/${filename}`];
+}
+
+function assembleDocument(html: string, files: ProjectFiles, importMapEntries: Record<string, string>): string {
+  let document = html;
+
+  // Inline stylesheet links that point at project files.
+  document = document.replace(/<link\b[^>]*href=["']\.?\/?([^"']+)["'][^>]*>/gi, (match, href: string) =>
+    href in files && /rel=["']stylesheet["']/i.test(match) ? styleTag(files[href]) : match
+  );
+
+  // Point script tags at the data: URL for the referenced project file and
+  // force them to be modules so import statements work.
+  document = document.replace(/<script\b[^>]*\bsrc=["']\.?\/?([^"']+)["'][^>]*><\/script>/gi, (match, src: string) => {
+    if (!(src in files) || !(src in importMapEntries)) {
+      return match;
+    }
+    return `<script type="module" src="${importMapEntries[src]}"></script>`;
+  });
+
+  const injection = `<script type="importmap">${JSON.stringify({ imports: importMapEntries })}</script>\n<script>${CONSOLE_SHIM_SOURCE}</script>`;
+
+  // The import map must come before any module scripts, so inject at the very
+  // start of <head>, falling back to prefixing the document.
+  if (/<head[^>]*>/i.test(document)) {
+    return document.replace(/<head[^>]*>/i, (match) => `${match}\n${injection}`);
+  }
+  return `${injection}\n${document}`;
+}
+
+function styleTag(css: string): string {
+  return `<style>\n${css}\n</style>`;
+}
+
+function missingIndexDocument(): string {
+  return `<!doctype html><html><head></head><body><p style="font-family: sans-serif; color: #666; padding: 16px;">This project needs an <code>index.html</code> file.</p></body></html>`;
+}

--- a/app/components/project-builder/lib/store.ts
+++ b/app/components/project-builder/lib/store.ts
@@ -1,0 +1,42 @@
+// Instance-based zustand store for a project-builder session, following the
+// coding-exercise orchestrator pattern: one store per orchestrator instance,
+// read via hook + useShallow, written via orchestrator methods.
+
+import { useStore } from "zustand";
+import { useShallow } from "zustand/shallow";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import type { ConsoleLine, PreviewError, ProjectFiles, TranscriptItem } from "./types";
+
+export interface ProjectBuilderState {
+  files: ProjectFiles;
+  activeFile: string;
+  transcript: TranscriptItem[];
+  agentStatus: "idle" | "running";
+  srcdoc: string | null;
+  runCounter: number;
+  previewError: PreviewError | null;
+  consoleLines: ConsoleLine[];
+  // filename -> timestamp of last agent edit, drives the flash highlight
+  agentEditedAt: Record<string, number>;
+}
+
+export function createProjectBuilderStore(files: ProjectFiles, activeFile: string): StoreApi<ProjectBuilderState> {
+  return createStore<ProjectBuilderState>(() => ({
+    files,
+    activeFile,
+    transcript: [],
+    agentStatus: "idle",
+    srcdoc: null,
+    runCounter: 0,
+    previewError: null,
+    consoleLines: [],
+    agentEditedAt: {}
+  }));
+}
+
+export function useProjectBuilderStore<T>(
+  store: StoreApi<ProjectBuilderState>,
+  selector: (state: ProjectBuilderState) => T
+): T {
+  return useStore(store, useShallow(selector));
+}

--- a/app/components/project-builder/lib/systemPrompt.ts
+++ b/app/components/project-builder/lib/systemPrompt.ts
@@ -1,0 +1,59 @@
+// Builds the system prompt: fixed persona + Socratic-gate rules, the lesson's
+// guidance, and the current project files under the per-file inline policy
+// (small files in full, large files as a head + retrieval marker).
+
+import type { LessonConfig, ProjectFiles } from "./types";
+
+const INLINE_FULL_MAX_CHARS = 6000;
+const TRUNCATED_HEAD_LINES = 60;
+
+export function buildSystemPrompt(lesson: LessonConfig, files: ProjectFiles): string {
+  return [personaSection(), lessonSection(lesson), filesSection(files)].join("\n\n");
+}
+
+function personaSection(): string {
+  return `You are Jiki, a friendly coding guide helping an absolute beginner build a real project. You work inside their editor: you can read and change their files and run their code using your tools.
+
+Rules:
+- Be Socratic. Before your first file change in a conversation, restate what the learner wants in one or two sentences and get their confirmation. Refuse (kindly) to build from vague instructions - ask what specifically they want until it's concrete.
+- One small step at a time. Make a change, run the code, show them, then discuss the next step.
+- Explain simply. No jargon without a one-line explanation. Keep responses short - a few sentences, not essays.
+- Vanilla HTML, CSS and JavaScript only. No frameworks, no build tools, no npm. You may only use the third-party libraries listed for this lesson, imported by their bare name.
+- Keep files small. If a file grows past ~150 lines, suggest splitting it (e.g. CSS by concern).
+- All project files are shown below - prefer acting on what you can see over re-listing or re-reading it.
+- After changing code, use run_code to check it works before telling the learner it's done. Report errors honestly.`;
+}
+
+function lessonSection(lesson: LessonConfig): string {
+  const libraries =
+    lesson.allowedLibraries.length > 0
+      ? lesson.allowedLibraries.map((l) => `- ${l.name} (import "${l.name}")`).join("\n")
+      : "- none";
+  return `## This lesson
+
+${lesson.instructions}
+
+Lesson-specific guidance for you:
+${lesson.agentGuidance}
+
+Allowed third-party libraries:
+${libraries}`;
+}
+
+function filesSection(files: ProjectFiles): string {
+  const sections = Object.entries(files).map(([filename, content]) => renderFile(filename, content));
+  return `## Current project files\n\n${sections.join("\n\n")}`;
+}
+
+function renderFile(filename: string, content: string): string {
+  const lines = content.split("\n");
+  const header = `### ${filename} (${lines.length} lines, ${content.length} chars)`;
+
+  if (content.length <= INLINE_FULL_MAX_CHARS) {
+    return `${header}\n\`\`\`\n${content}\n\`\`\``;
+  }
+
+  const head = lines.slice(0, TRUNCATED_HEAD_LINES).join("\n");
+  const remaining = lines.length - TRUNCATED_HEAD_LINES;
+  return `${header}\n\`\`\`\n${head}\n\`\`\`\n… truncated - ${remaining} more lines. Use read_file("${filename}", start_line, end_line) or grep to see the rest.`;
+}

--- a/app/components/project-builder/lib/systemPrompt.ts
+++ b/app/components/project-builder/lib/systemPrompt.ts
@@ -21,7 +21,8 @@ Rules:
 - Vanilla HTML, CSS and JavaScript only. No frameworks, no build tools, no npm. You may only use the third-party libraries listed for this lesson, imported by their bare name.
 - Keep files small. If a file grows past ~150 lines, suggest splitting it (e.g. CSS by concern).
 - All project files are shown below - prefer acting on what you can see over re-listing or re-reading it.
-- After changing code, use run_code to check it works before telling the learner it's done. Report errors honestly.`;
+- After changing code, use run_code to check it works before telling the learner it's done. Report errors honestly.
+- The learner sees their page live in the preview pane next to this chat. Never paste screenshots, image links or URLs, and never claim to show them anything - just tell them to look at the preview.`;
 }
 
 function lessonSection(lesson: LessonConfig): string {

--- a/app/components/project-builder/lib/tools.ts
+++ b/app/components/project-builder/lib/tools.ts
@@ -1,0 +1,314 @@
+// The agent's toolset: schemas (OpenAI function-calling format) and the
+// client-side executor that runs them against the orchestrator's file state.
+// Shapes follow the de-facto coding-agent convention so models drive them
+// reliably; run_code stands in for bash (the preview is our execution
+// primitive).
+
+import type { Orchestrator } from "./Orchestrator";
+import type { ToolSchema } from "./openrouter";
+
+export const MAX_FILES = 20;
+export const MAX_FILE_CHARS = 64_000;
+export const MAX_TOTAL_CHARS = 256_000;
+const MAX_GREP_RESULTS = 100;
+const FILENAME_PATTERN = /^[a-zA-Z0-9_\-./]+$/;
+
+export interface ToolExecution {
+  label: string;
+  detail: string;
+  result: string;
+  isError: boolean;
+}
+
+export const TOOL_SCHEMAS: ToolSchema[] = [
+  tool("list_files", "List all files in the project with their sizes.", {}),
+  tool("glob", "Find files whose path matches a glob pattern (supports * and **).", {
+    pattern: { type: "string", description: "Glob pattern, e.g. *.css" }
+  }),
+  tool("read_file", "Read a file, optionally a line range. Lines are numbered from 1.", {
+    filename: { type: "string" },
+    start_line: { type: "number", description: "First line to read (1-based, optional)" },
+    end_line: { type: "number", description: "Last line to read (inclusive, optional)" }
+  }),
+  tool("write_file", "Create a new file or completely overwrite an existing one.", {
+    filename: { type: "string" },
+    content: { type: "string" }
+  }),
+  tool(
+    "edit_file",
+    "Replace an exact string in a file. old_str must appear exactly once - include enough surrounding context to make it unique.",
+    {
+      filename: { type: "string" },
+      old_str: { type: "string" },
+      new_str: { type: "string" }
+    }
+  ),
+  tool("delete_file", "Delete a file from the project.", {
+    filename: { type: "string" }
+  }),
+  tool("grep", "Search all files for a regular expression. Returns matching lines as filename:line: text.", {
+    pattern: { type: "string" }
+  }),
+  tool("run_code", "Run the project in the preview and return its console output and any errors.", {})
+];
+
+export async function executeTool(
+  orchestrator: Orchestrator,
+  name: string,
+  rawArguments: string
+): Promise<ToolExecution> {
+  const args = parseArguments(rawArguments);
+  if (args === null) {
+    return failure(name, "", `Error: could not parse arguments as JSON: ${truncate(rawArguments, 200)}`);
+  }
+
+  switch (name) {
+    case "list_files":
+      return listFiles(orchestrator);
+    case "glob":
+      return glob(orchestrator, str(args.pattern));
+    case "read_file":
+      return readFile(orchestrator, str(args.filename), num(args.start_line), num(args.end_line));
+    case "write_file":
+      return writeFile(orchestrator, str(args.filename), str(args.content));
+    case "edit_file":
+      return editFile(orchestrator, str(args.filename), str(args.old_str), str(args.new_str));
+    case "delete_file":
+      return deleteFile(orchestrator, str(args.filename));
+    case "grep":
+      return grep(orchestrator, str(args.pattern));
+    case "run_code":
+      return runCode(orchestrator);
+    default:
+      return failure(name, "", `Error: unknown tool "${name}".`);
+  }
+}
+
+// Individual tools
+
+function listFiles(orchestrator: Orchestrator): ToolExecution {
+  const files = orchestrator.getFiles();
+  const listing = Object.entries(files)
+    .map(([filename, content]) => `${filename} (${content.split("\n").length} lines, ${content.length} chars)`)
+    .join("\n");
+  return success("Listed files", "", listing || "No files.");
+}
+
+function glob(orchestrator: Orchestrator, pattern: string): ToolExecution {
+  const regex = globToRegex(pattern);
+  const matches = Object.keys(orchestrator.getFiles()).filter((filename) => regex.test(filename));
+  return success(`Matched ${pattern}`, "", matches.join("\n") || "No files match.");
+}
+
+function readFile(orchestrator: Orchestrator, filename: string, startLine?: number, endLine?: number): ToolExecution {
+  const files = orchestrator.getFiles();
+  if (!(filename in files)) {
+    return failure(`Read ${filename}`, "", `Error: no file named "${filename}".`);
+  }
+  const lines = files[filename].split("\n");
+  const from = Math.max(1, startLine ?? 1);
+  const to = Math.min(lines.length, endLine ?? lines.length);
+  const numbered = lines
+    .slice(from - 1, to)
+    .map((line, index) => `${from + index}: ${line}`)
+    .join("\n");
+  const rangeNote = startLine !== undefined || endLine !== undefined ? ` (lines ${from}-${to})` : "";
+  return success(`Read ${filename}`, rangeNote.trim(), numbered);
+}
+
+function writeFile(orchestrator: Orchestrator, filename: string, content: string): ToolExecution {
+  const validationError = validateWrite(orchestrator, filename, content);
+  if (validationError) {
+    return failure(`Write ${filename}`, "", `Error: ${validationError}`);
+  }
+  const existed = filename in orchestrator.getFiles();
+  orchestrator.agentSetFile(filename, content);
+  const label = existed ? `Rewrote ${filename}` : `Created ${filename}`;
+  return success(label, `${content.split("\n").length} lines`, `${label} (${content.split("\n").length} lines).`);
+}
+
+function editFile(orchestrator: Orchestrator, filename: string, oldStr: string, newStr: string): ToolExecution {
+  const files = orchestrator.getFiles();
+  if (!(filename in files)) {
+    return failure(`Edit ${filename}`, "", `Error: no file named "${filename}".`);
+  }
+  const content = files[filename];
+  const occurrences = countOccurrences(content, oldStr);
+  if (oldStr === "") {
+    return failure(`Edit ${filename}`, "", "Error: old_str must not be empty.");
+  }
+  if (occurrences === 0) {
+    return failure(
+      `Edit ${filename}`,
+      "",
+      "Error: old_str was not found in the file. Read the file and try again with the exact text."
+    );
+  }
+  if (occurrences > 1) {
+    return failure(
+      `Edit ${filename}`,
+      "",
+      `Error: old_str appears ${occurrences} times - add surrounding context so it matches exactly once.`
+    );
+  }
+  const updated = content.replace(oldStr, newStr);
+  const validationError = validateWrite(orchestrator, filename, updated);
+  if (validationError) {
+    return failure(`Edit ${filename}`, "", `Error: ${validationError}`);
+  }
+  orchestrator.agentSetFile(filename, updated);
+  return success(`Edited ${filename}`, "", `Edited ${filename}.`);
+}
+
+function deleteFile(orchestrator: Orchestrator, filename: string): ToolExecution {
+  if (filename === "index.html") {
+    return failure("Delete index.html", "", "Error: index.html cannot be deleted - the project needs it.");
+  }
+  if (!(filename in orchestrator.getFiles())) {
+    return failure(`Delete ${filename}`, "", `Error: no file named "${filename}".`);
+  }
+  orchestrator.agentDeleteFile(filename);
+  return success(`Deleted ${filename}`, "", `Deleted ${filename}.`);
+}
+
+function grep(orchestrator: Orchestrator, pattern: string): ToolExecution {
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern);
+  } catch {
+    return failure(`Grep ${pattern}`, "", `Error: invalid regular expression: ${pattern}`);
+  }
+  const results: string[] = [];
+  for (const [filename, content] of Object.entries(orchestrator.getFiles())) {
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length && results.length < MAX_GREP_RESULTS; i++) {
+      if (regex.test(lines[i])) {
+        results.push(`${filename}:${i + 1}: ${lines[i]}`);
+      }
+    }
+  }
+  return success(
+    `Searched for ${truncate(pattern, 40)}`,
+    `${results.length} matches`,
+    results.join("\n") || "No matches."
+  );
+}
+
+async function runCode(orchestrator: Orchestrator): Promise<ToolExecution> {
+  const { consoleLines, error } = await orchestrator.runForAgent();
+  const output = consoleLines.map((line) => `[${line.level}] ${line.text}`).join("\n");
+  const parts: string[] = [];
+  if (output) {
+    parts.push(`Console output:\n${output}`);
+  }
+  if (error) {
+    parts.push(
+      `Error: ${error.message}${error.filename ? ` (${error.filename}${error.line ? `:${error.line}` : ""})` : ""}`
+    );
+  }
+  if (parts.length === 0) {
+    parts.push("The page ran with no console output and no errors.");
+  }
+  const detail = error ? "error" : `${consoleLines.length} console lines`;
+  return {
+    label: "Ran the code",
+    detail,
+    result: parts.join("\n\n"),
+    isError: Boolean(error)
+  };
+}
+
+// Helpers
+
+function tool(name: string, description: string, properties: Record<string, unknown>): ToolSchema {
+  return {
+    type: "function",
+    function: {
+      name,
+      description,
+      parameters: { type: "object", properties, required: requiredFrom(properties) }
+    }
+  };
+}
+
+function requiredFrom(properties: Record<string, unknown>): string[] {
+  return Object.entries(properties)
+    .filter(([, schema]) => !String((schema as { description?: string }).description ?? "").includes("optional"))
+    .map(([name]) => name);
+}
+
+function validateWrite(orchestrator: Orchestrator, filename: string, content: string): string | null {
+  if (!FILENAME_PATTERN.test(filename) || filename.includes("..")) {
+    return `invalid filename "${filename}".`;
+  }
+  if (content.length > MAX_FILE_CHARS) {
+    return `file too large (${content.length} chars; max ${MAX_FILE_CHARS}).`;
+  }
+  const files = orchestrator.getFiles();
+  const isNew = !(filename in files);
+  if (isNew && Object.keys(files).length >= MAX_FILES) {
+    return `too many files (max ${MAX_FILES}).`;
+  }
+  const totalOthers = Object.entries(files)
+    .filter(([name]) => name !== filename)
+    .reduce((sum, [, existing]) => sum + existing.length, 0);
+  if (totalOthers + content.length > MAX_TOTAL_CHARS) {
+    return `project too large (max ${MAX_TOTAL_CHARS} chars total).`;
+  }
+  return null;
+}
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, " ")
+    .replace(/\*/g, "[^/]*")
+    .replace(/ /g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`);
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle === "") {
+    return 0;
+  }
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+function parseArguments(raw: string): Record<string, unknown> | null {
+  if (raw.trim() === "") {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}
+
+function success(label: string, detail: string, result: string): ToolExecution {
+  return { label, detail, result, isError: false };
+}
+
+function failure(label: string, detail: string, result: string): ToolExecution {
+  return { label, detail, result, isError: true };
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/app/components/project-builder/lib/tools.ts
+++ b/app/components/project-builder/lib/tools.ts
@@ -5,7 +5,7 @@
 // primitive).
 
 import type { Orchestrator } from "./Orchestrator";
-import type { ToolSchema } from "./openrouter";
+import type { ToolSchema } from "./llmClient";
 
 export const MAX_FILES = 20;
 export const MAX_FILE_CHARS = 64_000;

--- a/app/components/project-builder/lib/types.ts
+++ b/app/components/project-builder/lib/types.ts
@@ -1,0 +1,56 @@
+// Core types for the project-builder prototype.
+
+export type ProjectFiles = Record<string, string>;
+
+export interface AllowedLibrary {
+  name: string;
+  path: string;
+}
+
+export interface LessonConfig {
+  slug: string;
+  title: string;
+  instructions: string;
+  agentGuidance: string;
+  startingFiles: ProjectFiles;
+  allowedLibraries: AllowedLibrary[];
+}
+
+export interface ConsoleLine {
+  level: "log" | "warn" | "error" | "info";
+  text: string;
+}
+
+export interface PreviewError {
+  message: string;
+  filename?: string;
+  line?: number;
+}
+
+// A single entry in the chat transcript. Assistant prose and tool activity
+// interleave in one flat list, rendered in order.
+export type TranscriptItem =
+  | { kind: "user"; id: string; content: string }
+  | { kind: "assistant"; id: string; content: string }
+  | {
+      kind: "tool";
+      id: string;
+      name: string;
+      label: string;
+      detail: string;
+      status: "running" | "done" | "error";
+    }
+  | { kind: "notice"; id: string; content: string };
+
+// OpenAI-compatible message shapes used with OpenRouter.
+export interface ChatToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}
+
+export type ChatCompletionMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string | null; tool_calls?: ChatToolCall[] }
+  | { role: "tool"; tool_call_id: string; content: string };

--- a/app/components/project-builder/ui/ChatPane.module.css
+++ b/app/components/project-builder/ui/ChatPane.module.css
@@ -1,0 +1,259 @@
+.chat {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-width: 0;
+}
+
+.headerTitle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+}
+
+.avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 6px;
+    background: var(--color-button-primary-bg);
+    color: var(--color-button-primary-text);
+    display: grid;
+    place-items: center;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    font-size: 14px;
+    line-height: 1.55;
+}
+
+/* ---- Empty state ---- */
+.empty {
+    margin: auto;
+    text-align: center;
+    color: var(--color-text-secondary);
+    max-width: 260px;
+    padding: 24px 0;
+}
+
+.emptyAvatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: var(--color-button-primary-bg);
+    color: var(--color-button-primary-text);
+    display: grid;
+    place-items: center;
+    font-size: 22px;
+    font-weight: 700;
+    margin: 0 auto 14px;
+}
+
+.emptyTitle {
+    margin: 0 0 6px;
+    font-size: 15px;
+    color: var(--color-text-primary);
+}
+
+.emptyText {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: center;
+    margin-top: 14px;
+}
+
+.chip {
+    font-size: 12px;
+    padding: 5px 11px;
+    border-radius: 16px;
+    border: 1px solid var(--color-border-secondary);
+    background: var(--color-bg-primary);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.chip:hover:not(:disabled) {
+    border-color: var(--color-button-primary-bg);
+    color: var(--color-button-primary-bg);
+}
+
+.chip:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+/* ---- Messages ---- */
+.userMessage {
+    align-self: flex-end;
+    max-width: 85%;
+    padding: 8px 12px;
+    border-radius: 14px 14px 4px 14px;
+    background: var(--color-purple-100);
+    color: var(--color-text-primary);
+    font-size: 13.5px;
+    white-space: pre-wrap;
+}
+
+.assistantMessage {
+    align-self: flex-start;
+    max-width: 92%;
+    margin: 0;
+    color: var(--color-text-primary);
+    white-space: pre-wrap;
+}
+
+.notice {
+    align-self: flex-start;
+    max-width: 92%;
+    margin: 0;
+    font-size: 13px;
+    font-style: italic;
+    color: var(--color-warning-text);
+}
+
+.working {
+    align-self: flex-start;
+    display: inline-block;
+    width: 8px;
+    height: 16px;
+    background: var(--color-gray-400);
+    animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.3;
+    }
+}
+
+/* ---- Tool activity chips ---- */
+.activity {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    max-width: 100%;
+    padding: 4px 9px;
+    border: 1px solid var(--color-border-primary);
+    border-radius: 7px;
+    background: var(--color-bg-secondary);
+    color: var(--color-text-secondary);
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+
+.activityGlyph {
+    color: var(--color-success-border);
+}
+
+.activityRun .activityGlyph {
+    color: var(--color-button-primary-bg);
+}
+
+.activityError {
+    border-color: var(--color-error-border);
+    color: var(--color-error-text);
+}
+
+.activityError .activityGlyph {
+    color: var(--color-error-text);
+}
+
+.activityDetail {
+    color: var(--color-text-tertiary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ---- Composer ---- */
+.composer {
+    flex: 0 0 auto;
+    padding: 12px 16px 16px;
+    background: var(--color-bg-secondary);
+    border-top: 1px solid var(--color-border-primary);
+}
+
+.composerField {
+    position: relative;
+}
+
+.textarea {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 11px 46px 11px 12px;
+    border: 2px solid color-mix(in srgb, var(--color-button-primary-bg) 35%, transparent);
+    border-radius: 8px;
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font-family: inherit;
+    font-size: 15px;
+    line-height: 1.5;
+    resize: none;
+    outline: none;
+    overflow-y: auto;
+    min-height: 44px;
+    max-height: 180px;
+    transition: border-color 0.2s;
+}
+
+.textarea::placeholder {
+    color: var(--color-text-tertiary);
+}
+
+.textarea:focus {
+    border-color: var(--color-button-primary-bg);
+}
+
+.sendButton {
+    position: absolute;
+    bottom: 7px;
+    inset-inline-end: 7px;
+    width: 30px;
+    height: 30px;
+    display: grid;
+    place-items: center;
+    border: none;
+    border-radius: 6px;
+    background: var(--color-button-primary-bg);
+    color: var(--color-button-primary-text);
+    cursor: pointer;
+}
+
+.sendButton:disabled {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-tertiary);
+    cursor: default;
+}
+
+.sendButton svg {
+    width: 14px;
+    height: 14px;
+}

--- a/app/components/project-builder/ui/ChatPane.tsx
+++ b/app/components/project-builder/ui/ChatPane.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+// The conversation: one continuous transcript (no bubbles), quiet tool-activity
+// lines, and a bare input that submits on Enter.
+
+import { useEffect, useRef, useState } from "react";
+import type { Orchestrator } from "../lib/Orchestrator";
+import { useProjectBuilderStore } from "../lib/store";
+import type { TranscriptItem } from "../lib/types";
+
+export function ChatPane({ orchestrator }: { orchestrator: Orchestrator }) {
+  const { transcript, agentStatus } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
+    transcript: state.transcript,
+    agentStatus: state.agentStatus
+  }));
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [transcript]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-[15px] leading-relaxed">
+        {transcript.length === 0 && (
+          <p className="text-gray-500">Tell Jiki what you want to build - it can edit your files and run your code.</p>
+        )}
+        {transcript.map((item) => (
+          <TranscriptEntry key={item.id} item={item} />
+        ))}
+        {agentStatus === "running" && (
+          <span className="inline-block h-4 w-2 animate-pulse bg-gray-400" aria-label="Jiki is working" />
+        )}
+      </div>
+      <ChatInput orchestrator={orchestrator} disabled={agentStatus === "running"} />
+    </div>
+  );
+}
+
+function TranscriptEntry({ item }: { item: TranscriptItem }) {
+  switch (item.kind) {
+    case "user":
+      return <p className="whitespace-pre-wrap text-gray-500">&gt; {item.content}</p>;
+    case "assistant":
+      return <p className="whitespace-pre-wrap">{item.content}</p>;
+    case "tool":
+      return <ToolLine item={item} />;
+    case "notice":
+      return <p className="text-sm italic text-amber-700">{item.content}</p>;
+  }
+}
+
+function ToolLine({ item }: { item: Extract<TranscriptItem, { kind: "tool" }> }) {
+  const glyph = item.status === "running" ? "…" : item.status === "error" ? "⚠" : glyphFor(item.name);
+  return (
+    <p className={`text-sm ${item.status === "error" ? "text-error-text" : "text-gray-500"}`}>
+      {glyph} {item.label}
+      {item.detail && <span className="text-gray-400"> · {item.detail}</span>}
+    </p>
+  );
+}
+
+function ChatInput({ orchestrator, disabled }: { orchestrator: Orchestrator; disabled: boolean }) {
+  const [value, setValue] = useState("");
+
+  const handleSubmit = () => {
+    const text = value.trim();
+    if (!text || disabled) {
+      return;
+    }
+    setValue("");
+    void orchestrator.sendMessage(text);
+  };
+
+  return (
+    <textarea
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          handleSubmit();
+        }
+      }}
+      placeholder={disabled ? "Jiki is working…" : "Message Jiki…"}
+      rows={2}
+      className="w-full resize-none border-t border-border-primary bg-transparent px-4 py-3 text-[15px] outline-none placeholder:text-gray-400"
+    />
+  );
+}
+
+function glyphFor(toolName: string): string {
+  const glyphs: Record<string, string> = {
+    write_file: "✏️",
+    edit_file: "✏️",
+    delete_file: "🗑",
+    read_file: "📄",
+    list_files: "📄",
+    glob: "🔍",
+    grep: "🔍",
+    run_code: "▶"
+  };
+  return glyphs[toolName] ?? "·";
+}

--- a/app/components/project-builder/ui/ChatPane.tsx
+++ b/app/components/project-builder/ui/ChatPane.tsx
@@ -1,12 +1,21 @@
 "use client";
 
-// The conversation: one continuous transcript (no bubbles), quiet tool-activity
-// lines, and a bare input that submits on Enter.
+// The conversation with Jiki: a welcoming empty state, user messages as
+// bubbles, assistant prose, quiet activity chips for tool calls, and an
+// auto-growing composer (Enter sends, Shift+Enter for a newline). Ported from
+// the coding-exercise ChatInput behaviour.
 
 import { useEffect, useRef, useState } from "react";
+import { useStore } from "zustand";
+import SendArrow from "@/icons/send-arrow.svg";
+import { devSettingsStore } from "../lib/debug/devSettingsStore";
 import type { Orchestrator } from "../lib/Orchestrator";
 import { useProjectBuilderStore } from "../lib/store";
 import type { TranscriptItem } from "../lib/types";
+import styles from "./ChatPane.module.css";
+import { PaneHeader } from "./PaneHeader";
+
+const SUGGESTIONS = ["Change the headline", "Pick some colours", "Add an about-me"];
 
 export function ChatPane({ orchestrator }: { orchestrator: Orchestrator }) {
   const { transcript, agentStatus } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
@@ -14,6 +23,8 @@ export function ChatPane({ orchestrator }: { orchestrator: Orchestrator }) {
     agentStatus: state.agentStatus
   }));
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const isRunning = agentStatus === "running";
+  const hasKey = useStore(devSettingsStore, (state) => state.llmKey.trim().length > 0);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -22,20 +33,72 @@ export function ChatPane({ orchestrator }: { orchestrator: Orchestrator }) {
     }
   }, [transcript]);
 
+  const send = (text: string) => {
+    void orchestrator.sendMessage(text);
+  };
+
   return (
-    <div className="flex h-full flex-col">
-      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-[15px] leading-relaxed">
-        {transcript.length === 0 && (
-          <p className="text-gray-500">Tell Jiki what you want to build - it can edit your files and run your code.</p>
-        )}
-        {transcript.map((item) => (
-          <TranscriptEntry key={item.id} item={item} />
-        ))}
-        {agentStatus === "running" && (
-          <span className="inline-block h-4 w-2 animate-pulse bg-gray-400" aria-label="Jiki is working" />
+    <div className={styles.chat}>
+      <PaneHeader
+        title={
+          <span className={styles.headerTitle}>
+            <span className={styles.avatar}>J</span> Jiki
+          </span>
+        }
+      />
+      <div ref={scrollRef} className={styles.scroll}>
+        {transcript.length === 0 ? (
+          <EmptyState hasKey={hasKey} disabled={isRunning} onPick={send} />
+        ) : (
+          <>
+            {transcript.map((item) => (
+              <TranscriptEntry key={item.id} item={item} />
+            ))}
+            {isRunning && <span className={styles.working} aria-label="Jiki is working" />}
+          </>
         )}
       </div>
-      <ChatInput orchestrator={orchestrator} disabled={agentStatus === "running"} />
+      <ChatComposer disabled={isRunning} onSend={send} />
+    </div>
+  );
+}
+
+function EmptyState({
+  hasKey,
+  disabled,
+  onPick
+}: {
+  hasKey: boolean;
+  disabled: boolean;
+  onPick: (text: string) => void;
+}) {
+  if (!hasKey) {
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyAvatar}>J</div>
+        <h3 className={styles.emptyTitle}>Add a key to get started</h3>
+        <p className={styles.emptyText}>
+          Jiki needs a model to talk to. Open the <strong>debug</strong> panel at the bottom of the screen and paste an
+          API key under Controls, then message me here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.empty}>
+      <div className={styles.emptyAvatar}>J</div>
+      <h3 className={styles.emptyTitle}>Let&apos;s build your homepage</h3>
+      <p className={styles.emptyText}>
+        Tell me what you&apos;d like to make. I can edit your files and run the code for you.
+      </p>
+      <div className={styles.chips}>
+        {SUGGESTIONS.map((text) => (
+          <button key={text} className={styles.chip} disabled={disabled} onClick={() => onPick(text)}>
+            {text}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }
@@ -43,59 +106,92 @@ export function ChatPane({ orchestrator }: { orchestrator: Orchestrator }) {
 function TranscriptEntry({ item }: { item: TranscriptItem }) {
   switch (item.kind) {
     case "user":
-      return <p className="whitespace-pre-wrap text-gray-500">&gt; {item.content}</p>;
+      return <div className={styles.userMessage}>{item.content}</div>;
     case "assistant":
-      return <p className="whitespace-pre-wrap">{item.content}</p>;
+      return <p className={styles.assistantMessage}>{item.content}</p>;
     case "tool":
       return <ToolLine item={item} />;
     case "notice":
-      return <p className="text-sm italic text-amber-700">{item.content}</p>;
+      return <p className={styles.notice}>{item.content}</p>;
   }
 }
 
 function ToolLine({ item }: { item: Extract<TranscriptItem, { kind: "tool" }> }) {
-  const glyph = item.status === "running" ? "…" : item.status === "error" ? "⚠" : glyphFor(item.name);
+  const isError = item.status === "error";
+  const isRun = item.name === "run_code";
+  const glyph = item.status === "running" ? "…" : isError ? "⚠" : glyphFor(item.name);
   return (
-    <p className={`text-sm ${item.status === "error" ? "text-error-text" : "text-gray-500"}`}>
-      {glyph} {item.label}
-      {item.detail && <span className="text-gray-400"> · {item.detail}</span>}
-    </p>
+    <div className={`${styles.activity} ${isError ? styles.activityError : ""} ${isRun ? styles.activityRun : ""}`}>
+      <span className={styles.activityGlyph}>{glyph}</span>
+      <span>{item.label}</span>
+      {item.detail && <span className={styles.activityDetail}> · {item.detail}</span>}
+    </div>
   );
 }
 
-function ChatInput({ orchestrator, disabled }: { orchestrator: Orchestrator; disabled: boolean }) {
+function ChatComposer({ disabled, onSend }: { disabled: boolean; onSend: (text: string) => void }) {
   const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const handleSubmit = () => {
+  // Auto-grow: reset to content height each keystroke, capped by max-height.
+  const resize = () => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  };
+
+  const handleSend = () => {
     const text = value.trim();
     if (!text || disabled) {
       return;
     }
+    onSend(text);
     setValue("");
-    void orchestrator.sendMessage(text);
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = "auto";
+    }
   };
 
   return (
-    <textarea
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          handleSubmit();
-        }
-      }}
-      placeholder={disabled ? "Jiki is working…" : "Message Jiki…"}
-      rows={2}
-      className="w-full resize-none border-t border-border-primary bg-transparent px-4 py-3 text-[15px] outline-none placeholder:text-gray-400"
-    />
+    <div className={styles.composer}>
+      <div className={styles.composerField}>
+        <textarea
+          ref={textareaRef}
+          className={styles.textarea}
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            resize();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSend();
+            }
+          }}
+          placeholder={disabled ? "Jiki is working…" : "Message Jiki…"}
+          rows={1}
+        />
+        <button
+          className={styles.sendButton}
+          onClick={handleSend}
+          disabled={disabled || !value.trim()}
+          aria-label="Send"
+        >
+          <SendArrow />
+        </button>
+      </div>
+    </div>
   );
 }
 
 function glyphFor(toolName: string): string {
   const glyphs: Record<string, string> = {
-    write_file: "✏️",
-    edit_file: "✏️",
+    write_file: "✎",
+    edit_file: "✎",
     delete_file: "🗑",
     read_file: "📄",
     list_files: "📄",

--- a/app/components/project-builder/ui/CodeEditor.module.css
+++ b/app/components/project-builder/ui/CodeEditor.module.css
@@ -1,0 +1,19 @@
+.editor {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.surface {
+    min-height: 0;
+    flex: 1;
+    overflow: hidden;
+}
+
+.surface :global(.cm-editor) {
+    height: 100%;
+}
+
+.surface :global(.cm-scroller) {
+    overflow: auto;
+}

--- a/app/components/project-builder/ui/CodeEditor.tsx
+++ b/app/components/project-builder/ui/CodeEditor.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+// One CodeMirror EditorView with a per-file EditorState cache so switching
+// files preserves undo history. Agent edits to the active file are applied as
+// a single replace-all transaction.
+
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { css } from "@codemirror/lang-css";
+import { html } from "@codemirror/lang-html";
+import { javascript } from "@codemirror/lang-javascript";
+import { EditorState, type Extension } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+import { useEffect, useRef } from "react";
+import type { Orchestrator } from "../lib/Orchestrator";
+import { useProjectBuilderStore } from "../lib/store";
+
+export function CodeEditor({ orchestrator }: { orchestrator: Orchestrator }) {
+  const { activeFile, files } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
+    activeFile: state.activeFile,
+    files: state.files
+  }));
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const stateCacheRef = useRef<Map<string, EditorState>>(new Map());
+  const displayedFileRef = useRef<string | null>(null);
+  // Set while we apply an external (agent) change so the update listener
+  // doesn't echo it back into the store.
+  const applyingExternalRef = useRef(false);
+
+  // Create/destroy the view with the DOM element (StrictMode-safe).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const view = new EditorView({ parent: container });
+    const stateCache = stateCacheRef.current;
+    viewRef.current = view;
+    displayedFileRef.current = null;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+      stateCache.clear();
+      displayedFileRef.current = null;
+    };
+  }, []);
+
+  // Swap in the active file's state; sync external content changes.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) {
+      return;
+    }
+    const content = files[activeFile] ?? "";
+
+    if (displayedFileRef.current !== activeFile) {
+      if (displayedFileRef.current !== null) {
+        stateCacheRef.current.set(displayedFileRef.current, view.state);
+      }
+      const cached = stateCacheRef.current.get(activeFile);
+      const state =
+        cached && cached.doc.toString() === content
+          ? cached
+          : EditorState.create({ doc: content, extensions: extensionsFor(activeFile, orchestrator) });
+      view.setState(state);
+      displayedFileRef.current = activeFile;
+      return;
+    }
+
+    const currentDoc = view.state.doc.toString();
+    if (currentDoc !== content) {
+      applyingExternalRef.current = true;
+      view.dispatch({ changes: { from: 0, to: currentDoc.length, insert: content } });
+      applyingExternalRef.current = false;
+    }
+  }, [activeFile, files, orchestrator]);
+
+  function extensionsFor(filename: string, orch: Orchestrator): Extension[] {
+    return [
+      lineNumbers(),
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
+      languageFor(filename),
+      EditorView.theme({ "&": { height: "100%", fontSize: "14px" } }),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged && !applyingExternalRef.current) {
+          orch.updateFileFromEditor(filename, update.state.doc.toString());
+        }
+      })
+    ];
+  }
+
+  return (
+    <div ref={containerRef} className="h-full overflow-hidden [&_.cm-editor]:h-full [&_.cm-scroller]:overflow-auto" />
+  );
+}
+
+function languageFor(filename: string): Extension {
+  if (filename.endsWith(".html")) {
+    return html();
+  }
+  if (filename.endsWith(".css")) {
+    return css();
+  }
+  return javascript();
+}

--- a/app/components/project-builder/ui/CodeEditor.tsx
+++ b/app/components/project-builder/ui/CodeEditor.tsx
@@ -13,6 +13,8 @@ import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { useEffect, useRef } from "react";
 import type { Orchestrator } from "../lib/Orchestrator";
 import { useProjectBuilderStore } from "../lib/store";
+import styles from "./CodeEditor.module.css";
+import { PaneHeader } from "./PaneHeader";
 
 export function CodeEditor({ orchestrator }: { orchestrator: Orchestrator }) {
   const { activeFile, files } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
@@ -81,7 +83,16 @@ export function CodeEditor({ orchestrator }: { orchestrator: Orchestrator }) {
       history(),
       keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
       languageFor(filename),
-      EditorView.theme({ "&": { height: "100%", fontSize: "14px" } }),
+      EditorView.theme({
+        "&": { height: "100%", fontSize: "13.5px" },
+        ".cm-content": { padding: "10px 0", lineHeight: "1.6" },
+        ".cm-gutters": {
+          background: "var(--color-bg-secondary)",
+          border: "none",
+          color: "var(--color-text-tertiary)",
+          paddingInlineEnd: "6px"
+        }
+      }),
       EditorView.updateListener.of((update) => {
         if (update.docChanged && !applyingExternalRef.current) {
           orch.updateFileFromEditor(filename, update.state.doc.toString());
@@ -91,7 +102,10 @@ export function CodeEditor({ orchestrator }: { orchestrator: Orchestrator }) {
   }
 
   return (
-    <div ref={containerRef} className="h-full overflow-hidden [&_.cm-editor]:h-full [&_.cm-scroller]:overflow-auto" />
+    <div className={styles.editor}>
+      <PaneHeader title={activeFile} mono />
+      <div ref={containerRef} className={styles.surface} />
+    </div>
   );
 }
 

--- a/app/components/project-builder/ui/DebugControls.module.css
+++ b/app/components/project-builder/ui/DebugControls.module.css
@@ -1,0 +1,155 @@
+/* Styles for the Controls tab of the dev debug drawer: a compact settings
+   card for the BYOK provider / key / model plus registered dev actions. */
+
+.panel {
+    max-width: 460px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    font-family: var(--font-sans);
+}
+
+.intro {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+    margin: 0;
+}
+
+.status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    align-self: flex-start;
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-size: 12.5px;
+    font-weight: 500;
+    font-family: var(--font-sans);
+    border: 1px solid transparent;
+}
+
+.statusReady {
+    background: var(--color-success-bg);
+    color: var(--color-success-text);
+    border-color: var(--color-success-border);
+}
+
+.statusIdle {
+    background: var(--color-warning-bg);
+    color: var(--color-warning-text);
+    border-color: var(--color-warning-border);
+}
+
+.statusDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+}
+
+.statusReady .statusDot {
+    background: var(--color-success-border);
+}
+
+.statusIdle .statusDot {
+    background: var(--color-warning-border);
+}
+
+.fields {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+}
+
+.input,
+.select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 9px 11px;
+    border: 1px solid var(--color-border-secondary);
+    border-radius: 8px;
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.input:focus,
+.select:focus {
+    border-color: var(--color-button-primary-bg);
+}
+
+.input::placeholder {
+    color: var(--color-text-tertiary);
+    font-family: var(--font-sans);
+}
+
+.select {
+    font-family: var(--font-sans);
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 11px center;
+    padding-inline-end: 32px;
+}
+
+.hint {
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--color-text-tertiary);
+    margin: 0;
+}
+
+.link {
+    color: var(--color-link-primary);
+    text-decoration: none;
+}
+
+.link:hover {
+    text-decoration: underline;
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding-top: 4px;
+    border-top: 1px solid var(--color-border-primary);
+}
+
+.actionButton {
+    padding: 7px 12px;
+    border: 1px solid var(--color-border-secondary);
+    border-radius: 8px;
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    cursor: pointer;
+    transition:
+        background 0.15s,
+        border-color 0.15s;
+}
+
+.actionButton:hover {
+    background: var(--color-bg-secondary);
+    border-color: var(--color-button-primary-bg);
+}

--- a/app/components/project-builder/ui/DebugDrawer.tsx
+++ b/app/components/project-builder/ui/DebugDrawer.tsx
@@ -8,7 +8,7 @@
 import { useState } from "react";
 import { useStore } from "zustand";
 import { clearDebugEvents, debugBusStore, type DebugEvent } from "../lib/debug/debugBus";
-import { devSettingsStore, SUGGESTED_MODELS, updateDevSettings } from "../lib/debug/devSettingsStore";
+import { devSettingsStore, PROVIDERS, updateDevSettings, type LlmEndpoint } from "../lib/debug/devSettingsStore";
 import type { Orchestrator } from "../lib/Orchestrator";
 import { useProjectBuilderStore } from "../lib/store";
 
@@ -70,11 +70,25 @@ function ControlsTab() {
   return (
     <div className="flex max-w-xl flex-col gap-2">
       <label className="flex items-center gap-2">
-        <span className="w-28 text-gray-500">OpenRouter key</span>
+        <span className="w-28 text-gray-500">Provider</span>
+        <select
+          value={settings.endpoint}
+          onChange={(e) => updateDevSettings({ endpoint: e.target.value as LlmEndpoint })}
+          className="flex-1 rounded border border-border-primary px-2 py-1"
+        >
+          {Object.entries(PROVIDERS).map(([id, provider]) => (
+            <option key={id} value={id}>
+              {provider.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2">
+        <span className="w-28 text-gray-500">API key</span>
         <input
           type="password"
-          value={settings.openrouterKey}
-          onChange={(e) => updateDevSettings({ openrouterKey: e.target.value })}
+          value={settings.llmKey}
+          onChange={(e) => updateDevSettings({ llmKey: e.target.value })}
           className="flex-1 rounded border border-border-primary px-2 py-1"
         />
       </label>
@@ -87,7 +101,7 @@ function ControlsTab() {
           className="flex-1 rounded border border-border-primary px-2 py-1"
         />
         <datalist id="project-builder-models">
-          {SUGGESTED_MODELS.map((model) => (
+          {PROVIDERS[settings.endpoint].suggestedModels.map((model) => (
             <option key={model} value={model} />
           ))}
         </datalist>

--- a/app/components/project-builder/ui/DebugDrawer.tsx
+++ b/app/components/project-builder/ui/DebugDrawer.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+// Development-only drawer pinned to the bottom of the viewport. Mounted by the
+// dev page (not the app layout) but positioned fixed so it sits "below" the
+// whole UI. Tabs: Controls (BYOK key, model, registered actions), Agent
+// (request/stream events), Console (preview capture), State.
+
+import { useState } from "react";
+import { useStore } from "zustand";
+import { clearDebugEvents, debugBusStore, type DebugEvent } from "../lib/debug/debugBus";
+import { devSettingsStore, SUGGESTED_MODELS, updateDevSettings } from "../lib/debug/devSettingsStore";
+import type { Orchestrator } from "../lib/Orchestrator";
+import { useProjectBuilderStore } from "../lib/store";
+
+type Tab = "controls" | "agent" | "console" | "state";
+
+export function DebugDrawer({ orchestrator }: { orchestrator: Orchestrator }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [tab, setTab] = useState<Tab>("controls");
+
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="fixed bottom-0 left-1/2 z-50 -translate-x-1/2 rounded-t-md border border-b-0 border-border-primary bg-bg-secondary px-4 py-0.5 font-mono text-xs text-gray-500"
+      >
+        debug
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 h-72 border-t border-border-primary bg-bg-primary font-mono text-xs shadow-lg">
+      <div className="flex items-center gap-1 border-b border-border-primary px-2 py-1">
+        {(["controls", "agent", "console", "state"] as Tab[]).map((name) => (
+          <button
+            key={name}
+            onClick={() => setTab(name)}
+            className={`rounded px-2 py-0.5 ${tab === name ? "bg-blue-100 text-blue-900" : "text-gray-500"}`}
+          >
+            {name}
+          </button>
+        ))}
+        <div className="flex-1" />
+        <button onClick={clearDebugEvents} className="px-2 text-gray-400">
+          clear
+        </button>
+        <button onClick={() => setIsOpen(false)} className="px-2 text-gray-400">
+          close
+        </button>
+      </div>
+      <div className="h-[calc(100%-29px)] overflow-y-auto p-2">
+        {tab === "controls" && <ControlsTab />}
+        {tab === "agent" && <EventList channels={["agent"]} />}
+        {tab === "console" && <EventList channels={["console", "preview"]} />}
+        {tab === "state" && <StateTab orchestrator={orchestrator} />}
+      </div>
+    </div>
+  );
+}
+
+function ControlsTab() {
+  const settings = useStore(devSettingsStore);
+  const actions = useStore(debugBusStore, (state) => state.actions);
+
+  return (
+    <div className="flex max-w-xl flex-col gap-2">
+      <label className="flex items-center gap-2">
+        <span className="w-28 text-gray-500">OpenRouter key</span>
+        <input
+          type="password"
+          value={settings.openrouterKey}
+          onChange={(e) => updateDevSettings({ openrouterKey: e.target.value })}
+          className="flex-1 rounded border border-border-primary px-2 py-1"
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        <span className="w-28 text-gray-500">Model</span>
+        <input
+          list="project-builder-models"
+          value={settings.model}
+          onChange={(e) => updateDevSettings({ model: e.target.value })}
+          className="flex-1 rounded border border-border-primary px-2 py-1"
+        />
+        <datalist id="project-builder-models">
+          {SUGGESTED_MODELS.map((model) => (
+            <option key={model} value={model} />
+          ))}
+        </datalist>
+      </label>
+      <div className="flex gap-2">
+        {actions.map((action) => (
+          <button
+            key={action.name}
+            onClick={action.run}
+            className="rounded border border-border-primary px-2 py-1 hover:bg-bg-secondary"
+          >
+            {action.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EventList({ channels }: { channels: string[] }) {
+  const events = useStore(debugBusStore, (state) => state.events);
+  const filtered = events.filter((event) => channels.includes(event.channel));
+
+  return (
+    <div className="flex flex-col gap-1">
+      {filtered.length === 0 && <span className="text-gray-400">no events yet</span>}
+      {filtered.map((event) => (
+        <EventRow key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}
+
+function EventRow({ event }: { event: DebugEvent }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setIsExpanded(!isExpanded)} className="text-left">
+        <span className="text-gray-400">{event.at.slice(11, 19)}</span> <span>{event.label}</span>
+      </button>
+      {isExpanded && event.payload !== undefined && (
+        <pre className="mt-1 overflow-x-auto rounded bg-bg-secondary p-2">{JSON.stringify(event.payload, null, 2)}</pre>
+      )}
+    </div>
+  );
+}
+
+function StateTab({ orchestrator }: { orchestrator: Orchestrator }) {
+  const { files, agentStatus, transcript } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
+    files: state.files,
+    agentStatus: state.agentStatus,
+    transcript: state.transcript
+  }));
+
+  return (
+    <pre className="overflow-x-auto">
+      {JSON.stringify(
+        {
+          agentStatus,
+          transcriptItems: transcript.length,
+          historyMessages: orchestrator.history.length,
+          files: Object.fromEntries(Object.entries(files).map(([name, content]) => [name, `${content.length} chars`]))
+        },
+        null,
+        2
+      )}
+    </pre>
+  );
+}

--- a/app/components/project-builder/ui/DebugDrawer.tsx
+++ b/app/components/project-builder/ui/DebugDrawer.tsx
@@ -11,6 +11,13 @@ import { clearDebugEvents, debugBusStore, type DebugEvent } from "../lib/debug/d
 import { devSettingsStore, PROVIDERS, updateDevSettings, type LlmEndpoint } from "../lib/debug/devSettingsStore";
 import type { Orchestrator } from "../lib/Orchestrator";
 import { useProjectBuilderStore } from "../lib/store";
+import controls from "./DebugControls.module.css";
+
+// Where to grab a free key for each provider, shown as a hint under the field.
+const KEY_SIGNUP_URL: Record<LlmEndpoint, string> = {
+  "opencode-zen": "https://opencode.ai/zen",
+  openrouter: "https://openrouter.ai/keys"
+};
 
 type Tab = "controls" | "agent" | "console" | "state";
 
@@ -26,7 +33,7 @@ export function DebugDrawer({ orchestrator }: { orchestrator: Orchestrator }) {
     return (
       <button
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-0 left-1/2 z-50 -translate-x-1/2 rounded-t-md border border-b-0 border-border-primary bg-bg-secondary px-4 py-0.5 font-mono text-xs text-gray-500"
+        className="fixed bottom-0 left-1/2 z-50 -translate-x-1/2 rounded-t-md border border-b-0 border-border-primary bg-bg-secondary px-4 py-1 font-mono text-sm text-gray-500 shadow-md hover:text-gray-700"
       >
         debug
       </button>
@@ -34,26 +41,32 @@ export function DebugDrawer({ orchestrator }: { orchestrator: Orchestrator }) {
   }
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 h-72 border-t border-border-primary bg-bg-primary font-mono text-xs shadow-lg">
-      <div className="flex items-center gap-1 border-b border-border-primary px-2 py-1">
+    <div className="fixed inset-x-0 bottom-0 z-50 flex h-[60vh] max-h-[600px] min-h-[320px] flex-col border-t border-border-primary bg-bg-primary font-mono text-sm shadow-2xl">
+      <div className="flex flex-shrink-0 items-center gap-1.5 border-b border-border-primary px-3 py-2">
         {(["controls", "agent", "console", "state"] as Tab[]).map((name) => (
           <button
             key={name}
             onClick={() => setTab(name)}
-            className={`rounded px-2 py-0.5 ${tab === name ? "bg-blue-100 text-blue-900" : "text-gray-500"}`}
+            className={`rounded px-3 py-1 ${tab === name ? "bg-blue-100 text-blue-900" : "text-gray-500 hover:bg-bg-secondary"}`}
           >
             {name}
           </button>
         ))}
         <div className="flex-1" />
-        <button onClick={clearDebugEvents} className="px-2 text-gray-400">
+        <button
+          onClick={clearDebugEvents}
+          className="rounded px-3 py-1 text-gray-400 hover:bg-bg-secondary hover:text-gray-600"
+        >
           clear
         </button>
-        <button onClick={() => setIsOpen(false)} className="px-2 text-gray-400">
+        <button
+          onClick={() => setIsOpen(false)}
+          className="rounded px-3 py-1 text-gray-400 hover:bg-bg-secondary hover:text-gray-600"
+        >
           close
         </button>
       </div>
-      <div className="h-[calc(100%-29px)] overflow-y-auto p-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
         {tab === "controls" && <ControlsTab />}
         {tab === "agent" && <EventList channels={["agent"]} />}
         {tab === "console" && <EventList channels={["console", "preview"]} />}
@@ -66,57 +79,79 @@ export function DebugDrawer({ orchestrator }: { orchestrator: Orchestrator }) {
 function ControlsTab() {
   const settings = useStore(devSettingsStore);
   const actions = useStore(debugBusStore, (state) => state.actions);
+  const isReady = settings.llmKey.trim().length > 0;
 
   return (
-    <div className="flex max-w-xl flex-col gap-2">
-      <label className="flex items-center gap-2">
-        <span className="w-28 text-gray-500">Provider</span>
-        <select
-          value={settings.endpoint}
-          onChange={(e) => updateDevSettings({ endpoint: e.target.value as LlmEndpoint })}
-          className="flex-1 rounded border border-border-primary px-2 py-1"
-        >
-          {Object.entries(PROVIDERS).map(([id, provider]) => (
-            <option key={id} value={id}>
-              {provider.label}
-            </option>
-          ))}
-        </select>
-      </label>
-      <label className="flex items-center gap-2">
-        <span className="w-28 text-gray-500">API key</span>
-        <input
-          type="password"
-          value={settings.llmKey}
-          onChange={(e) => updateDevSettings({ llmKey: e.target.value })}
-          className="flex-1 rounded border border-border-primary px-2 py-1"
-        />
-      </label>
-      <label className="flex items-center gap-2">
-        <span className="w-28 text-gray-500">Model</span>
-        <input
-          list="project-builder-models"
-          value={settings.model}
-          onChange={(e) => updateDevSettings({ model: e.target.value })}
-          className="flex-1 rounded border border-border-primary px-2 py-1"
-        />
-        <datalist id="project-builder-models">
-          {PROVIDERS[settings.endpoint].suggestedModels.map((model) => (
-            <option key={model} value={model} />
-          ))}
-        </datalist>
-      </label>
-      <div className="flex gap-2">
-        {actions.map((action) => (
-          <button
-            key={action.name}
-            onClick={action.run}
-            className="rounded border border-border-primary px-2 py-1 hover:bg-bg-secondary"
-          >
-            {action.name}
-          </button>
-        ))}
+    <div className={controls.panel}>
+      <p className={controls.intro}>
+        Connect a model to chat with Jiki. Your key is stored locally and sent straight from the browser.
+      </p>
+
+      <div className={`${controls.status} ${isReady ? controls.statusReady : controls.statusIdle}`}>
+        <span className={controls.statusDot} aria-hidden />
+        {isReady ? `Ready — chatting with ${settings.model}` : "No key yet — add one below to start"}
       </div>
+
+      <div className={controls.fields}>
+        <label className={controls.field}>
+          <span className={controls.label}>Provider</span>
+          <select
+            className={controls.select}
+            value={settings.endpoint}
+            onChange={(e) => updateDevSettings({ endpoint: e.target.value as LlmEndpoint })}
+          >
+            {Object.entries(PROVIDERS).map(([id, provider]) => (
+              <option key={id} value={id}>
+                {provider.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={controls.field}>
+          <span className={controls.label}>API key</span>
+          <input
+            className={controls.input}
+            type="password"
+            value={settings.llmKey}
+            onChange={(e) => updateDevSettings({ llmKey: e.target.value })}
+            placeholder="Paste your API key"
+          />
+          <p className={controls.hint}>
+            Get a free key at{" "}
+            <a className={controls.link} href={KEY_SIGNUP_URL[settings.endpoint]} target="_blank" rel="noreferrer">
+              {KEY_SIGNUP_URL[settings.endpoint].replace(/^https:\/\//, "")}
+            </a>{" "}
+            — no card needed.
+          </p>
+        </label>
+
+        <label className={controls.field}>
+          <span className={controls.label}>Model</span>
+          <input
+            className={controls.input}
+            list="project-builder-models"
+            value={settings.model}
+            onChange={(e) => updateDevSettings({ model: e.target.value })}
+          />
+          <datalist id="project-builder-models">
+            {PROVIDERS[settings.endpoint].suggestedModels.map((model) => (
+              <option key={model} value={model} />
+            ))}
+          </datalist>
+          <p className={controls.hint}>Free models end in “-free”. The default works out of the box.</p>
+        </label>
+      </div>
+
+      {actions.length > 0 && (
+        <div className={controls.actions}>
+          {actions.map((action) => (
+            <button key={action.name} className={controls.actionButton} onClick={action.run}>
+              {action.name}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/components/project-builder/ui/FileTree.module.css
+++ b/app/components/project-builder/ui/FileTree.module.css
@@ -1,0 +1,198 @@
+.tree {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-width: 0;
+}
+
+.headerTitle {
+    display: inline;
+}
+
+.iconButton {
+    width: 26px;
+    height: 26px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: none;
+    cursor: pointer;
+    border-radius: 6px;
+    color: var(--color-text-tertiary);
+}
+
+.iconButton:hover {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+}
+
+.iconButton svg {
+    width: 15px;
+    height: 15px;
+}
+
+/* Chevron points left to collapse; flip it to point right (= expand) when the
+   rail is already collapsed. */
+.collapseButton svg {
+    transform: scaleX(-1);
+}
+
+.list {
+    flex: 1;
+    overflow: auto;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    border-radius: 7px;
+    color: var(--color-text-secondary);
+}
+
+.row:hover {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+}
+
+.rowActive,
+.rowActive:hover {
+    background: var(--color-button-primary-bg);
+    color: var(--color-button-primary-text);
+}
+
+.rowFlash {
+    animation: flash 1s ease-in-out;
+}
+
+@keyframes flash {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
+
+.rowSelect {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 7px 9px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: inherit;
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    text-align: start;
+}
+
+.dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+}
+
+.dotHtml {
+    background: var(--color-amber-500);
+}
+.dotCss {
+    background: var(--color-blue-400);
+}
+.dotJs {
+    background: var(--color-yellow-400);
+}
+.dotOther {
+    background: var(--color-gray-400);
+}
+
+.rowActive .dot {
+    background: var(--color-button-primary-text);
+}
+
+.name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.delete {
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0;
+}
+
+.delete svg {
+    width: 9px;
+    height: 9px;
+}
+
+.row:hover .delete {
+    opacity: 0.5;
+}
+
+.delete:hover {
+    opacity: 1;
+}
+
+.newFileInput {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 9px;
+    border: 1px solid var(--color-border-secondary);
+    border-radius: 7px;
+    background: var(--color-bg-primary);
+    color: var(--color-text-primary);
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    outline: none;
+}
+
+.newFileInput:focus {
+    border-color: var(--color-button-primary-bg);
+}
+
+/* ---- Collapsed rail: a thin strip of file-type dots only ---- */
+.collapsed .headerTitle,
+.collapsed .name {
+    display: none;
+}
+
+.collapsed .list {
+    padding: 8px 0;
+    align-items: center;
+}
+
+.collapsed .row {
+    width: 100%;
+}
+
+.collapsed .rowSelect {
+    justify-content: center;
+    padding: 9px 0;
+    gap: 0;
+}
+
+.collapsed .dot {
+    width: 9px;
+    height: 9px;
+}
+
+.collapsed .collapseButton svg {
+    transform: none;
+}

--- a/app/components/project-builder/ui/FileTree.tsx
+++ b/app/components/project-builder/ui/FileTree.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import type { Orchestrator } from "../lib/Orchestrator";
+import { useProjectBuilderStore } from "../lib/store";
+
+const FLASH_WINDOW_MS = 3000;
+
+export function FileTree({ orchestrator }: { orchestrator: Orchestrator }) {
+  const { files, activeFile, agentEditedAt } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
+    files: state.files,
+    activeFile: state.activeFile,
+    agentEditedAt: state.agentEditedAt
+  }));
+  const [isAdding, setIsAdding] = useState(false);
+  const [newFilename, setNewFilename] = useState("");
+
+  const handleCreate = () => {
+    const filename = newFilename.trim();
+    if (filename) {
+      orchestrator.createFile(filename);
+    }
+    setIsAdding(false);
+    setNewFilename("");
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-1 overflow-y-auto p-2">
+      {Object.keys(files)
+        .sort()
+        .map((filename) => (
+          <FileRow
+            key={filename}
+            filename={filename}
+            isActive={filename === activeFile}
+            wasJustEdited={Date.now() - (agentEditedAt[filename] ?? 0) < FLASH_WINDOW_MS}
+            onSelect={() => orchestrator.setActiveFile(filename)}
+            onDelete={filename === "index.html" ? undefined : () => orchestrator.deleteFileFromUi(filename)}
+          />
+        ))}
+      {isAdding ? (
+        <input
+          autoFocus
+          value={newFilename}
+          onChange={(e) => setNewFilename(e.target.value)}
+          onBlur={handleCreate}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              handleCreate();
+            }
+            if (e.key === "Escape") {
+              setIsAdding(false);
+              setNewFilename("");
+            }
+          }}
+          placeholder="filename.js"
+          className="rounded border border-border-primary px-2 py-1 font-mono text-sm"
+        />
+      ) : (
+        <button
+          onClick={() => setIsAdding(true)}
+          className="mt-1 rounded px-2 py-1 text-left text-sm text-gray-500 hover:bg-bg-secondary"
+        >
+          + file
+        </button>
+      )}
+    </div>
+  );
+}
+
+function FileRow({
+  filename,
+  isActive,
+  wasJustEdited,
+  onSelect,
+  onDelete
+}: {
+  filename: string;
+  isActive: boolean;
+  wasJustEdited: boolean;
+  onSelect: () => void;
+  onDelete?: () => void;
+}) {
+  return (
+    <div
+      className={`group flex items-center justify-between rounded px-2 py-1 font-mono text-sm ${
+        isActive ? "bg-blue-100 text-blue-900" : "hover:bg-bg-secondary"
+      } ${wasJustEdited ? "animate-pulse" : ""}`}
+    >
+      <button onClick={onSelect} className="flex-1 truncate text-left">
+        {filename}
+      </button>
+      {onDelete && (
+        <button
+          onClick={onDelete}
+          className="hidden text-gray-400 hover:text-error-500 group-hover:inline"
+          aria-label={`Delete ${filename}`}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/components/project-builder/ui/FileTree.tsx
+++ b/app/components/project-builder/ui/FileTree.tsx
@@ -1,12 +1,25 @@
 "use client";
 
 import { useState } from "react";
+import ChevronRightIcon from "@/icons/chevron-right.svg";
+import CrossIcon from "@/icons/cross.svg";
+import PlusIcon from "@/icons/plus.svg";
 import type { Orchestrator } from "../lib/Orchestrator";
 import { useProjectBuilderStore } from "../lib/store";
+import styles from "./FileTree.module.css";
+import { PaneHeader } from "./PaneHeader";
 
 const FLASH_WINDOW_MS = 3000;
 
-export function FileTree({ orchestrator }: { orchestrator: Orchestrator }) {
+export function FileTree({
+  orchestrator,
+  collapsed,
+  onToggleCollapsed
+}: {
+  orchestrator: Orchestrator;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}) {
   const { files, activeFile, agentEditedAt } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
     files: state.files,
     activeFile: state.activeFile,
@@ -25,45 +38,62 @@ export function FileTree({ orchestrator }: { orchestrator: Orchestrator }) {
   };
 
   return (
-    <div className="flex h-full flex-col gap-1 overflow-y-auto p-2">
-      {Object.keys(files)
-        .sort()
-        .map((filename) => (
-          <FileRow
-            key={filename}
-            filename={filename}
-            isActive={filename === activeFile}
-            wasJustEdited={Date.now() - (agentEditedAt[filename] ?? 0) < FLASH_WINDOW_MS}
-            onSelect={() => orchestrator.setActiveFile(filename)}
-            onDelete={filename === "index.html" ? undefined : () => orchestrator.deleteFileFromUi(filename)}
-          />
-        ))}
-      {isAdding ? (
-        <input
-          autoFocus
-          value={newFilename}
-          onChange={(e) => setNewFilename(e.target.value)}
-          onBlur={handleCreate}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              handleCreate();
-            }
-            if (e.key === "Escape") {
-              setIsAdding(false);
-              setNewFilename("");
-            }
-          }}
-          placeholder="filename.js"
-          className="rounded border border-border-primary px-2 py-1 font-mono text-sm"
-        />
-      ) : (
+    <div className={`${styles.tree} ${collapsed ? styles.collapsed : ""}`}>
+      <PaneHeader title={<span className={styles.headerTitle}>Files</span>}>
+        {!collapsed && (
+          <button
+            className={styles.iconButton}
+            onClick={() => setIsAdding(true)}
+            aria-label="New file"
+            title="New file"
+          >
+            <PlusIcon />
+          </button>
+        )}
         <button
-          onClick={() => setIsAdding(true)}
-          className="mt-1 rounded px-2 py-1 text-left text-sm text-gray-500 hover:bg-bg-secondary"
+          className={`${styles.iconButton} ${styles.collapseButton}`}
+          onClick={onToggleCollapsed}
+          aria-label={collapsed ? "Expand files" : "Collapse files"}
+          title={collapsed ? "Expand files" : "Collapse files"}
         >
-          + file
+          <ChevronRightIcon />
         </button>
-      )}
+      </PaneHeader>
+
+      <div className={styles.list}>
+        {Object.keys(files)
+          .sort()
+          .map((filename) => (
+            <FileRow
+              key={filename}
+              filename={filename}
+              isActive={filename === activeFile}
+              wasJustEdited={Date.now() - (agentEditedAt[filename] ?? 0) < FLASH_WINDOW_MS}
+              collapsed={collapsed}
+              onSelect={() => orchestrator.setActiveFile(filename)}
+              onDelete={filename === "index.html" ? undefined : () => orchestrator.deleteFileFromUi(filename)}
+            />
+          ))}
+        {isAdding && !collapsed && (
+          <input
+            autoFocus
+            className={styles.newFileInput}
+            value={newFilename}
+            onChange={(e) => setNewFilename(e.target.value)}
+            onBlur={handleCreate}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                handleCreate();
+              }
+              if (e.key === "Escape") {
+                setIsAdding(false);
+                setNewFilename("");
+              }
+            }}
+            placeholder="filename.js"
+          />
+        )}
+      </div>
     </div>
   );
 }
@@ -72,33 +102,45 @@ function FileRow({
   filename,
   isActive,
   wasJustEdited,
+  collapsed,
   onSelect,
   onDelete
 }: {
   filename: string;
   isActive: boolean;
   wasJustEdited: boolean;
+  collapsed: boolean;
   onSelect: () => void;
   onDelete?: () => void;
 }) {
   return (
     <div
-      className={`group flex items-center justify-between rounded px-2 py-1 font-mono text-sm ${
-        isActive ? "bg-blue-100 text-blue-900" : "hover:bg-bg-secondary"
-      } ${wasJustEdited ? "animate-pulse" : ""}`}
+      className={`${styles.row} ${isActive ? styles.rowActive : ""} ${wasJustEdited ? styles.rowFlash : ""}`}
+      title={collapsed ? filename : undefined}
     >
-      <button onClick={onSelect} className="flex-1 truncate text-left">
-        {filename}
+      <button className={styles.rowSelect} onClick={onSelect}>
+        <span className={`${styles.dot} ${styles[dotKind(filename)]}`} aria-hidden />
+        <span className={styles.name}>{filename}</span>
       </button>
-      {onDelete && (
-        <button
-          onClick={onDelete}
-          className="hidden text-gray-400 hover:text-error-500 group-hover:inline"
-          aria-label={`Delete ${filename}`}
-        >
-          ×
+      {onDelete && !collapsed && (
+        <button className={styles.delete} onClick={onDelete} aria-label={`Delete ${filename}`}>
+          <CrossIcon />
         </button>
       )}
     </div>
   );
+}
+
+// A quiet colour cue by file type so the list is scannable at a glance.
+function dotKind(filename: string): "dotHtml" | "dotCss" | "dotJs" | "dotOther" {
+  if (filename.endsWith(".html")) {
+    return "dotHtml";
+  }
+  if (filename.endsWith(".css")) {
+    return "dotCss";
+  }
+  if (filename.endsWith(".js")) {
+    return "dotJs";
+  }
+  return "dotOther";
 }

--- a/app/components/project-builder/ui/PaneHeader.module.css
+++ b/app/components/project-builder/ui/PaneHeader.module.css
@@ -1,0 +1,37 @@
+.header {
+    height: 40px;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 0 10px 0 12px;
+    background: var(--color-bg-secondary);
+    border-bottom: 1px solid var(--color-border-primary);
+}
+
+.title {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.titleMono {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--color-text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.actions {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+}

--- a/app/components/project-builder/ui/PaneHeader.tsx
+++ b/app/components/project-builder/ui/PaneHeader.tsx
@@ -1,0 +1,22 @@
+// Shared header strip for the workspace panes, so Files, Editor, Preview and
+// Jiki all read as one system. `mono` renders the title as a filename.
+
+import type { ReactNode } from "react";
+import styles from "./PaneHeader.module.css";
+
+export function PaneHeader({
+  title,
+  mono = false,
+  children
+}: {
+  title: ReactNode;
+  mono?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <div className={styles.header}>
+      <div className={mono ? styles.titleMono : styles.title}>{title}</div>
+      {children && <div className={styles.actions}>{children}</div>}
+    </div>
+  );
+}

--- a/app/components/project-builder/ui/PreviewPane.module.css
+++ b/app/components/project-builder/ui/PreviewPane.module.css
@@ -1,0 +1,67 @@
+.preview {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.runButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 13px;
+    border: none;
+    border-radius: 7px;
+    background: var(--color-button-primary-bg);
+    color: var(--color-button-primary-text);
+    font-family: inherit;
+    font-size: 12.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: filter 0.15s;
+}
+
+.runButton:hover {
+    filter: brightness(1.05);
+}
+
+.canvas {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    background: #fff;
+}
+
+.frame {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.error {
+    position: absolute;
+    inset-inline: 12px;
+    bottom: 12px;
+    padding: 12px;
+    border: 1px solid var(--color-error-border);
+    border-radius: 8px;
+    background: var(--color-error-bg);
+    color: var(--color-error-text);
+    font-size: 13px;
+    box-shadow: 0 8px 24px var(--color-gray-900-30);
+}
+
+.errorTitle {
+    font-weight: 600;
+}
+
+.errorMessage {
+    margin-top: 4px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+
+.errorHint {
+    margin-top: 6px;
+    font-size: 12px;
+    opacity: 0.8;
+}

--- a/app/components/project-builder/ui/PreviewPane.tsx
+++ b/app/components/project-builder/ui/PreviewPane.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Orchestrator } from "../lib/Orchestrator";
+import { useProjectBuilderStore } from "../lib/store";
+
+export function PreviewPane({ orchestrator }: { orchestrator: Orchestrator }) {
+  const { srcdoc, runCounter, previewError } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
+    srcdoc: state.srcdoc,
+    runCounter: state.runCounter,
+    previewError: state.previewError
+  }));
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  // Register the iframe's window so the orchestrator can attribute postMessages.
+  useEffect(() => {
+    orchestrator.setIframeWindow(iframeRef.current?.contentWindow ?? null);
+    return () => {
+      orchestrator.setIframeWindow(null);
+    };
+  }, [orchestrator, runCounter]);
+
+  // First run on mount.
+  useEffect(() => {
+    if (orchestrator.getStore().getState().srcdoc === null) {
+      orchestrator.run();
+    }
+  }, [orchestrator]);
+
+  return (
+    <div className="relative flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border-primary px-3 py-1.5">
+        <span className="text-sm font-medium text-gray-600">Preview</span>
+        <button
+          onClick={() => orchestrator.run()}
+          className="rounded bg-button-primary-bg px-3 py-1 text-sm font-medium text-button-primary-text"
+        >
+          ▶ Run
+        </button>
+      </div>
+      <div className="relative flex-1 bg-white">
+        {srcdoc !== null && (
+          <iframe
+            key={runCounter}
+            ref={iframeRef}
+            srcDoc={srcdoc}
+            sandbox="allow-scripts"
+            title="Project preview"
+            className="h-full w-full border-0"
+          />
+        )}
+        {previewError && (
+          <div className="absolute inset-x-2 bottom-2 rounded-lg border border-error-border bg-error-bg p-3 text-sm text-error-text shadow">
+            <div className="font-medium">
+              Something went wrong{previewError.filename ? ` in ${previewError.filename}` : ""}
+            </div>
+            <div className="mt-1 font-mono text-xs">
+              {previewError.message}
+              {previewError.line !== undefined && ` (line ${previewError.line})`}
+            </div>
+            <div className="mt-1 text-xs">Ask Jiki about it in the chat.</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/project-builder/ui/PreviewPane.tsx
+++ b/app/components/project-builder/ui/PreviewPane.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef } from "react";
 import type { Orchestrator } from "../lib/Orchestrator";
 import { useProjectBuilderStore } from "../lib/store";
+import { PaneHeader } from "./PaneHeader";
+import styles from "./PreviewPane.module.css";
 
 export function PreviewPane({ orchestrator }: { orchestrator: Orchestrator }) {
   const { srcdoc, runCounter, previewError } = useProjectBuilderStore(orchestrator.getStore(), (state) => ({
@@ -28,17 +30,13 @@ export function PreviewPane({ orchestrator }: { orchestrator: Orchestrator }) {
   }, [orchestrator]);
 
   return (
-    <div className="relative flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-border-primary px-3 py-1.5">
-        <span className="text-sm font-medium text-gray-600">Preview</span>
-        <button
-          onClick={() => orchestrator.run()}
-          className="rounded bg-button-primary-bg px-3 py-1 text-sm font-medium text-button-primary-text"
-        >
-          ▶ Run
+    <div className={styles.preview}>
+      <PaneHeader title="Preview">
+        <button className={styles.runButton} onClick={() => orchestrator.run()}>
+          <span aria-hidden>▶</span> Run
         </button>
-      </div>
-      <div className="relative flex-1 bg-white">
+      </PaneHeader>
+      <div className={styles.canvas}>
         {srcdoc !== null && (
           <iframe
             key={runCounter}
@@ -46,19 +44,19 @@ export function PreviewPane({ orchestrator }: { orchestrator: Orchestrator }) {
             srcDoc={srcdoc}
             sandbox="allow-scripts"
             title="Project preview"
-            className="h-full w-full border-0"
+            className={styles.frame}
           />
         )}
         {previewError && (
-          <div className="absolute inset-x-2 bottom-2 rounded-lg border border-error-border bg-error-bg p-3 text-sm text-error-text shadow">
-            <div className="font-medium">
+          <div className={styles.error}>
+            <div className={styles.errorTitle}>
               Something went wrong{previewError.filename ? ` in ${previewError.filename}` : ""}
             </div>
-            <div className="mt-1 font-mono text-xs">
+            <div className={styles.errorMessage}>
               {previewError.message}
               {previewError.line !== undefined && ` (line ${previewError.line})`}
             </div>
-            <div className="mt-1 text-xs">Ask Jiki about it in the chat.</div>
+            <div className={styles.errorHint}>Ask Jiki about it in the chat.</div>
           </div>
         )}
       </div>

--- a/app/components/project-builder/ui/useResizablePanels.ts
+++ b/app/components/project-builder/ui/useResizablePanels.ts
@@ -1,0 +1,187 @@
+"use client";
+
+// Resizing for the four-pane workspace. Modelled on the coding-exercise
+// useResizablePanels, but for three vertical dividers plus a collapsible file
+// rail. The container is fixed to its own width and clips overflow, so a
+// divider only ever rebalances its two neighbours - nothing can leave the
+// screen. The Files and Jiki rails are pixel-width (clamped); the middle group
+// splits Editor/Preview by percentage so it always sums to 100%.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY = "jiki_project_builder_layout";
+
+const FILES = { min: 160, max: 360, default: 224 };
+const JIKI = { min: 300, max: 560, default: 360 };
+const EDITOR_PCT = { min: 25, max: 75, default: 50 };
+
+type Divider = "files" | "editor" | "jiki";
+
+interface StoredLayout {
+  filesWidth?: number;
+  jikiWidth?: number;
+  editorPercent?: number;
+  filesCollapsed?: boolean;
+}
+
+interface DragState {
+  divider: Divider;
+  startX: number;
+  filesWidth: number;
+  jikiWidth: number;
+  editorWidth: number;
+  middleWidth: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function readStored(): StoredLayout {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStored(update: StoredLayout): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...readStored(), ...update }));
+  } catch {
+    // localStorage unavailable (private mode, quota) - persistence is best-effort
+  }
+}
+
+// document.body is typed non-null but can be gone during teardown; degrade quietly.
+function setBodyDragStyles(cursor: string, userSelect: string): void {
+  const body = document.body as HTMLElement | null;
+  if (body) {
+    body.style.cursor = cursor;
+    body.style.userSelect = userSelect;
+  }
+}
+
+export interface ResizablePanels {
+  filesWidth: number;
+  jikiWidth: number;
+  editorPercent: number;
+  filesCollapsed: boolean;
+  toggleFilesCollapsed: () => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  middleRef: React.RefObject<HTMLDivElement | null>;
+  onDividerMouseDown: (divider: Divider) => (e: React.MouseEvent) => void;
+}
+
+export function useResizablePanels(): ResizablePanels {
+  const [filesWidth, setFilesWidth] = useState(FILES.default);
+  const [jikiWidth, setJikiWidth] = useState(JIKI.default);
+  const [editorPercent, setEditorPercent] = useState(EDITOR_PCT.default);
+  const [filesCollapsed, setFilesCollapsed] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const middleRef = useRef<HTMLDivElement | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+
+  // Restore persisted sizes on mount.
+  useEffect(() => {
+    const stored = readStored();
+    if (typeof stored.filesWidth === "number") {
+      setFilesWidth(clamp(stored.filesWidth, FILES.min, FILES.max));
+    }
+    if (typeof stored.jikiWidth === "number") {
+      setJikiWidth(clamp(stored.jikiWidth, JIKI.min, JIKI.max));
+    }
+    if (typeof stored.editorPercent === "number") {
+      setEditorPercent(clamp(stored.editorPercent, EDITOR_PCT.min, EDITOR_PCT.max));
+    }
+    if (typeof stored.filesCollapsed === "boolean") {
+      setFilesCollapsed(stored.filesCollapsed);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      const drag = dragRef.current;
+      if (!drag) {
+        return;
+      }
+      const dx = e.clientX - drag.startX;
+
+      if (drag.divider === "files") {
+        setFilesWidth(clamp(drag.filesWidth + dx, FILES.min, FILES.max));
+      } else if (drag.divider === "jiki") {
+        // dragging left grows Jiki
+        setJikiWidth(clamp(drag.jikiWidth - dx, JIKI.min, JIKI.max));
+      } else {
+        const percent = ((drag.editorWidth + dx) / drag.middleWidth) * 100;
+        setEditorPercent(clamp(percent, EDITOR_PCT.min, EDITOR_PCT.max));
+      }
+    };
+
+    const handleMouseUp = () => {
+      const drag = dragRef.current;
+      if (!drag) {
+        return;
+      }
+      dragRef.current = null;
+      setBodyDragStyles("", "");
+      if (drag.divider === "files") {
+        writeStored({ filesWidth });
+      } else if (drag.divider === "jiki") {
+        writeStored({ jikiWidth });
+      } else {
+        writeStored({ editorPercent });
+      }
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      setBodyDragStyles("", "");
+    };
+  }, [filesWidth, jikiWidth, editorPercent]);
+
+  const onDividerMouseDown = useCallback(
+    (divider: Divider) => (e: React.MouseEvent) => {
+      // The collapsed files rail is not resizable.
+      if (divider === "files" && filesCollapsed) {
+        return;
+      }
+      e.preventDefault();
+      const middle = middleRef.current;
+      dragRef.current = {
+        divider,
+        startX: e.clientX,
+        filesWidth,
+        jikiWidth,
+        editorWidth: middle ? (middle.offsetWidth * editorPercent) / 100 : 0,
+        middleWidth: middle?.offsetWidth ?? 1
+      };
+      setBodyDragStyles("col-resize", "none");
+    },
+    [filesCollapsed, filesWidth, jikiWidth, editorPercent]
+  );
+
+  const toggleFilesCollapsed = useCallback(() => {
+    setFilesCollapsed((prev) => {
+      writeStored({ filesCollapsed: !prev });
+      return !prev;
+    });
+  }, []);
+
+  return {
+    filesWidth,
+    jikiWidth,
+    editorPercent,
+    filesCollapsed,
+    toggleFilesCollapsed,
+    containerRef,
+    middleRef,
+    onDividerMouseDown
+  };
+}

--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -21,7 +21,9 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
-      "components/ui-kit/icon-types.ts"
+      "components/ui-kit/icon-types.ts",
+      // Vendored third-party ESM libraries served to preview iframes
+      "public/static/vendor/**"
     ]
   },
 

--- a/app/icons/plus.svg
+++ b/app/icons/plus.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 3V13M3 8H13" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -12,7 +12,7 @@ function setCSP(response: NextResponse): void {
 
   // Set Content Security Policy headers
   // Allow unsafe-inline for Next.js inline scripts (required for RSC flight data)
-  // Dev-only: script-src data: + connect-src openrouter.ai are for the
+  // Dev-only: script-src data: + connect-src openrouter.ai/opencode.ai are for the
   // project-builder prototype (data:-URL modules in the sandboxed preview
   // iframe, BYOK model calls). Production needs a dedicated preview origin.
   const cspHeader = `
@@ -22,7 +22,7 @@ function setCSP(response: NextResponse): void {
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self' https://*.jiki.io;
     media-src 'self' blob: https://*.jiki.io https://*.mux.com;
-    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "https://openrouter.ai http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
+    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "https://openrouter.ai https://opencode.ai http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
     frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
     worker-src 'self' blob:;
     object-src 'none';

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -12,14 +12,17 @@ function setCSP(response: NextResponse): void {
 
   // Set Content Security Policy headers
   // Allow unsafe-inline for Next.js inline scripts (required for RSC flight data)
+  // Dev-only: script-src data: + connect-src openrouter.ai are for the
+  // project-builder prototype (data:-URL modules in the sandboxed preview
+  // iframe, BYOK model calls). Production needs a dedicated preview origin.
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com ${isProduction ? "" : "'unsafe-eval' http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
+    script-src 'self' 'unsafe-inline' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://www.gstatic.com https://www.youtube.com https://www.youtube-nocookie.com https://www.ytimg.com https://s.ytimg.com https://challenges.cloudflare.com https://static.cloudflareinsights.com ${isProduction ? "" : "'unsafe-eval' data: http://www.youtube.com http://www.ytimg.com http://s.ytimg.com"};
     style-src 'self' 'unsafe-inline' https://*.jiki.io https://accounts.google.com;
     img-src 'self' blob: data: https://*.stripe.com https://*.mux.com https://*.litix.io https://*.jiki.io https://assets.exercism.org ${isProduction ? "" : "http://localhost:* http://local.jiki.io:*"};
     font-src 'self' https://*.jiki.io;
     media-src 'self' blob: https://*.jiki.io https://*.mux.com;
-    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
+    connect-src 'self' https://*.jiki.io https://*.stripe.com https://accounts.google.com https://*.mux.com https://*.litix.io https://storage.googleapis.com https://*.sentry.io https://cloudflareinsights.com ${isProduction ? "" : "https://openrouter.ai http://localhost:* https://localhost:* http://local.jiki.io:* https://local.jiki.io:* ws://localhost:* ws://127.0.0.1:*"};
     frame-src 'self' https://*.stripe.com https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
     worker-src 'self' blob:;
     object-src 'none';

--- a/app/package.json
+++ b/app/package.json
@@ -45,6 +45,8 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.1",
+    "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-html": "^6.4.11",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/language": "^6.12.1",

--- a/app/public/static/vendor/canvas-confetti-1.9.3.mjs
+++ b/app/public/static/vendor/canvas-confetti-1.9.3.mjs
@@ -1,0 +1,904 @@
+// canvas-confetti v1.9.3 built on 2024-04-30T22:19:17.794Z
+var module = {};
+
+// source content
+/* globals Map */
+
+(function main(global, module, isWorker, workerSize) {
+  var canUseWorker = !!(
+    global.Worker &&
+    global.Blob &&
+    global.Promise &&
+    global.OffscreenCanvas &&
+    global.OffscreenCanvasRenderingContext2D &&
+    global.HTMLCanvasElement &&
+    global.HTMLCanvasElement.prototype.transferControlToOffscreen &&
+    global.URL &&
+    global.URL.createObjectURL
+  );
+
+  var canUsePaths = typeof Path2D === "function" && typeof DOMMatrix === "function";
+  var canDrawBitmap = (function () {
+    // this mostly supports ssr
+    if (!global.OffscreenCanvas) {
+      return false;
+    }
+
+    var canvas = new OffscreenCanvas(1, 1);
+    var ctx = canvas.getContext("2d");
+    ctx.fillRect(0, 0, 1, 1);
+    var bitmap = canvas.transferToImageBitmap();
+
+    try {
+      ctx.createPattern(bitmap, "no-repeat");
+    } catch (e) {
+      return false;
+    }
+
+    return true;
+  })();
+
+  function noop() {}
+
+  // create a promise if it exists, otherwise, just
+  // call the function directly
+  function promise(func) {
+    var ModulePromise = module.exports.Promise;
+    var Prom = ModulePromise !== void 0 ? ModulePromise : global.Promise;
+
+    if (typeof Prom === "function") {
+      return new Prom(func);
+    }
+
+    func(noop, noop);
+
+    return null;
+  }
+
+  var bitmapMapper = (function (skipTransform, map) {
+    // see https://github.com/catdad/canvas-confetti/issues/209
+    // creating canvases is actually pretty expensive, so we should create a
+    // 1:1 map for bitmap:canvas, so that we can animate the confetti in
+    // a performant manner, but also not store them forever so that we don't
+    // have a memory leak
+    return {
+      transform: function (bitmap) {
+        if (skipTransform) {
+          return bitmap;
+        }
+
+        if (map.has(bitmap)) {
+          return map.get(bitmap);
+        }
+
+        var canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+        var ctx = canvas.getContext("2d");
+        ctx.drawImage(bitmap, 0, 0);
+
+        map.set(bitmap, canvas);
+
+        return canvas;
+      },
+      clear: function () {
+        map.clear();
+      }
+    };
+  })(canDrawBitmap, new Map());
+
+  var raf = (function () {
+    var TIME = Math.floor(1000 / 60);
+    var frame, cancel;
+    var frames = {};
+    var lastFrameTime = 0;
+
+    if (typeof requestAnimationFrame === "function" && typeof cancelAnimationFrame === "function") {
+      frame = function (cb) {
+        var id = Math.random();
+
+        frames[id] = requestAnimationFrame(function onFrame(time) {
+          if (lastFrameTime === time || lastFrameTime + TIME - 1 < time) {
+            lastFrameTime = time;
+            delete frames[id];
+
+            cb();
+          } else {
+            frames[id] = requestAnimationFrame(onFrame);
+          }
+        });
+
+        return id;
+      };
+      cancel = function (id) {
+        if (frames[id]) {
+          cancelAnimationFrame(frames[id]);
+        }
+      };
+    } else {
+      frame = function (cb) {
+        return setTimeout(cb, TIME);
+      };
+      cancel = function (timer) {
+        return clearTimeout(timer);
+      };
+    }
+
+    return { frame: frame, cancel: cancel };
+  })();
+
+  var getWorker = (function () {
+    var worker;
+    var prom;
+    var resolves = {};
+
+    function decorate(worker) {
+      function execute(options, callback) {
+        worker.postMessage({ options: options || {}, callback: callback });
+      }
+      worker.init = function initWorker(canvas) {
+        var offscreen = canvas.transferControlToOffscreen();
+        worker.postMessage({ canvas: offscreen }, [offscreen]);
+      };
+
+      worker.fire = function fireWorker(options, size, done) {
+        if (prom) {
+          execute(options, null);
+          return prom;
+        }
+
+        var id = Math.random().toString(36).slice(2);
+
+        prom = promise(function (resolve) {
+          function workerDone(msg) {
+            if (msg.data.callback !== id) {
+              return;
+            }
+
+            delete resolves[id];
+            worker.removeEventListener("message", workerDone);
+
+            prom = null;
+
+            bitmapMapper.clear();
+
+            done();
+            resolve();
+          }
+
+          worker.addEventListener("message", workerDone);
+          execute(options, id);
+
+          resolves[id] = workerDone.bind(null, { data: { callback: id } });
+        });
+
+        return prom;
+      };
+
+      worker.reset = function resetWorker() {
+        worker.postMessage({ reset: true });
+
+        for (var id in resolves) {
+          resolves[id]();
+          delete resolves[id];
+        }
+      };
+    }
+
+    return function () {
+      if (worker) {
+        return worker;
+      }
+
+      if (!isWorker && canUseWorker) {
+        var code = [
+          "var CONFETTI, SIZE = {}, module = {};",
+          "(" + main.toString() + ")(this, module, true, SIZE);",
+          "onmessage = function(msg) {",
+          "  if (msg.data.options) {",
+          "    CONFETTI(msg.data.options).then(function () {",
+          "      if (msg.data.callback) {",
+          "        postMessage({ callback: msg.data.callback });",
+          "      }",
+          "    });",
+          "  } else if (msg.data.reset) {",
+          "    CONFETTI && CONFETTI.reset();",
+          "  } else if (msg.data.resize) {",
+          "    SIZE.width = msg.data.resize.width;",
+          "    SIZE.height = msg.data.resize.height;",
+          "  } else if (msg.data.canvas) {",
+          "    SIZE.width = msg.data.canvas.width;",
+          "    SIZE.height = msg.data.canvas.height;",
+          "    CONFETTI = module.exports.create(msg.data.canvas);",
+          "  }",
+          "}"
+        ].join("\n");
+        try {
+          worker = new Worker(URL.createObjectURL(new Blob([code])));
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          typeof console !== undefined && typeof console.warn === "function"
+            ? console.warn("🎊 Could not load worker", e)
+            : null;
+
+          return null;
+        }
+
+        decorate(worker);
+      }
+
+      return worker;
+    };
+  })();
+
+  var defaults = {
+    particleCount: 50,
+    angle: 90,
+    spread: 45,
+    startVelocity: 45,
+    decay: 0.9,
+    gravity: 1,
+    drift: 0,
+    ticks: 200,
+    x: 0.5,
+    y: 0.5,
+    shapes: ["square", "circle"],
+    zIndex: 100,
+    colors: ["#26ccff", "#a25afd", "#ff5e7e", "#88ff5a", "#fcff42", "#ffa62d", "#ff36ff"],
+    // probably should be true, but back-compat
+    disableForReducedMotion: false,
+    scalar: 1
+  };
+
+  function convert(val, transform) {
+    return transform ? transform(val) : val;
+  }
+
+  function isOk(val) {
+    return !(val === null || val === undefined);
+  }
+
+  function prop(options, name, transform) {
+    return convert(options && isOk(options[name]) ? options[name] : defaults[name], transform);
+  }
+
+  function onlyPositiveInt(number) {
+    return number < 0 ? 0 : Math.floor(number);
+  }
+
+  function randomInt(min, max) {
+    // [min, max)
+    return Math.floor(Math.random() * (max - min)) + min;
+  }
+
+  function toDecimal(str) {
+    return parseInt(str, 16);
+  }
+
+  function colorsToRgb(colors) {
+    return colors.map(hexToRgb);
+  }
+
+  function hexToRgb(str) {
+    var val = String(str).replace(/[^0-9a-f]/gi, "");
+
+    if (val.length < 6) {
+      val = val[0] + val[0] + val[1] + val[1] + val[2] + val[2];
+    }
+
+    return {
+      r: toDecimal(val.substring(0, 2)),
+      g: toDecimal(val.substring(2, 4)),
+      b: toDecimal(val.substring(4, 6))
+    };
+  }
+
+  function getOrigin(options) {
+    var origin = prop(options, "origin", Object);
+    origin.x = prop(origin, "x", Number);
+    origin.y = prop(origin, "y", Number);
+
+    return origin;
+  }
+
+  function setCanvasWindowSize(canvas) {
+    canvas.width = document.documentElement.clientWidth;
+    canvas.height = document.documentElement.clientHeight;
+  }
+
+  function setCanvasRectSize(canvas) {
+    var rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width;
+    canvas.height = rect.height;
+  }
+
+  function getCanvas(zIndex) {
+    var canvas = document.createElement("canvas");
+
+    canvas.style.position = "fixed";
+    canvas.style.top = "0px";
+    canvas.style.left = "0px";
+    canvas.style.pointerEvents = "none";
+    canvas.style.zIndex = zIndex;
+
+    return canvas;
+  }
+
+  function ellipse(context, x, y, radiusX, radiusY, rotation, startAngle, endAngle, antiClockwise) {
+    context.save();
+    context.translate(x, y);
+    context.rotate(rotation);
+    context.scale(radiusX, radiusY);
+    context.arc(0, 0, 1, startAngle, endAngle, antiClockwise);
+    context.restore();
+  }
+
+  function randomPhysics(opts) {
+    var radAngle = opts.angle * (Math.PI / 180);
+    var radSpread = opts.spread * (Math.PI / 180);
+
+    return {
+      x: opts.x,
+      y: opts.y,
+      wobble: Math.random() * 10,
+      wobbleSpeed: Math.min(0.11, Math.random() * 0.1 + 0.05),
+      velocity: opts.startVelocity * 0.5 + Math.random() * opts.startVelocity,
+      angle2D: -radAngle + (0.5 * radSpread - Math.random() * radSpread),
+      tiltAngle: (Math.random() * (0.75 - 0.25) + 0.25) * Math.PI,
+      color: opts.color,
+      shape: opts.shape,
+      tick: 0,
+      totalTicks: opts.ticks,
+      decay: opts.decay,
+      drift: opts.drift,
+      random: Math.random() + 2,
+      tiltSin: 0,
+      tiltCos: 0,
+      wobbleX: 0,
+      wobbleY: 0,
+      gravity: opts.gravity * 3,
+      ovalScalar: 0.6,
+      scalar: opts.scalar,
+      flat: opts.flat
+    };
+  }
+
+  function updateFetti(context, fetti) {
+    fetti.x += Math.cos(fetti.angle2D) * fetti.velocity + fetti.drift;
+    fetti.y += Math.sin(fetti.angle2D) * fetti.velocity + fetti.gravity;
+    fetti.velocity *= fetti.decay;
+
+    if (fetti.flat) {
+      fetti.wobble = 0;
+      fetti.wobbleX = fetti.x + 10 * fetti.scalar;
+      fetti.wobbleY = fetti.y + 10 * fetti.scalar;
+
+      fetti.tiltSin = 0;
+      fetti.tiltCos = 0;
+      fetti.random = 1;
+    } else {
+      fetti.wobble += fetti.wobbleSpeed;
+      fetti.wobbleX = fetti.x + 10 * fetti.scalar * Math.cos(fetti.wobble);
+      fetti.wobbleY = fetti.y + 10 * fetti.scalar * Math.sin(fetti.wobble);
+
+      fetti.tiltAngle += 0.1;
+      fetti.tiltSin = Math.sin(fetti.tiltAngle);
+      fetti.tiltCos = Math.cos(fetti.tiltAngle);
+      fetti.random = Math.random() + 2;
+    }
+
+    var progress = fetti.tick++ / fetti.totalTicks;
+
+    var x1 = fetti.x + fetti.random * fetti.tiltCos;
+    var y1 = fetti.y + fetti.random * fetti.tiltSin;
+    var x2 = fetti.wobbleX + fetti.random * fetti.tiltCos;
+    var y2 = fetti.wobbleY + fetti.random * fetti.tiltSin;
+
+    context.fillStyle =
+      "rgba(" + fetti.color.r + ", " + fetti.color.g + ", " + fetti.color.b + ", " + (1 - progress) + ")";
+
+    context.beginPath();
+
+    if (
+      canUsePaths &&
+      fetti.shape.type === "path" &&
+      typeof fetti.shape.path === "string" &&
+      Array.isArray(fetti.shape.matrix)
+    ) {
+      context.fill(
+        transformPath2D(
+          fetti.shape.path,
+          fetti.shape.matrix,
+          fetti.x,
+          fetti.y,
+          Math.abs(x2 - x1) * 0.1,
+          Math.abs(y2 - y1) * 0.1,
+          (Math.PI / 10) * fetti.wobble
+        )
+      );
+    } else if (fetti.shape.type === "bitmap") {
+      var rotation = (Math.PI / 10) * fetti.wobble;
+      var scaleX = Math.abs(x2 - x1) * 0.1;
+      var scaleY = Math.abs(y2 - y1) * 0.1;
+      var width = fetti.shape.bitmap.width * fetti.scalar;
+      var height = fetti.shape.bitmap.height * fetti.scalar;
+
+      var matrix = new DOMMatrix([
+        Math.cos(rotation) * scaleX,
+        Math.sin(rotation) * scaleX,
+        -Math.sin(rotation) * scaleY,
+        Math.cos(rotation) * scaleY,
+        fetti.x,
+        fetti.y
+      ]);
+
+      // apply the transform matrix from the confetti shape
+      matrix.multiplySelf(new DOMMatrix(fetti.shape.matrix));
+
+      var pattern = context.createPattern(bitmapMapper.transform(fetti.shape.bitmap), "no-repeat");
+      pattern.setTransform(matrix);
+
+      context.globalAlpha = 1 - progress;
+      context.fillStyle = pattern;
+      context.fillRect(fetti.x - width / 2, fetti.y - height / 2, width, height);
+      context.globalAlpha = 1;
+    } else if (fetti.shape === "circle") {
+      context.ellipse
+        ? context.ellipse(
+            fetti.x,
+            fetti.y,
+            Math.abs(x2 - x1) * fetti.ovalScalar,
+            Math.abs(y2 - y1) * fetti.ovalScalar,
+            (Math.PI / 10) * fetti.wobble,
+            0,
+            2 * Math.PI
+          )
+        : ellipse(
+            context,
+            fetti.x,
+            fetti.y,
+            Math.abs(x2 - x1) * fetti.ovalScalar,
+            Math.abs(y2 - y1) * fetti.ovalScalar,
+            (Math.PI / 10) * fetti.wobble,
+            0,
+            2 * Math.PI
+          );
+    } else if (fetti.shape === "star") {
+      var rot = (Math.PI / 2) * 3;
+      var innerRadius = 4 * fetti.scalar;
+      var outerRadius = 8 * fetti.scalar;
+      var x = fetti.x;
+      var y = fetti.y;
+      var spikes = 5;
+      var step = Math.PI / spikes;
+
+      while (spikes--) {
+        x = fetti.x + Math.cos(rot) * outerRadius;
+        y = fetti.y + Math.sin(rot) * outerRadius;
+        context.lineTo(x, y);
+        rot += step;
+
+        x = fetti.x + Math.cos(rot) * innerRadius;
+        y = fetti.y + Math.sin(rot) * innerRadius;
+        context.lineTo(x, y);
+        rot += step;
+      }
+    } else {
+      context.moveTo(Math.floor(fetti.x), Math.floor(fetti.y));
+      context.lineTo(Math.floor(fetti.wobbleX), Math.floor(y1));
+      context.lineTo(Math.floor(x2), Math.floor(y2));
+      context.lineTo(Math.floor(x1), Math.floor(fetti.wobbleY));
+    }
+
+    context.closePath();
+    context.fill();
+
+    return fetti.tick < fetti.totalTicks;
+  }
+
+  function animate(canvas, fettis, resizer, size, done) {
+    var animatingFettis = fettis.slice();
+    var context = canvas.getContext("2d");
+    var animationFrame;
+    var destroy;
+
+    var prom = promise(function (resolve) {
+      function onDone() {
+        animationFrame = destroy = null;
+
+        context.clearRect(0, 0, size.width, size.height);
+        bitmapMapper.clear();
+
+        done();
+        resolve();
+      }
+
+      function update() {
+        if (isWorker && !(size.width === workerSize.width && size.height === workerSize.height)) {
+          size.width = canvas.width = workerSize.width;
+          size.height = canvas.height = workerSize.height;
+        }
+
+        if (!size.width && !size.height) {
+          resizer(canvas);
+          size.width = canvas.width;
+          size.height = canvas.height;
+        }
+
+        context.clearRect(0, 0, size.width, size.height);
+
+        animatingFettis = animatingFettis.filter(function (fetti) {
+          return updateFetti(context, fetti);
+        });
+
+        if (animatingFettis.length) {
+          animationFrame = raf.frame(update);
+        } else {
+          onDone();
+        }
+      }
+
+      animationFrame = raf.frame(update);
+      destroy = onDone;
+    });
+
+    return {
+      addFettis: function (fettis) {
+        animatingFettis = animatingFettis.concat(fettis);
+
+        return prom;
+      },
+      canvas: canvas,
+      promise: prom,
+      reset: function () {
+        if (animationFrame) {
+          raf.cancel(animationFrame);
+        }
+
+        if (destroy) {
+          destroy();
+        }
+      }
+    };
+  }
+
+  function confettiCannon(canvas, globalOpts) {
+    var isLibCanvas = !canvas;
+    var allowResize = !!prop(globalOpts || {}, "resize");
+    var hasResizeEventRegistered = false;
+    var globalDisableForReducedMotion = prop(globalOpts, "disableForReducedMotion", Boolean);
+    var shouldUseWorker = canUseWorker && !!prop(globalOpts || {}, "useWorker");
+    var worker = shouldUseWorker ? getWorker() : null;
+    var resizer = isLibCanvas ? setCanvasWindowSize : setCanvasRectSize;
+    var initialized = canvas && worker ? !!canvas.__confetti_initialized : false;
+    var preferLessMotion = typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion)").matches;
+    var animationObj;
+
+    function fireLocal(options, size, done) {
+      var particleCount = prop(options, "particleCount", onlyPositiveInt);
+      var angle = prop(options, "angle", Number);
+      var spread = prop(options, "spread", Number);
+      var startVelocity = prop(options, "startVelocity", Number);
+      var decay = prop(options, "decay", Number);
+      var gravity = prop(options, "gravity", Number);
+      var drift = prop(options, "drift", Number);
+      var colors = prop(options, "colors", colorsToRgb);
+      var ticks = prop(options, "ticks", Number);
+      var shapes = prop(options, "shapes");
+      var scalar = prop(options, "scalar");
+      var flat = !!prop(options, "flat");
+      var origin = getOrigin(options);
+
+      var temp = particleCount;
+      var fettis = [];
+
+      var startX = canvas.width * origin.x;
+      var startY = canvas.height * origin.y;
+
+      while (temp--) {
+        fettis.push(
+          randomPhysics({
+            x: startX,
+            y: startY,
+            angle: angle,
+            spread: spread,
+            startVelocity: startVelocity,
+            color: colors[temp % colors.length],
+            shape: shapes[randomInt(0, shapes.length)],
+            ticks: ticks,
+            decay: decay,
+            gravity: gravity,
+            drift: drift,
+            scalar: scalar,
+            flat: flat
+          })
+        );
+      }
+
+      // if we have a previous canvas already animating,
+      // add to it
+      if (animationObj) {
+        return animationObj.addFettis(fettis);
+      }
+
+      animationObj = animate(canvas, fettis, resizer, size, done);
+
+      return animationObj.promise;
+    }
+
+    function fire(options) {
+      var disableForReducedMotion = globalDisableForReducedMotion || prop(options, "disableForReducedMotion", Boolean);
+      var zIndex = prop(options, "zIndex", Number);
+
+      if (disableForReducedMotion && preferLessMotion) {
+        return promise(function (resolve) {
+          resolve();
+        });
+      }
+
+      if (isLibCanvas && animationObj) {
+        // use existing canvas from in-progress animation
+        canvas = animationObj.canvas;
+      } else if (isLibCanvas && !canvas) {
+        // create and initialize a new canvas
+        canvas = getCanvas(zIndex);
+        document.body.appendChild(canvas);
+      }
+
+      if (allowResize && !initialized) {
+        // initialize the size of a user-supplied canvas
+        resizer(canvas);
+      }
+
+      var size = {
+        width: canvas.width,
+        height: canvas.height
+      };
+
+      if (worker && !initialized) {
+        worker.init(canvas);
+      }
+
+      initialized = true;
+
+      if (worker) {
+        canvas.__confetti_initialized = true;
+      }
+
+      function onResize() {
+        if (worker) {
+          // TODO this really shouldn't be immediate, because it is expensive
+          var obj = {
+            getBoundingClientRect: function () {
+              if (!isLibCanvas) {
+                return canvas.getBoundingClientRect();
+              }
+            }
+          };
+
+          resizer(obj);
+
+          worker.postMessage({
+            resize: {
+              width: obj.width,
+              height: obj.height
+            }
+          });
+          return;
+        }
+
+        // don't actually query the size here, since this
+        // can execute frequently and rapidly
+        size.width = size.height = null;
+      }
+
+      function done() {
+        animationObj = null;
+
+        if (allowResize) {
+          hasResizeEventRegistered = false;
+          global.removeEventListener("resize", onResize);
+        }
+
+        if (isLibCanvas && canvas) {
+          if (document.body.contains(canvas)) {
+            document.body.removeChild(canvas);
+          }
+          canvas = null;
+          initialized = false;
+        }
+      }
+
+      if (allowResize && !hasResizeEventRegistered) {
+        hasResizeEventRegistered = true;
+        global.addEventListener("resize", onResize, false);
+      }
+
+      if (worker) {
+        return worker.fire(options, size, done);
+      }
+
+      return fireLocal(options, size, done);
+    }
+
+    fire.reset = function () {
+      if (worker) {
+        worker.reset();
+      }
+
+      if (animationObj) {
+        animationObj.reset();
+      }
+    };
+
+    return fire;
+  }
+
+  // Make default export lazy to defer worker creation until called.
+  var defaultFire;
+  function getDefaultFire() {
+    if (!defaultFire) {
+      defaultFire = confettiCannon(null, { useWorker: true, resize: true });
+    }
+    return defaultFire;
+  }
+
+  function transformPath2D(pathString, pathMatrix, x, y, scaleX, scaleY, rotation) {
+    var path2d = new Path2D(pathString);
+
+    var t1 = new Path2D();
+    t1.addPath(path2d, new DOMMatrix(pathMatrix));
+
+    var t2 = new Path2D();
+    // see https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrix/DOMMatrix
+    t2.addPath(
+      t1,
+      new DOMMatrix([
+        Math.cos(rotation) * scaleX,
+        Math.sin(rotation) * scaleX,
+        -Math.sin(rotation) * scaleY,
+        Math.cos(rotation) * scaleY,
+        x,
+        y
+      ])
+    );
+
+    return t2;
+  }
+
+  function shapeFromPath(pathData) {
+    if (!canUsePaths) {
+      throw new Error("path confetti are not supported in this browser");
+    }
+
+    var path, matrix;
+
+    if (typeof pathData === "string") {
+      path = pathData;
+    } else {
+      path = pathData.path;
+      matrix = pathData.matrix;
+    }
+
+    var path2d = new Path2D(path);
+    var tempCanvas = document.createElement("canvas");
+    var tempCtx = tempCanvas.getContext("2d");
+
+    if (!matrix) {
+      // attempt to figure out the width of the path, up to 1000x1000
+      var maxSize = 1000;
+      var minX = maxSize;
+      var minY = maxSize;
+      var maxX = 0;
+      var maxY = 0;
+      var width, height;
+
+      // do some line skipping... this is faster than checking
+      // every pixel and will be mostly still correct
+      for (var x = 0; x < maxSize; x += 2) {
+        for (var y = 0; y < maxSize; y += 2) {
+          if (tempCtx.isPointInPath(path2d, x, y, "nonzero")) {
+            minX = Math.min(minX, x);
+            minY = Math.min(minY, y);
+            maxX = Math.max(maxX, x);
+            maxY = Math.max(maxY, y);
+          }
+        }
+      }
+
+      width = maxX - minX;
+      height = maxY - minY;
+
+      var maxDesiredSize = 10;
+      var scale = Math.min(maxDesiredSize / width, maxDesiredSize / height);
+
+      matrix = [scale, 0, 0, scale, -Math.round(width / 2 + minX) * scale, -Math.round(height / 2 + minY) * scale];
+    }
+
+    return {
+      type: "path",
+      path: path,
+      matrix: matrix
+    };
+  }
+
+  function shapeFromText(textData) {
+    var text,
+      scalar = 1,
+      color = "#000000",
+      // see https://nolanlawson.com/2022/04/08/the-struggle-of-using-native-emoji-on-the-web/
+      fontFamily =
+        '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", "EmojiOne Color", "Android Emoji", "Twemoji Mozilla", "system emoji", sans-serif';
+
+    if (typeof textData === "string") {
+      text = textData;
+    } else {
+      text = textData.text;
+      scalar = "scalar" in textData ? textData.scalar : scalar;
+      fontFamily = "fontFamily" in textData ? textData.fontFamily : fontFamily;
+      color = "color" in textData ? textData.color : color;
+    }
+
+    // all other confetti are 10 pixels,
+    // so this pixel size is the de-facto 100% scale confetti
+    var fontSize = 10 * scalar;
+    var font = "" + fontSize + "px " + fontFamily;
+
+    var canvas = new OffscreenCanvas(fontSize, fontSize);
+    var ctx = canvas.getContext("2d");
+
+    ctx.font = font;
+    var size = ctx.measureText(text);
+    var width = Math.ceil(size.actualBoundingBoxRight + size.actualBoundingBoxLeft);
+    var height = Math.ceil(size.actualBoundingBoxAscent + size.actualBoundingBoxDescent);
+
+    var padding = 2;
+    var x = size.actualBoundingBoxLeft + padding;
+    var y = size.actualBoundingBoxAscent + padding;
+    width += padding + padding;
+    height += padding + padding;
+
+    canvas = new OffscreenCanvas(width, height);
+    ctx = canvas.getContext("2d");
+    ctx.font = font;
+    ctx.fillStyle = color;
+
+    ctx.fillText(text, x, y);
+
+    var scale = 1 / scalar;
+
+    return {
+      type: "bitmap",
+      // TODO these probably need to be transfered for workers
+      bitmap: canvas.transferToImageBitmap(),
+      matrix: [scale, 0, 0, scale, (-width * scale) / 2, (-height * scale) / 2]
+    };
+  }
+
+  module.exports = function () {
+    return getDefaultFire().apply(this, arguments);
+  };
+  module.exports.reset = function () {
+    getDefaultFire().reset();
+  };
+  module.exports.create = confettiCannon;
+  module.exports.shapeFromPath = shapeFromPath;
+  module.exports.shapeFromText = shapeFromText;
+})(
+  (function () {
+    if (typeof window !== "undefined") {
+      return window;
+    }
+
+    if (typeof self !== "undefined") {
+      return self;
+    }
+
+    return this || {};
+  })(),
+  module,
+  false
+);
+
+// end source content
+
+export default module.exports;
+export var create = module.exports.create;

--- a/app/scripts/pre-commit
+++ b/app/scripts/pre-commit
@@ -35,11 +35,14 @@ if [ -n "$STAGED_TS_FILES_RELATIVE" ]; then
     echo "Linting: $STAGED_TS_FILES_RELATIVE"
     # Convert relative paths to absolute paths for eslint
     STAGED_TS_FILES_ABSOLUTE=$(echo "$STAGED_TS_FILES_RELATIVE" | sed "s|^|$APP_DIR/|")
-    pnpm exec eslint --fix $STAGED_TS_FILES_ABSOLUTE
+    # --no-warn-ignored: staged files that eslint.config.mjs ignores (e.g.
+    # vendored files under public/static/vendor) would otherwise emit a
+    # "file ignored" warning and fail --max-warnings=0
+    pnpm exec eslint --fix --no-warn-ignored $STAGED_TS_FILES_ABSOLUTE
     # Re-add any files that eslint auto-fixed
     git add $STAGED_TS_FILES_RELATIVE
     # Now check for remaining errors/warnings
-    pnpm exec eslint $STAGED_TS_FILES_ABSOLUTE --max-warnings=0
+    pnpm exec eslint $STAGED_TS_FILES_ABSOLUTE --max-warnings=0 --no-warn-ignored
     if [ $? -ne 0 ]; then
         echo "❌ Lint check failed (errors or warnings found). Commit aborted."
         exit 1

--- a/app/tests/unit/components/project-builder/previewBuilder.test.ts
+++ b/app/tests/unit/components/project-builder/previewBuilder.test.ts
@@ -1,0 +1,87 @@
+import { buildPreview } from "@/components/project-builder/lib/previewBuilder";
+
+function extractImportMap(srcdoc: string): Record<string, string> {
+  const match = srcdoc.match(/<script type="importmap">(.*?)<\/script>/s);
+  expect(match).not.toBeNull();
+  return (JSON.parse(match![1]) as { imports: Record<string, string> }).imports;
+}
+
+function decodeDataUrl(url: string): string {
+  expect(url).toMatch(/^data:text\/javascript;base64,/);
+  return Buffer.from(url.split(",")[1], "base64").toString("utf-8");
+}
+
+describe("buildPreview", () => {
+  const files = {
+    "index.html": `<!doctype html><html><head><link rel="stylesheet" href="style.css"></head><body><script type="module" src="main.js"></script></body></html>`,
+    "style.css": "body { color: red; }",
+    "main.js": `import { greet } from "./lib/util.js"; greet();`,
+    "lib/util.js": "export function greet() {}"
+  };
+
+  it("maps every js file under all three specifier forms to a data url", () => {
+    const preview = buildPreview(files, []);
+    const imports = extractImportMap(preview.srcdoc);
+
+    for (const filename of ["main.js", "lib/util.js"]) {
+      const url = imports[filename];
+      expect(decodeDataUrl(url)).toBe(files[filename as keyof typeof files]);
+      expect(imports[`./${filename}`]).toBe(url);
+      expect(imports[`/${filename}`]).toBe(url);
+    }
+  });
+
+  it("survives non-latin content", () => {
+    const preview = buildPreview(
+      { "index.html": "<html><head></head></html>", "main.js": `console.log("héllo 🎉");` },
+      []
+    );
+    const imports = extractImportMap(preview.srcdoc);
+    expect(decodeDataUrl(imports["main.js"])).toContain("héllo 🎉");
+  });
+
+  it("maps allowed libraries by bare name", () => {
+    const preview = buildPreview(files, [
+      { name: "canvas-confetti", path: "/static/vendor/canvas-confetti-1.9.3.mjs" }
+    ]);
+    const imports = extractImportMap(preview.srcdoc);
+    expect(imports["canvas-confetti"]).toBe("/static/vendor/canvas-confetti-1.9.3.mjs");
+  });
+
+  it("inlines project stylesheets", () => {
+    const preview = buildPreview(files, []);
+    expect(preview.srcdoc).toContain("<style>\nbody { color: red; }\n</style>");
+    expect(preview.srcdoc).not.toContain('href="style.css"');
+  });
+
+  it("rewrites project script tags to data urls as modules", () => {
+    const preview = buildPreview(files, []);
+    expect(preview.srcdoc).toMatch(/<script type="module" src="data:text\/javascript;base64,[^"]+"><\/script>/);
+    expect(preview.srcdoc).not.toContain('src="main.js"');
+  });
+
+  it("leaves external links and scripts alone", () => {
+    const external = {
+      "index.html": `<html><head><link rel="stylesheet" href="https://example.com/x.css"><script src="https://example.com/x.js"></script></head><body></body></html>`
+    };
+    const preview = buildPreview(external, []);
+    expect(preview.srcdoc).toContain('href="https://example.com/x.css"');
+    expect(preview.srcdoc).toContain('src="https://example.com/x.js"');
+  });
+
+  it("injects the console shim and import map into head", () => {
+    const preview = buildPreview(files, []);
+    expect(preview.srcdoc).toContain("__jikiProjectBuilder");
+    expect(preview.srcdoc.indexOf("importmap")).toBeLessThan(preview.srcdoc.indexOf("main.js"));
+  });
+
+  it("records the url-to-file mapping for error attribution", () => {
+    const preview = buildPreview(files, []);
+    expect(Object.values(preview.urlToFile).sort()).toEqual(["lib/util.js", "main.js"]);
+  });
+
+  it("falls back to a placeholder document without index.html", () => {
+    const preview = buildPreview({ "main.js": "" }, []);
+    expect(preview.srcdoc).toContain("needs an <code>index.html</code>");
+  });
+});

--- a/app/tests/unit/components/project-builder/tools.test.ts
+++ b/app/tests/unit/components/project-builder/tools.test.ts
@@ -1,0 +1,155 @@
+import type { Orchestrator } from "@/components/project-builder/lib/Orchestrator";
+import { executeTool, MAX_FILES } from "@/components/project-builder/lib/tools";
+import type { ConsoleLine, PreviewError, ProjectFiles } from "@/components/project-builder/lib/types";
+
+// A minimal stand-in for the orchestrator: just the file-state surface the
+// tools use, plus a stubbed runForAgent.
+function fakeOrchestrator(
+  initialFiles: ProjectFiles,
+  runResult: { consoleLines: ConsoleLine[]; error: PreviewError | null } = { consoleLines: [], error: null }
+) {
+  const files = { ...initialFiles };
+  return {
+    orchestrator: {
+      getFiles: () => files,
+      agentSetFile: (filename: string, content: string) => {
+        files[filename] = content;
+      },
+      agentDeleteFile: (filename: string) => {
+        delete files[filename];
+      },
+      runForAgent: () => Promise.resolve(runResult)
+    } as unknown as Orchestrator,
+    files
+  };
+}
+
+function args(value: object): string {
+  return JSON.stringify(value);
+}
+
+describe("executeTool", () => {
+  describe("edit_file", () => {
+    it("replaces a unique match", async () => {
+      const { orchestrator, files } = fakeOrchestrator({ "main.js": "const a = 1;\nconst b = 2;" });
+      const result = await executeTool(
+        orchestrator,
+        "edit_file",
+        args({ filename: "main.js", old_str: "const b = 2;", new_str: "const b = 3;" })
+      );
+      expect(result.isError).toBe(false);
+      expect(files["main.js"]).toBe("const a = 1;\nconst b = 3;");
+    });
+
+    it("errors when old_str is missing", async () => {
+      const { orchestrator } = fakeOrchestrator({ "main.js": "const a = 1;" });
+      const result = await executeTool(
+        orchestrator,
+        "edit_file",
+        args({ filename: "main.js", old_str: "nope", new_str: "x" })
+      );
+      expect(result.isError).toBe(true);
+      expect(result.result).toContain("not found");
+    });
+
+    it("errors when old_str matches more than once", async () => {
+      const { orchestrator, files } = fakeOrchestrator({ "main.js": "x = 1;\nx = 1;" });
+      const result = await executeTool(
+        orchestrator,
+        "edit_file",
+        args({ filename: "main.js", old_str: "x = 1;", new_str: "y" })
+      );
+      expect(result.isError).toBe(true);
+      expect(result.result).toContain("2 times");
+      expect(files["main.js"]).toBe("x = 1;\nx = 1;");
+    });
+  });
+
+  describe("write_file", () => {
+    it("creates and overwrites files", async () => {
+      const { orchestrator, files } = fakeOrchestrator({ "index.html": "" });
+      await executeTool(orchestrator, "write_file", args({ filename: "style.css", content: "body {}" }));
+      expect(files["style.css"]).toBe("body {}");
+    });
+
+    it("rejects path traversal", async () => {
+      const { orchestrator } = fakeOrchestrator({ "index.html": "" });
+      const result = await executeTool(orchestrator, "write_file", args({ filename: "../evil.js", content: "" }));
+      expect(result.isError).toBe(true);
+    });
+
+    it("rejects a 21st file", async () => {
+      const many: ProjectFiles = {};
+      for (let i = 0; i < MAX_FILES; i++) {
+        many[`f${i}.js`] = "";
+      }
+      const { orchestrator } = fakeOrchestrator(many);
+      const result = await executeTool(orchestrator, "write_file", args({ filename: "one-more.js", content: "" }));
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("delete_file", () => {
+    it("refuses to delete index.html", async () => {
+      const { orchestrator, files } = fakeOrchestrator({ "index.html": "x" });
+      const result = await executeTool(orchestrator, "delete_file", args({ filename: "index.html" }));
+      expect(result.isError).toBe(true);
+      expect(files["index.html"]).toBe("x");
+    });
+  });
+
+  describe("read_file", () => {
+    it("returns numbered lines for a range", async () => {
+      const { orchestrator } = fakeOrchestrator({ "main.js": "one\ntwo\nthree\nfour" });
+      const result = await executeTool(
+        orchestrator,
+        "read_file",
+        args({ filename: "main.js", start_line: 2, end_line: 3 })
+      );
+      expect(result.result).toBe("2: two\n3: three");
+    });
+  });
+
+  describe("glob", () => {
+    it("matches * within a segment and ** across segments", async () => {
+      const { orchestrator } = fakeOrchestrator({ "a.css": "", "lib/b.css": "", "lib/c.js": "" });
+      const star = await executeTool(orchestrator, "glob", args({ pattern: "*.css" }));
+      expect(star.result).toBe("a.css");
+      const doubleStar = await executeTool(orchestrator, "glob", args({ pattern: "**.css" }));
+      expect(doubleStar.result).toBe("a.css\nlib/b.css");
+    });
+  });
+
+  describe("grep", () => {
+    it("returns filename:line matches", async () => {
+      const { orchestrator } = fakeOrchestrator({
+        "main.js": "let color = 'red';",
+        "style.css": "h1 { color: blue; }"
+      });
+      const result = await executeTool(orchestrator, "grep", args({ pattern: "color" }));
+      expect(result.result).toContain("main.js:1:");
+      expect(result.result).toContain("style.css:1:");
+    });
+  });
+
+  describe("run_code", () => {
+    it("reports console output and errors", async () => {
+      const { orchestrator } = fakeOrchestrator(
+        { "index.html": "" },
+        { consoleLines: [{ level: "log", text: "hi" }], error: { message: "boom", filename: "main.js", line: 3 } }
+      );
+      const result = await executeTool(orchestrator, "run_code", "{}");
+      expect(result.isError).toBe(true);
+      expect(result.result).toContain("[log] hi");
+      expect(result.result).toContain("boom");
+      expect(result.result).toContain("main.js:3");
+    });
+  });
+
+  it("reports unknown tools", async () => {
+    const { orchestrator } = fakeOrchestrator({});
+    const result = await executeTool(orchestrator, "bash", "{}");
+    expect(result.isError).toBe(true);
+    expect(result.result).toContain("unknown tool");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@codemirror/commands':
         specifier: ^6.10.1
         version: 6.10.3
+      '@codemirror/lang-css':
+        specifier: ^6.3.1
+        version: 6.3.1
+      '@codemirror/lang-html':
+        specifier: ^6.4.11
+        version: 6.4.11
       '@codemirror/lang-javascript':
         specifier: ^6.2.5
         version: 6.2.5
@@ -1484,6 +1490,12 @@ packages:
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
   '@codemirror/lang-javascript@6.2.5':
     resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
 
@@ -2645,8 +2657,14 @@ packages:
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
+  '@lezer/css@1.3.4':
+    resolution: {integrity: sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==}
+
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
 
   '@lezer/lr@1.4.7':
     resolution: {integrity: sha512-wNIFWdSUfX9Jc6ePMzxSPVgTVB4EOfDIwLQLWASyiUdHKaMsiilj9bYiGkGQCKVodd0x6bgQCV207PILGFCF9Q==}
@@ -10189,6 +10207,26 @@ snapshots:
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
 
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.4
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.4
+      '@lezer/html': 1.3.13
+
   '@codemirror/lang-javascript@6.2.5':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
@@ -11140,9 +11178,21 @@ snapshots:
 
   '@lezer/common@1.5.2': {}
 
+  '@lezer/css@1.3.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.7
+
   '@lezer/highlight@1.2.3':
     dependencies:
       '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.7
 
   '@lezer/lr@1.4.7':
     dependencies:


### PR DESCRIPTION
## What

A `/dev/project-builder` prototype of an **agentic project editor** — a virtual file map + CodeMirror editor, a sandboxed `srcdoc` preview built from `data:`-URL modules and import maps (no bundler), a console/error shim, and a BYOK agent loop that drives 8 client-side tools (`list`/`glob`/`read`/`write`/`edit`/`delete`/`grep`/`run_code`).

Built as a prototype by Claude (`claude-fable-5`) out of the `jiki-browser-agent-research-brief.md` research task.

## Highlights

- **Provider-switchable LLM client** — supports OpenAI-compatible providers (OpenRouter, OpenCode Zen), selectable in the debug drawer. OpenRouter goes browser-direct (the real BYOK path); Zen (no browser CORS) routes through a dev-only same-origin relay at `/dev/project-builder/api/llm`.
- **Sandboxed preview** — `data:`-URL modules + import maps in an opaque-origin iframe, no bundler needed.
- **Dev-only debug drawer** — API key, model, streamed `reasoning_content`, and event log, encapsulated in `components/project-builder`.
- **Dev-only CSP additions** — `script-src data:` (sandboxed preview modules) and `connect-src` for the LLM providers. `middleware.ts` already 404s `/dev/*` in production.

## Notes

- **Everything is behind `/dev/`**, which `middleware.ts` 404s in production, so no production surface is affected.
- Rebased onto current `main`; the diff is scoped to `project-builder` files plus the small dev-only `middleware.ts`/`eslint`/`pre-commit`/`package.json` changes.
- Adds `@codemirror/lang-css` and `@codemirror/lang-html`; the lockfile is included so frozen-lockfile CI installs pass.

## Verification

Verified live on `deepseek-v4-flash-free`: the Socratic gate holds on a vague request (zero tool calls), and a confirmed specific request produces the full multi-phase loop (prose, `edit_file` ×2, `run_code`, verified summary) with files actually mutated. `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
