### PR TITLE
Remove numberToString reference from tile-rack

### DIFF
--- a/curriculum/src/exercises/tile-rack/index.ts
+++ b/curriculum/src/exercises/tile-rack/index.ts
@@ -3,15 +3,7 @@ import { tasks, scenarios } from "./scenarios";
 import metadata from "./metadata.json";
 import type { IOExerciseCore, FunctionInfo } from "../types";
 
-const functions: FunctionInfo[] = [
-  {
-    name: "numberToString",
-    signature: "numberToString(number)",
-    description: "functions.numberToString.description",
-    examples: ['numberToString(42) returns "42"'],
-    category: "functions.numberToString.category"
-  }
-];
+const functions: FunctionInfo[] = [];
 
 const exerciseDefinition: IOExerciseCore = {
   type: "io",

--- a/curriculum/src/exercises/tile-rack/locales/en/translation.json
+++ b/curriculum/src/exercises/tile-rack/locales/en/translation.json
@@ -56,11 +56,5 @@
       "question": "What if the letter isn't in the rack?",
       "answer": "Only after the loop has finished without finding the letter should you return the error message. Returning the error inside the loop would give up after the first non-matching tile."
     }
-  },
-  "functions": {
-    "numberToString": {
-      "description": "Convert a number to its string representation (provided by level stdlib)",
-      "category": "Type Conversion"
-    }
   }
 }

--- a/curriculum/src/exercises/tile-rack/locales/hu/translation.json
+++ b/curriculum/src/exercises/tile-rack/locales/hu/translation.json
@@ -56,11 +56,5 @@
       "question": "What if the letter isn't in the rack?",
       "answer": "Only after the loop has finished without finding the letter should you return the error message. Returning the error inside the loop would give up after the first non-matching tile."
     }
-  },
-  "functions": {
-    "numberToString": {
-      "description": "Convert a number to its string representation (provided by level stdlib)",
-      "category": "Type Conversion"
-    }
   }
 }


### PR DESCRIPTION
The JavaScript solution for `tile-rack` uses template literals, so the `numberToString` stdlib function reference in the exercise metadata was misleading for the JS-first launch.

Removed the `numberToString` entry from:
- `index.ts` `functions` array (now empty)
- `locales/en/translation.json`
- `locales/hu/translation.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)