### PR TITLE
Emit ISO 8601 datetimes with timezone in SEO schemas

### DIFF
--- a/app/lib/seo/schemas.ts
+++ b/app/lib/seo/schemas.ts
@@ -25,6 +25,17 @@ export function canonicalUrl(localelessPath: string, locale: string): string {
   return `${SITE_URL}${localePath(localelessPath, locale)}`;
 }
 
+/**
+ * Normalise a date to an ISO 8601 datetime with a timezone, as Google's
+ * structured-data validators require (a bare `YYYY-MM-DD` is flagged as an
+ * invalid datetime "missing a time zone"). Our content dates are day-granular,
+ * so a bare date becomes midnight UTC; anything already carrying a time is left
+ * untouched.
+ */
+function isoDateTime(date: string): string {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? `${date}T00:00:00+00:00` : date;
+}
+
 /** Seconds -> ISO 8601 duration (e.g. 605 -> "PT10M5S"), as VideoObject expects. */
 function isoDuration(totalSeconds: number): string {
   const hours = Math.floor(totalSeconds / 3600);
@@ -107,8 +118,8 @@ export function articleSchema(article: ArticleInput) {
     url,
     mainEntityOfPage: url,
     inLanguage: article.locale,
-    ...(article.datePublished ? { datePublished: article.datePublished } : {}),
-    ...(article.dateModified ? { dateModified: article.dateModified } : {}),
+    ...(article.datePublished ? { datePublished: isoDateTime(article.datePublished) } : {}),
+    ...(article.dateModified ? { dateModified: isoDateTime(article.dateModified) } : {}),
     ...(article.image ? { image: absolute(article.image) } : {}),
     ...(article.keywords && article.keywords.length > 0 ? { keywords: article.keywords.join(", ") } : {}),
     // Person author when we have one, otherwise attribute to the Organization.
@@ -149,7 +160,7 @@ export function videoObjectSchema(video: VideoInput) {
     name: video.name,
     description: video.description,
     thumbnailUrl,
-    uploadDate: video.uploadDate,
+    uploadDate: isoDateTime(video.uploadDate),
     ...(video.durationSeconds ? { duration: isoDuration(video.durationSeconds) } : {}),
     embedUrl,
     ...(video.provider === "mux" ? { contentUrl: `https://stream.mux.com/${video.videoKey}.m3u8` } : {}),

--- a/app/tests/unit/lib/seo/schemas.test.ts
+++ b/app/tests/unit/lib/seo/schemas.test.ts
@@ -68,6 +68,7 @@ describe("articleSchema", () => {
     expect(schema.publisher).toEqual({ "@id": ORG_ID });
     expect(schema.keywords).toBe("a, b");
     expect(schema.image).toBe(`${SITE}/static/images/cover.png`);
+    expect(schema.datePublished).toBe("2026-01-02T00:00:00+00:00");
   });
 
   it("falls back to the Organization author when no person is given", () => {
@@ -112,6 +113,7 @@ describe("videoObjectSchema", () => {
     expect(schema.embedUrl).toBe("https://www.youtube.com/embed/abc123");
     expect(schema.thumbnailUrl).toBe("https://img.youtube.com/vi/abc123/maxresdefault.jpg");
     expect(schema.duration).toBe("PT10M5S");
+    expect(schema.uploadDate).toBe("2026-03-04T00:00:00+00:00");
     expect(schema.url).toBe(`${SITE}/projects/maze/episodes/intro`);
     expect(schema.isAccessibleForFree).toBe(true);
     expect(schema).not.toHaveProperty("contentUrl");


### PR DESCRIPTION
## Problem

Google's Rich Results / structured-data validator flags `VideoObject.uploadDate` on episode pages:

- *Invalid datetime value for 'uploadDate'*
- *Datetime property 'uploadDate' is missing a time zone*

The value was a bare `YYYY-MM-DD` (e.g. `2026-06-11`) fed straight from the episode config's day-granular `date` into the JSON-LD. Schema.org datetimes need a time component **and** a timezone.

## Fix

Added an `isoDateTime()` helper in `lib/seo/schemas.ts` that normalises a bare date to midnight UTC (`YYYY-MM-DDT00:00:00+00:00`) and leaves anything already carrying a time untouched. Applied it to:

- `videoObjectSchema` → `uploadDate` (the flagged property)
- `articleSchema` → `datePublished` / `dateModified` (same raw passthrough, would trip the identical warning on blog/guide Article schemas)

Tests updated to assert the normalised output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)