### PR TITLE
Fix Prettier formatting on main

### DIFF
--- a/app/.context/seo.md
+++ b/app/.context/seo.md
@@ -18,15 +18,15 @@ Two layers of SEO signal are emitted from the public `(hybrid)/[locale]` tree:
 
 ### What each page emits
 
-| Page | Nodes |
-| --- | --- |
-| `(hybrid)/[locale]/layout.tsx` (all public pages) | `Organization` + `WebSite`, linked by `@id` |
-| `concepts/[slug]` | `LearningResource` + `BreadcrumbList` |
-| `projects/[slug]` | `Course` (free online `CourseInstance`, episodes as `hasPart`) + `BreadcrumbList` |
-| `projects/[slug]/episodes/[episodeSlug]` | `VideoObject` + `BreadcrumbList` |
-| `blog/[slug]` | `BlogPosting` + `BreadcrumbList` |
-| `guides/[slug]` | `TechArticle` + `BreadcrumbList` |
-| `help/[slug]` | `Article` + `BreadcrumbList` |
+| Page                                              | Nodes                                                                             |
+| ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `(hybrid)/[locale]/layout.tsx` (all public pages) | `Organization` + `WebSite`, linked by `@id`                                       |
+| `concepts/[slug]`                                 | `LearningResource` + `BreadcrumbList`                                             |
+| `projects/[slug]`                                 | `Course` (free online `CourseInstance`, episodes as `hasPart`) + `BreadcrumbList` |
+| `projects/[slug]/episodes/[episodeSlug]`          | `VideoObject` + `BreadcrumbList`                                                  |
+| `blog/[slug]`                                     | `BlogPosting` + `BreadcrumbList`                                                  |
+| `guides/[slug]`                                   | `TechArticle` + `BreadcrumbList`                                                  |
+| `help/[slug]`                                     | `Article` + `BreadcrumbList`                                                      |
 
 `VideoObject` on episodes is what populates Google Search Console's **Video indexing**
 report. `embedUrl`/`contentUrl` and the thumbnail are derived from

--- a/app/app/dev/hints-walkthrough/page.tsx
+++ b/app/app/dev/hints-walkthrough/page.tsx
@@ -11,7 +11,12 @@ const sampleHints = [
 ];
 
 const walkthroughVideoData: VideoSource[] = [
-  { provider: "mux", id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU", durationSeconds: 120, uploadDate: "2026-01-01" }
+  {
+    provider: "mux",
+    id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+    durationSeconds: 120,
+    uploadDate: "2026-01-01"
+  }
 ];
 
 export default function HintsWalkthroughPage() {

--- a/app/app/dev/walkthrough-card/page.tsx
+++ b/app/app/dev/walkthrough-card/page.tsx
@@ -11,7 +11,12 @@ function createLesson(overrides: Partial<LessonDisplayData> = {}): LessonDisplay
       description: "A test lesson",
       type: "exercise",
       walkthrough_video_data: [
-        { provider: "mux", id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU", durationSeconds: 120, uploadDate: "2026-01-01" }
+        {
+          provider: "mux",
+          id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+          durationSeconds: 120,
+          uploadDate: "2026-01-01"
+        }
       ]
     },
     completed: false,


### PR DESCRIPTION
## Summary
- The JSON-LD structured data PR (#645) merged unformatted files, breaking the `format` CI check on main
- Runs `prettier --write` on the 3 offending files: `.context/seo.md`, `app/dev/hints-walkthrough/page.tsx`, `app/dev/walkthrough-card/page.tsx`

## Test plan
- [x] `pnpm run format:check` passes across the monorepo
- [x] `pnpm typecheck` passes
- [x] `pnpm run lint` passes (pre-existing unrelated warning only)
- [x] Full test suite passes via pre-commit hook (2130 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011okzL9KwKbyJtNv3UX1NDy