### PR TITLE
Block walking through fire in maze exercises

### DIFF
--- a/curriculum/src/exercise-categories/maze/MazeExercise.ts
+++ b/curriculum/src/exercise-categories/maze/MazeExercise.ts
@@ -80,6 +80,11 @@ export default class MazeExercise extends VisualExercise {
       return;
     }
 
+    if (this.grid[newRow][newCol] === 5) {
+      executionCtx.logicError(this.t("errors.walkedIntoPoop"));
+      return;
+    }
+
     // Update position
     this.characterRow = newRow;
     this.characterCol = newCol;

--- a/curriculum/src/exercise-categories/maze/MazeExercise.ts
+++ b/curriculum/src/exercise-categories/maze/MazeExercise.ts
@@ -75,6 +75,11 @@ export default class MazeExercise extends VisualExercise {
       return;
     }
 
+    if (this.grid[newRow][newCol] === 4) {
+      executionCtx.logicError(this.t("errors.walkedIntoFire"));
+      return;
+    }
+
     // Update position
     this.characterRow = newRow;
     this.characterCol = newCol;

--- a/curriculum/src/exercise-categories/maze/locales/en/translation.json
+++ b/curriculum/src/exercise-categories/maze/locales/en/translation.json
@@ -1,7 +1,8 @@
 {
   "errors": {
     "fellOffEdge": "Oh no - you tried to fall off the edge of the maze!",
-    "hitWall": "Ouch - you walked into a wall!"
+    "hitWall": "Ouch - you walked into a wall!",
+    "walkedIntoFire": "Yikes - you walked straight into the fire!"
   },
   "describers": {
     "move": "Move the character forward one cell",

--- a/curriculum/src/exercise-categories/maze/locales/en/translation.json
+++ b/curriculum/src/exercise-categories/maze/locales/en/translation.json
@@ -2,7 +2,8 @@
   "errors": {
     "fellOffEdge": "Oh no - you tried to fall off the edge of the maze!",
     "hitWall": "Ouch - you walked into a wall!",
-    "walkedIntoFire": "Yikes - you walked straight into the fire!"
+    "walkedIntoFire": "Ouch! You walked into the fire!",
+    "walkedIntoPoop": "Ewww! You walked into the poop! 💩💩💩"
   },
   "describers": {
     "move": "Move the character forward one cell",

--- a/curriculum/src/exercise-categories/maze/locales/hu/translation.json
+++ b/curriculum/src/exercise-categories/maze/locales/hu/translation.json
@@ -1,7 +1,8 @@
 {
   "errors": {
     "fellOffEdge": "Oh no - you tried to fall off the edge of the maze!",
-    "hitWall": "Ouch - you walked into a wall!"
+    "hitWall": "Ouch - you walked into a wall!",
+    "walkedIntoFire": "Yikes - you walked straight into the fire!"
   },
   "describers": {
     "move": "Move the character forward one cell",

--- a/curriculum/src/exercise-categories/maze/locales/hu/translation.json
+++ b/curriculum/src/exercise-categories/maze/locales/hu/translation.json
@@ -2,7 +2,8 @@
   "errors": {
     "fellOffEdge": "Oh no - you tried to fall off the edge of the maze!",
     "hitWall": "Ouch - you walked into a wall!",
-    "walkedIntoFire": "Yikes - you walked straight into the fire!"
+    "walkedIntoFire": "Ouch! You walked into the fire!",
+    "walkedIntoPoop": "Ewww! You walked into the poop! 💩💩💩"
   },
   "describers": {
     "move": "Move the character forward one cell",

--- a/curriculum/src/exercises/maze-automated-solve/Exercise.ts
+++ b/curriculum/src/exercises/maze-automated-solve/Exercise.ts
@@ -73,11 +73,11 @@ export default class MazeAutomatedSolveExercise extends MazeExercise {
       return false;
     }
 
-    // Walls (1) and fire (4) are both impassable — the sensor must agree with
-    // `move`, which raises a logic error on either, so the wall-follower routes
-    // around fire instead of walking into it.
+    // Walls (1), fire (4) and poop (5) are all impassable — the sensor must
+    // agree with `move`, which raises a logic error on each, so the wall-follower
+    // routes around hazards instead of walking into them.
     const cell = this.grid[newRow][newCol];
-    return cell !== 1 && cell !== 4;
+    return cell !== 1 && cell !== 4 && cell !== 5;
   }
 
   private getLeftDirection(): Direction {

--- a/curriculum/src/exercises/maze-automated-solve/Exercise.ts
+++ b/curriculum/src/exercises/maze-automated-solve/Exercise.ts
@@ -73,7 +73,11 @@ export default class MazeAutomatedSolveExercise extends MazeExercise {
       return false;
     }
 
-    return this.grid[newRow][newCol] !== 1;
+    // Walls (1) and fire (4) are both impassable — the sensor must agree with
+    // `move`, which raises a logic error on either, so the wall-follower routes
+    // around fire instead of walking into it.
+    const cell = this.grid[newRow][newCol];
+    return cell !== 1 && cell !== 4;
   }
 
   private getLeftDirection(): Direction {

--- a/curriculum/src/exercises/maze-turn-around/Exercise.ts
+++ b/curriculum/src/exercises/maze-turn-around/Exercise.ts
@@ -73,7 +73,11 @@ export default class MazeTurnAroundExercise extends MazeExercise {
       return false;
     }
 
-    return this.grid[newRow][newCol] !== 1;
+    // Walls (1) and fire (4) are both impassable — the sensor must agree with
+    // `move`, which raises a logic error on either, so the wall-follower routes
+    // around fire instead of walking into it.
+    const cell = this.grid[newRow][newCol];
+    return cell !== 1 && cell !== 4;
   }
 
   private getLeftDirection(): Direction {

--- a/curriculum/src/exercises/maze-turn-around/Exercise.ts
+++ b/curriculum/src/exercises/maze-turn-around/Exercise.ts
@@ -73,11 +73,11 @@ export default class MazeTurnAroundExercise extends MazeExercise {
       return false;
     }
 
-    // Walls (1) and fire (4) are both impassable — the sensor must agree with
-    // `move`, which raises a logic error on either, so the wall-follower routes
-    // around fire instead of walking into it.
+    // Walls (1), fire (4) and poop (5) are all impassable — the sensor must
+    // agree with `move`, which raises a logic error on each, so the wall-follower
+    // routes around hazards instead of walking into them.
     const cell = this.grid[newRow][newCol];
-    return cell !== 1 && cell !== 4;
+    return cell !== 1 && cell !== 4 && cell !== 5;
   }
 
   private getLeftDirection(): Direction {

--- a/curriculum/tests/exercises/maze-fire.test.ts
+++ b/curriculum/tests/exercises/maze-fire.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { ExecutionContext } from "@jiki/interpreters";
+import MazeSolveBasicExercise from "../../src/exercises/maze-solve-basic/Exercise";
+import enDict from "../../src/exercise-categories/maze/locales/en/translation.json";
+
+/**
+ * Fire cells (grid value 4) are hazards, not walkable path. Moving into one must
+ * raise the pre-translated `errors.walkedIntoFire` logic error and leave the
+ * character where it stood, exactly as walls (value 1) do.
+ */
+
+function createMockExecutionContext(): ExecutionContext {
+  return {
+    getCurrentTimeInMs: vi.fn(() => 0),
+    fastForward: vi.fn(),
+    logicError: vi.fn()
+  } as unknown as ExecutionContext;
+}
+
+describe("maze move into fire", () => {
+  let exercise: MazeSolveBasicExercise;
+  let ctx: ExecutionContext;
+
+  beforeEach(() => {
+    ctx = createMockExecutionContext();
+    exercise = new MazeSolveBasicExercise();
+    exercise.setMessages(enDict);
+  });
+
+  it("blocks movement into a fire cell and raises the localized logic error", () => {
+    exercise.setupMaze(
+      [
+        [2, 4, 3],
+        [1, 1, 1],
+        [1, 1, 1]
+      ],
+      0,
+      0,
+      "right"
+    );
+
+    exercise.move(ctx);
+
+    expect(ctx.logicError).toHaveBeenCalledWith("Yikes - you walked straight into the fire!");
+    expect(exercise.characterRow).toBe(0);
+    expect(exercise.characterCol).toBe(0);
+  });
+
+  it("still allows movement onto open path and target cells", () => {
+    exercise.setupMaze(
+      [
+        [2, 0, 3],
+        [1, 1, 1],
+        [1, 1, 1]
+      ],
+      0,
+      0,
+      "right"
+    );
+
+    exercise.move(ctx);
+    exercise.move(ctx);
+
+    expect(ctx.logicError).not.toHaveBeenCalled();
+    expect(exercise.characterCol).toBe(2);
+    expect(exercise.getGameResult()).toBe("win");
+  });
+});

--- a/curriculum/tests/exercises/maze-hazards.test.ts
+++ b/curriculum/tests/exercises/maze-hazards.test.ts
@@ -4,9 +4,9 @@ import MazeSolveBasicExercise from "../../src/exercises/maze-solve-basic/Exercis
 import enDict from "../../src/exercise-categories/maze/locales/en/translation.json";
 
 /**
- * Fire cells (grid value 4) are hazards, not walkable path. Moving into one must
- * raise the pre-translated `errors.walkedIntoFire` logic error and leave the
- * character where it stood, exactly as walls (value 1) do.
+ * Fire cells (grid value 4) and poop cells (grid value 5) are hazards, not
+ * walkable path. Moving into either must raise the matching pre-translated logic
+ * error and leave the character where it stood, exactly as walls (value 1) do.
  */
 
 function createMockExecutionContext(): ExecutionContext {
@@ -17,7 +17,7 @@ function createMockExecutionContext(): ExecutionContext {
   } as unknown as ExecutionContext;
 }
 
-describe("maze move into fire", () => {
+describe("maze move into hazards", () => {
   let exercise: MazeSolveBasicExercise;
   let ctx: ExecutionContext;
 
@@ -41,7 +41,26 @@ describe("maze move into fire", () => {
 
     exercise.move(ctx);
 
-    expect(ctx.logicError).toHaveBeenCalledWith("Yikes - you walked straight into the fire!");
+    expect(ctx.logicError).toHaveBeenCalledWith("Ouch! You walked into the fire!");
+    expect(exercise.characterRow).toBe(0);
+    expect(exercise.characterCol).toBe(0);
+  });
+
+  it("blocks movement into a poop cell and raises the localized logic error", () => {
+    exercise.setupMaze(
+      [
+        [2, 5, 3],
+        [1, 1, 1],
+        [1, 1, 1]
+      ],
+      0,
+      0,
+      "right"
+    );
+
+    exercise.move(ctx);
+
+    expect(ctx.logicError).toHaveBeenCalledWith("Ewww! You walked into the poop! 💩💩💩");
     expect(exercise.characterRow).toBe(0);
     expect(exercise.characterCol).toBe(0);
   });


### PR DESCRIPTION
## Problem

You could walk straight through fire on the maze exercises. Fire cells (grid value `4`) are rendered as hazards, but `MazeExercise.move()` only blocked walls (`1`) and out-of-bounds edges. Fire was treated as ordinary walkable path, so the character strolled over it with no consequence.

## Fix

- **`move()`** now raises a logic error when the target cell is fire, using a new pre-translated `errors.walkedIntoFire` key (added to the maze category `en` + `hu` catalogs, which deep-merge into every maze exercise).
- **`canMoveInDirection()`** (the sensor behind `canMove()` / `canTurnLeft()` / `canTurnRight()` in `maze-automated-solve` and `maze-turn-around`) now treats fire as impassable too. Without this, the automated wall-follower would see `canMove() === true` on a fire cell, step in, and hit the new logic error. Keeping the sensor and the mover in agreement means the solver routes *around* fire, exactly as it does for walls.

## Verification

- New test `tests/exercises/maze-fire.test.ts` proves moving into fire raises the localized error and leaves the character in place, while open path/target cells still work.
- Full solution-validation suite (`all-exercises.test.ts`, 102 solutions) passes — every maze scenario with fire is still solved, confirming the fire cells sit off the intended paths.
- `pnpm typecheck` and the i18n key audit (`en`/`hu`) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)