### PR TITLE
Convert tile-search to a string-based rack (no arrays)

### DIFF
--- a/curriculum/README.md
+++ b/curriculum/README.md
@@ -167,6 +167,7 @@ This is the canonical curriculum structure. Each level contains a sequence of vi
     "lessons": [
       { "type": "exercise", "slug": "reverse-string" },
       { "type": "exercise", "slug": "tile-rack" },
+      { "type": "exercise", "slug": "tile-search" },
       { "type": "exercise", "slug": "sign-price" },
       { "type": "exercise", "slug": "driving-test" }
     ]
@@ -184,7 +185,6 @@ This is the canonical curriculum structure. Each level contains a sequence of vi
     "level": "lists",
     "lessons": [
       { "type": "exercise", "slug": "guest-list" },
-      { "type": "exercise", "slug": "tile-search" },
       { "type": "exercise", "slug": "lunchbox" },
       { "type": "exercise", "slug": "meal-prep" },
       { "type": "exercise", "slug": "process-guess" },

--- a/curriculum/src/exercises/tile-search/index.ts
+++ b/curriculum/src/exercises/tile-search/index.ts
@@ -12,7 +12,7 @@ const exerciseDefinition: IOExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["arrays", "methods", "if", "using-functions-with-return-values"]
+  conceptSlugs: ["string-iteration", "if", "using-functions-with-return-values"]
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/tile-search/instructions/hu.md
+++ b/curriculum/src/exercises/tile-search/instructions/hu.md
@@ -5,17 +5,17 @@ description: "Search through a rack of tiles to find a specific letter."
 
 You're building a Scrabble bot. Before the bot tries to play a word, it needs to check whether it has a specific letter tile in its rack.
 
-The rack is represented as a list of single-letter strings (e.g. `["S", "C", "R", "A", "B"]`).
+The rack is represented as a string of letters (e.g. `"SCRAB"`).
 
-Write a function called `contains` that takes two inputs:
+Write a function called <define>`contains`</define> that takes two inputs:
 
-- `haystack`: the list of tiles in the rack
-- `needle`: the letter to search for
+- <define>`haystack`</define>: the rack of tiles, as a string
+- <define>`needle`</define>: the letter to search for
 
 Return `true` if the letter is in the rack, or `false` if it isn't.
 
 Examples:
 
-- `contains(["S", "C", "R", "A", "B"], "A")` returns `true`
-- `contains(["S", "C", "R", "A", "B"], "Z")` returns `false`
-- `contains([], "A")` returns `false`
+- `contains("SCRAB", "A")` returns `true`
+- `contains("SCRAB", "Z")` returns `false`
+- `contains("", "A")` returns `false`

--- a/curriculum/src/exercises/tile-search/instructions/source.md
+++ b/curriculum/src/exercises/tile-search/instructions/source.md
@@ -5,17 +5,17 @@ description: "Search through a rack of tiles to find a specific letter."
 
 You're building a Scrabble bot. Before the bot tries to play a word, it needs to check whether it has a specific letter tile in its rack.
 
-The rack is represented as a list of single-letter strings (e.g. `["S", "C", "R", "A", "B"]`).
+The rack is represented as a string of letters (e.g. `"SCRAB"`).
 
 Write a function called <define>`contains`</define> that takes two inputs:
 
-- <define>`haystack`</define>: the list of tiles in the rack
+- <define>`haystack`</define>: the rack of tiles, as a string
 - <define>`needle`</define>: the letter to search for
 
 Return `true` if the letter is in the rack, or `false` if it isn't.
 
 Examples:
 
-- `contains(["S", "C", "R", "A", "B"], "A")` returns `true`
-- `contains(["S", "C", "R", "A", "B"], "Z")` returns `false`
-- `contains([], "A")` returns `false`
+- `contains("SCRAB", "A")` returns `true`
+- `contains("SCRAB", "Z")` returns `false`
+- `contains("", "A")` returns `false`

--- a/curriculum/src/exercises/tile-search/llm-metadata.ts
+++ b/curriculum/src/exercises/tile-search/llm-metadata.ts
@@ -19,9 +19,9 @@ export const llmMetadata: LLMMetadata = {
     "search-for-tile": {
       description: `
         Anchor steps:
-        1. Loop through each tile in the haystack.
-        2. Return true immediately when a tile matches the needle.
-        3. Return false only AFTER the loop, once all tiles have been checked.
+        1. Loop through each letter of the haystack string (a for-of loop).
+        2. Return true immediately when a letter matches the needle.
+        3. Return false only AFTER the loop, once all letters have been checked.
 
         The most common trap is returning false inside the loop (which bails
         after the first non-match instead of checking the rest). Use that

--- a/curriculum/src/exercises/tile-search/locales/en/translation.json
+++ b/curriculum/src/exercises/tile-search/locales/en/translation.json
@@ -53,19 +53,19 @@
   "hints": {
     "byHand": {
       "question": "How would I do this by hand?",
-      "answer": "You'd go through the haystack one element at a time, comparing each to the needle. As soon as you found a match you'd stop. If you got to the end without a match, the needle isn't there."
+      "answer": "You'd go through the haystack one letter at a time, comparing each to the needle. As soon as you found a match you'd stop. If you got to the end without a match, the needle isn't there."
     },
     "loopAndCompare": {
       "question": "How do I loop and compare?",
-      "answer": "A for-each loop gives you each element in turn. Inside, an if-statement compares the current element to the needle."
+      "answer": "A for-of loop gives you each letter of the string in turn. Inside, an if-statement compares the current letter to the needle."
     },
     "returnTrue": {
       "question": "When should I return true?",
-      "answer": "As soon as you find a match. There's no point checking the remaining elements."
+      "answer": "As soon as you find a match. There's no point checking the remaining letters."
     },
     "returnFalse": {
       "question": "When should I return false?",
-      "answer": "ONLY after the loop has finished without finding a match. A common mistake is putting `return false` inside the loop. That gives up after the very first non-matching element, before you've checked the rest."
+      "answer": "ONLY after the loop has finished without finding a match. A common mistake is putting `return false` inside the loop. That gives up after the very first non-matching letter, before you've checked the rest."
     }
   }
 }

--- a/curriculum/src/exercises/tile-search/locales/hu/translation.json
+++ b/curriculum/src/exercises/tile-search/locales/hu/translation.json
@@ -53,19 +53,19 @@
   "hints": {
     "byHand": {
       "question": "How would I do this by hand?",
-      "answer": "You'd go through the haystack one element at a time, comparing each to the needle. As soon as you found a match you'd stop. If you got to the end without a match, the needle isn't there."
+      "answer": "You'd go through the haystack one letter at a time, comparing each to the needle. As soon as you found a match you'd stop. If you got to the end without a match, the needle isn't there."
     },
     "loopAndCompare": {
       "question": "How do I loop and compare?",
-      "answer": "A for-each loop gives you each element in turn. Inside, an if-statement compares the current element to the needle."
+      "answer": "A for-of loop gives you each letter of the string in turn. Inside, an if-statement compares the current letter to the needle."
     },
     "returnTrue": {
       "question": "When should I return true?",
-      "answer": "As soon as you find a match. There's no point checking the remaining elements."
+      "answer": "As soon as you find a match. There's no point checking the remaining letters."
     },
     "returnFalse": {
       "question": "When should I return false?",
-      "answer": "ONLY after the loop has finished without finding a match. A common mistake is putting `return false` inside the loop. That gives up after the very first non-matching element, before you've checked the rest."
+      "answer": "ONLY after the loop has finished without finding a match. A common mistake is putting `return false` inside the loop. That gives up after the very first non-matching letter, before you've checked the rest."
     }
   }
 }

--- a/curriculum/src/exercises/tile-search/metadata.json
+++ b/curriculum/src/exercises/tile-search/metadata.json
@@ -1,6 +1,6 @@
 {
   "slug": "tile-search",
-  "levelId": "lists",
+  "levelId": "string-iteration",
   "hints": [
     {
       "question": "hints.byHand.question",

--- a/curriculum/src/exercises/tile-search/scenarios.ts
+++ b/curriculum/src/exercises/tile-search/scenarios.ts
@@ -45,7 +45,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.letterFoundAtStart.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [["S", "C", "R"], "S"],
+    args: ["SCR", "S"],
     expected: true
   },
   {
@@ -54,7 +54,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.letterFoundInMiddle.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [["S", "C", "R", "A", "B"], "R"],
+    args: ["SCRAB", "R"],
     expected: true
   },
   {
@@ -63,7 +63,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.letterFoundAtEnd.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [["S", "C", "R"], "R"],
+    args: ["SCR", "R"],
     expected: true
   },
   {
@@ -72,7 +72,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.letterNotFound.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [["S", "C", "R", "A", "B"], "Z"],
+    args: ["SCRAB", "Z"],
     expected: false
   },
   {
@@ -81,7 +81,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.emptyRack.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [[], "A"],
+    args: ["", "A"],
     expected: false
   },
   {
@@ -90,7 +90,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.duplicateLetters.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [["A", "B", "A", "N", "A"], "N"],
+    args: ["ABANA", "N"],
     expected: true
   },
   {
@@ -99,7 +99,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.singleTileFound.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [["Q"], "Q"],
+    args: ["Q", "Q"],
     expected: true
   },
   {
@@ -108,7 +108,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.singleTileNotFound.description",
     taskId: "search-for-tile",
     functionName: "contains",
-    args: [["Q"], "X"],
+    args: ["Q", "X"],
     expected: false
   },
   {
@@ -117,7 +117,7 @@ export const scenarios: IOScenario[] = [
     description: "scenarios.bonus1.description",
     taskId: "solve-in-eight-lines",
     functionName: "contains",
-    args: [["S", "C", "R", "A", "B"], "A"],
+    args: ["SCRAB", "A"],
     expected: true,
     codeChecks: eightLinesCheck
   }

--- a/curriculum/src/exercises/tile-search/solution.javascript
+++ b/curriculum/src/exercises/tile-search/solution.javascript
@@ -1,6 +1,6 @@
 function contains(haystack, needle) {
-  for (const element of haystack) {
-    if (element === needle) {
+  for (const letter of haystack) {
+    if (letter === needle) {
       return true
     }
   }

--- a/curriculum/src/exercises/tile-search/solution.jiki
+++ b/curriculum/src/exercises/tile-search/solution.jiki
@@ -1,6 +1,6 @@
 function contains with haystack, needle do
-  for each element in haystack do
-    if element == needle do
+  for each letter in haystack do
+    if letter == needle do
       return true
     end
   end

--- a/curriculum/src/exercises/tile-search/solution.py
+++ b/curriculum/src/exercises/tile-search/solution.py
@@ -1,5 +1,5 @@
 def contains(haystack, needle):
-    for element in haystack:
-        if element == needle:
+    for letter in haystack:
+        if letter == needle:
             return True
     return False


### PR DESCRIPTION
## Problem

The **tile-search** exercise took the rack as an array of single-letter strings (`["S", "C", "R", "A", "B"]`), so solving it required iterating an array. It lived in the **lists** level directly after **guest-list** — a near-identical array linear-search exercise (`onGuestList(list, person)` vs `contains(haystack, needle)`, same for-loop shape). Students effectively hit "search a collection" twice, and the reported concern was that it leans on arrays before they've been taught.

## Change

Rework it as a **string** search so it no longer needs arrays:

- Rack is now a string (e.g. `"SCRAB"`); the student iterates it character by character with a `for-of` loop.
- **Moved from the `lists` level to `string-iteration`** (alongside `tile-rack`), where `for-of` over strings is the taught concept. Updated `metadata.json` `levelId`, `conceptSlugs` (`arrays`/`methods` → `string-iteration`), and README ordering.
- Updated scenarios (string args), instructions, hints, `llm-metadata`, and solutions for all three languages.
- Hungarian instructions + translation re-stubbed from English (no auto-translation).

## Verification

- `pnpm typecheck` + `pnpm lint` clean.
- Full curriculum test suite passes (1139 tests), including `all-exercises` solution-vs-scenario validation for tile-search.

## Note

`guest-list` (the array version) is left untouched in the `lists` level. Flagging in case you'd rather it also change or the two want further differentiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)