### PR TITLE
Align exercise levelIds with API curriculum syllabus

### DIFF
--- a/curriculum/README.md
+++ b/curriculum/README.md
@@ -81,8 +81,6 @@ This is the canonical curriculum structure. Each level contains a sequence of vi
       { "type": "exercise", "slug": "golf-rolling-ball-state" },
       { "type": "exercise", "slug": "finish-wall" },
       { "type": "video", "slug": "colors-hsl-rgb" },
-      { "type": "exercise", "slug": "rainbow" },
-      { "type": "exercise", "slug": "sunset" },
       { "type": "project", "slug": "sprouting-flower" }
     ]
   },
@@ -92,6 +90,8 @@ This is the canonical curriculum structure. Each level contains a sequence of vi
       { "type": "video", "slug": "functions-that-return-things" },
       { "type": "exercise", "slug": "dnd-roll" },
       { "type": "exercise", "slug": "gold-panning" },
+      { "type": "exercise", "slug": "rainbow" },
+      { "type": "exercise", "slug": "sunset" },
       { "type": "video", "slug": "random-numbers" },
       { "type": "exercise", "slug": "random-salad" },
       { "type": "exercise", "slug": "stock-market" },

--- a/curriculum/src/exercises/formal-dinner/metadata.json
+++ b/curriculum/src/exercises/formal-dinner/metadata.json
@@ -1,6 +1,6 @@
 {
   "slug": "formal-dinner",
-  "levelId": "everything",
+  "levelId": "lists",
   "hints": [
     {
       "question": "hints.extractSurname.question",

--- a/curriculum/src/exercises/nucleotide-count/metadata.json
+++ b/curriculum/src/exercises/nucleotide-count/metadata.json
@@ -1,6 +1,6 @@
 {
   "slug": "nucleotide-count",
-  "levelId": "everything",
+  "levelId": "dictionaries",
   "hints": [
     {
       "question": "hints.setupCounts.question",

--- a/curriculum/src/exercises/rainbow/metadata.json
+++ b/curriculum/src/exercises/rainbow/metadata.json
@@ -1,6 +1,6 @@
 {
   "slug": "rainbow",
-  "levelId": "basic-state",
+  "levelId": "functions-that-return-things",
   "hints": [
     {
       "question": "hints.hundredRectangles.question",

--- a/curriculum/src/exercises/scrabble-score/metadata.json
+++ b/curriculum/src/exercises/scrabble-score/metadata.json
@@ -1,6 +1,6 @@
 {
   "slug": "scrabble-score",
-  "levelId": "everything",
+  "levelId": "dictionaries",
   "hints": [
     {
       "question": "hints.startingPoint.question",

--- a/curriculum/src/exercises/sunset/metadata.json
+++ b/curriculum/src/exercises/sunset/metadata.json
@@ -1,6 +1,6 @@
 {
   "slug": "sunset",
-  "levelId": "basic-state",
+  "levelId": "functions-that-return-things",
   "hints": [
     {
       "question": "hints.howToAnimate.question",

--- a/curriculum/src/exercises/wordle-process-game/metadata.json
+++ b/curriculum/src/exercises/wordle-process-game/metadata.json
@@ -1,6 +1,6 @@
 {
   "slug": "wordle-process-game",
-  "levelId": "everything",
+  "levelId": "lists",
   "hints": [
     {
       "question": "hints.reuseWork.question",


### PR DESCRIPTION
## What

Several exercises' `metadata.json` `levelId` had drifted from where the live syllabus (API `curriculum.json`) actually places them. Taking the API as the source of truth, this aligns the repo:

| Exercise | Was | Now |
|---|---|---|
| rainbow | `basic-state` | `functions-that-return-things` |
| sunset | `basic-state` | `functions-that-return-things` |
| formal-dinner | `everything` | `lists` |
| wordle-process-game | `everything` | `lists` |
| nucleotide-count | `everything` | `dictionaries` |
| scrabble-score | `everything` | `dictionaries` |

The README is updated to match (rainbow/sunset moved into the `functions-that-return-things` block).

## Deliberately left out

**`llm-response`** (API places it in `dictionaries`) stays at `everything`. Its solution uses a `break` statement, and `BreakStatement` is only whitelisted by the `everything` level's `allowedNodes` — no accumulated level up to `dictionaries` permits it. Moving it makes the solution return `undefined` (loop can't break). Resolving that needs a level-definition decision (whitelist `break` somewhere in the chain, or rework the solution) and is out of scope here.

## Verification

- `pnpm typecheck` clean.
- Full curriculum suite passes (1139 tests), including `all-exercises` solution-vs-scenario validation — the six moved exercises all still validate under their new levels' node restrictions.

## Note

This was found via a metadata-vs-API sweep. Nothing is in the API but missing from the repo. 16 repo exercises aren't in the API syllabus at all (presumably WIP/unpublished) and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)