### PR TITLE
Add tile-rack hint for adding a number to a string

### DIFF
--- a/curriculum/src/exercises/tile-rack/locales/en/translation.json
+++ b/curriculum/src/exercises/tile-rack/locales/en/translation.json
@@ -48,6 +48,10 @@
       "question": "What do I do when I find the letter?",
       "answer": "Build the success message. Convert the position number to a string, then combine it with the surrounding text the exercise asks for using concatenation (`+`) or a template string. Return immediately. There's no need to keep looking."
     },
+    "addNumberToString": {
+      "question": "I cannot add a number to a string",
+      "answer": "You've learned two ways to join strings together. Rather than concatenating strings, try the other method you've learned."
+    },
     "positionAlwaysWrong": {
       "question": "Why is my position always wrong?",
       "answer": "Make sure you're increasing the position counter every iteration, not just sometimes. Otherwise every tile reports the same position."

--- a/curriculum/src/exercises/tile-rack/locales/hu/translation.json
+++ b/curriculum/src/exercises/tile-rack/locales/hu/translation.json
@@ -48,6 +48,10 @@
       "question": "What do I do when I find the letter?",
       "answer": "Build the success message. Convert the position number to a string, then combine it with the surrounding text the exercise asks for using concatenation (`+`) or a template string. Return immediately. There's no need to keep looking."
     },
+    "addNumberToString": {
+      "question": "I cannot add a number to a string",
+      "answer": "You've learned two ways to join strings together. Rather than concatenating strings, try the other method you've learned."
+    },
     "positionAlwaysWrong": {
       "question": "Why is my position always wrong?",
       "answer": "Make sure you're increasing the position counter every iteration, not just sometimes. Otherwise every tile reports the same position."

--- a/curriculum/src/exercises/tile-rack/metadata.json
+++ b/curriculum/src/exercises/tile-rack/metadata.json
@@ -15,6 +15,10 @@
       "answer": "hints.onFound.answer"
     },
     {
+      "question": "hints.addNumberToString.question",
+      "answer": "hints.addNumberToString.answer"
+    },
+    {
       "question": "hints.positionAlwaysWrong.question",
       "answer": "hints.positionAlwaysWrong.answer"
     },


### PR DESCRIPTION
There was no hint covering the common error students hit when they try to concatenate the position number directly onto a string with `+`.

Added a new hint:

- **Q:** I cannot add a number to a string
- **A:** You've learned two ways to join strings together. Rather than concatenating strings, try the other method you've learned.

Added to `metadata.json` (hint order, after `onFound`) and the `en`/`hu` translation files. The `hu` entry is stubbed with the English text pending translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)