### PR TITLE
i18n blog/help/guides page titles via seo.* catalog

### DIFF
--- a/app/app/(hybrid)/[locale]/blog/[slug]/page.tsx
+++ b/app/app/(hybrid)/[locale]/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
-  return getBlogPostMetadata(slug, locale);
+  return await getBlogPostMetadata(slug, locale);
 }
 
 export default async function AuthenticatedLocaleBlogPostPage({ params }: Props) {

--- a/app/app/(hybrid)/[locale]/blog/page.tsx
+++ b/app/app/(hybrid)/[locale]/blog/page.tsx
@@ -4,6 +4,7 @@ import { SUPPORTED_LOCALES } from "@/lib/locales";
 import { getAvailableLocales } from "@/lib/content";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -12,20 +13,11 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-
-  const titles: Record<string, string> = {
-    en: "Blog - Jiki",
-    es: "Blog - Jiki"
-  };
-
-  const descriptions: Record<string, string> = {
-    en: "Read the latest articles about programming, coding challenges, and learning tips from the Jiki community.",
-    es: "Lee los últimos artículos sobre programación, desafíos de código y consejos de aprendizaje de la comunidad Jiki."
-  };
+  const t = await getTranslations({ locale, namespace: "seo.blog" });
 
   return {
-    title: titles[locale] || titles.en,
-    description: descriptions[locale] || descriptions.en
+    title: t("title"),
+    description: t("description")
   };
 }
 

--- a/app/app/(hybrid)/[locale]/guides/page.tsx
+++ b/app/app/(hybrid)/[locale]/guides/page.tsx
@@ -4,6 +4,7 @@ import { SUPPORTED_LOCALES } from "@/lib/locales";
 import { getAvailableLocales } from "@/lib/content";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -12,18 +13,11 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-
-  const titles: Record<string, string> = {
-    en: "Guides - Jiki"
-  };
-
-  const descriptions: Record<string, string> = {
-    en: "Step by step guides to help you set up your tools and get the most out of Jiki."
-  };
+  const t = await getTranslations({ locale, namespace: "seo.guides" });
 
   return {
-    title: titles[locale] || titles.en,
-    description: descriptions[locale] || descriptions.en
+    title: t("title"),
+    description: t("description")
   };
 }
 

--- a/app/app/(hybrid)/[locale]/help/[slug]/page.tsx
+++ b/app/app/(hybrid)/[locale]/help/[slug]/page.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
-  return getArticleMetadata(slug, locale);
+  return await getArticleMetadata(slug, locale);
 }
 
 export default async function AuthenticatedLocaleArticlePage({ params }: Props) {

--- a/app/app/(hybrid)/[locale]/help/page.tsx
+++ b/app/app/(hybrid)/[locale]/help/page.tsx
@@ -4,6 +4,7 @@ import { SUPPORTED_LOCALES } from "@/lib/locales";
 import { getAvailableLocales } from "@/lib/content";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -12,20 +13,11 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-
-  const titles: Record<string, string> = {
-    en: "Help Center - Jiki",
-    es: "Centro de ayuda - Jiki"
-  };
-
-  const descriptions: Record<string, string> = {
-    en: "Answers, how-tos, and policies to help you get the most out of Jiki.",
-    es: "Respuestas, tutoriales y políticas para ayudarte a sacar el máximo partido a Jiki."
-  };
+  const t = await getTranslations({ locale, namespace: "seo.help" });
 
   return {
-    title: titles[locale] || titles.en,
-    description: descriptions[locale] || descriptions.en
+    title: t("title"),
+    description: t("description")
   };
 }
 

--- a/app/components/articles/ArticleDetailPage.tsx
+++ b/app/components/articles/ArticleDetailPage.tsx
@@ -1,5 +1,6 @@
 import { getArticle, getAllArticles, getRelatedArticles } from "@/lib/content";
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import CTABlock from "../blog/CTABlock";
 import ArticleDetailContent from "./ArticleDetailContent";
@@ -11,12 +12,13 @@ interface ArticleDetailPageProps {
 }
 
 // Helper for generateMetadata
-export function getArticleMetadata(slug: string, locale: string = "en"): Metadata {
+export async function getArticleMetadata(slug: string, locale: string = "en"): Promise<Metadata> {
+  const t = await getTranslations({ locale, namespace: "seo.help" });
   try {
     const allArticles = getAllArticles(locale);
     const article = allArticles.find((a) => a.slug === slug);
     if (!article) {
-      return { title: "Article Not Found" };
+      return { title: t("notFound") };
     }
 
     return {
@@ -25,7 +27,7 @@ export function getArticleMetadata(slug: string, locale: string = "en"): Metadat
       keywords: article.seo.keywords.join(", ")
     };
   } catch {
-    return { title: "Article Not Found" };
+    return { title: t("notFound") };
   }
 }
 

--- a/app/components/blog/BlogPostPage.tsx
+++ b/app/components/blog/BlogPostPage.tsx
@@ -1,5 +1,6 @@
 import { getAllBlogPosts, getBlogPost, getRelatedBlogPosts } from "@/lib/content";
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import BlogPostContent from "./BlogPostContent";
 import CTABlock from "./CTABlock";
@@ -12,12 +13,13 @@ interface BlogPostPageProps {
 }
 
 // Helper for generateMetadata
-export function getBlogPostMetadata(slug: string, locale: string = "en"): Metadata {
+export async function getBlogPostMetadata(slug: string, locale: string = "en"): Promise<Metadata> {
+  const t = await getTranslations({ locale, namespace: "seo.blog" });
   try {
     const allPosts = getAllBlogPosts(locale);
     const post = allPosts.find((p) => p.slug === slug);
     if (!post) {
-      return { title: "Post Not Found" };
+      return { title: t("notFound") };
     }
 
     return {
@@ -27,7 +29,7 @@ export function getBlogPostMetadata(slug: string, locale: string = "en"): Metada
       ...(post.coverImage ? { openGraph: { images: [{ url: post.coverImage }] } } : {})
     };
   } catch {
-    return { title: "Post Not Found" };
+    return { title: t("notFound") };
   }
 }
 

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1029,6 +1029,20 @@
     "unsubscribe": {
       "title": "Unsubscribe - Jiki",
       "description": "Unsubscribe from Jiki emails"
+    },
+    "blog": {
+      "title": "Blog - Jiki",
+      "description": "Read the latest articles about programming, coding challenges, and learning tips from the Jiki community.",
+      "notFound": "Post Not Found"
+    },
+    "help": {
+      "title": "Help Center - Jiki",
+      "description": "Answers, how-tos, and policies to help you get the most out of Jiki.",
+      "notFound": "Article Not Found"
+    },
+    "guides": {
+      "title": "Guides - Jiki",
+      "description": "Step by step guides to help you set up your tools and get the most out of Jiki."
     }
   },
   "toasts": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1029,6 +1029,20 @@
     "unsubscribe": {
       "title": "Leiratkozás - Jiki",
       "description": "Leiratkozás a Jiki e-mailjeiről"
+    },
+    "blog": {
+      "title": "Blog - Jiki",
+      "description": "Read the latest articles about programming, coding challenges, and learning tips from the Jiki community.",
+      "notFound": "Post Not Found"
+    },
+    "help": {
+      "title": "Help Center - Jiki",
+      "description": "Answers, how-tos, and policies to help you get the most out of Jiki.",
+      "notFound": "Article Not Found"
+    },
+    "guides": {
+      "title": "Guides - Jiki",
+      "description": "Step by step guides to help you set up your tools and get the most out of Jiki."
     }
   },
   "toasts": {


### PR DESCRIPTION
## Summary

The `blog`, `help`, and `guides` listing pages set their metadata title and description from inline hardcoded per-locale dicts, bypassing the `seo.*` message catalog that every other listing page uses. The blog/article not-found fallbacks were hardcoded English (`"Post Not Found"`, `"Article Not Found"`) while their guide/concept equivalents were already translated through the catalog.

This moves all of them onto the `seo.*` catalog so they behave like the other 21 SEO titles.

## Changes

- Add `seo.blog`, `seo.help`, `seo.guides` (title + description, plus `notFound` for blog/help) to `messages/en.json` and `messages/hu.json`.
- Listing pages (`blog`, `help`, `guides`) now resolve title/description via `getTranslations("seo.{blog,help,guides}")` instead of inline dicts. Dropped the stray inline `es` entries (es isn't in `ALL_LOCALES` yet).
- `getBlogPostMetadata` / `getArticleMetadata` are now `async` and resolve their not-found title via `getTranslations`; the `[slug]` callers `await` them.

## Translations

Hungarian values are **stubbed as English copies** pending Jeremy's translation pass (per the no-auto-translate convention). The `en`/`hu` key trees stay structurally identical so `messages.test.ts` passes.

## Verification

- `pnpm typecheck` clean; `eslint` clean on changed files.
- Full app test suite (2118 tests) passes, including `messages.test.ts` (ICU validity + identical key trees).
- **SSR checked** against the running dev server — server-rendered `<title>` confirmed for `/blog`, `/help`, `/guides` and their `/hu/*` variants; 404 slugs still render the not-found boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)