### PR TITLE
Add max-lines bonus scenario to niche-named-party

### DIFF
--- a/curriculum/src/exercises/niche-named-party/llm-metadata.ts
+++ b/curriculum/src/exercises/niche-named-party/llm-metadata.ts
@@ -30,6 +30,18 @@ export const llmMetadata: LLMMetadata = {
         instead of returning false. The two traps worth watching are missing that guard and inverting
         the comparison logic.
       `
+    },
+    "solve-tightly": {
+      description: `
+        Bonus (optional): solve the whole exercise in 20 lines or fewer (14 in Python). This only
+        rewards the tidy decomposition, it does not change the required logic.
+
+        The tight version pulls the length-counting loop into a single \`getLength(word)\` helper that
+        \`handleGuest\` calls for both the prefix and the name. Students who overshoot the line limit have
+        almost always inlined that counting loop twice instead of reusing one helper; point them at
+        extracting the duplicated loop, not at rewriting their logic. Don't sacrifice the required length
+        guard to save a line.
+      `
     }
   }
 };

--- a/curriculum/src/exercises/niche-named-party/locales/en/translation.json
+++ b/curriculum/src/exercises/niche-named-party/locales/en/translation.json
@@ -3,6 +3,10 @@
     "checkTheName": {
       "name": "Check the name",
       "description": "Write a `handleGuest` function that checks whether the person's name starts with the allowed letters for tonight's party. Return `true` if it does, or `false` if it doesn't."
+    },
+    "solveTightly": {
+      "name": "Solve it in 20 lines",
+      "description": "Bonus: with the length-counting pulled out into a helper function that `handleGuest` reuses, the whole solution fits in 20 lines. Can you match it?"
     }
   },
   "scenarios": {
@@ -29,7 +33,14 @@
     "cherCherParty": {
       "name": "Cher Party: Cher arrives",
       "description": "Tonight only names starting with \"Cher\" are allowed. Cher's name is exactly \"Cher\" — let her in!"
+    },
+    "nicheNamedPartyBonusLineCount": {
+      "name": "Tight and tidy",
+      "description": "The complete solution fits in 20 lines when the length-counting lives in its own helper function."
     }
+  },
+  "checks": {
+    "tooManyLines": "Almost! See if you can solve it in fewer lines by leaning on a helper function instead of repeating the length-counting loop."
   },
   "hints": {
     "checkStartsWith": {

--- a/curriculum/src/exercises/niche-named-party/locales/en/translation.json
+++ b/curriculum/src/exercises/niche-named-party/locales/en/translation.json
@@ -35,12 +35,12 @@
       "description": "Tonight only names starting with \"Cher\" are allowed. Cher's name is exactly \"Cher\" — let her in!"
     },
     "nicheNamedPartyBonusLineCount": {
-      "name": "Tight and tidy",
-      "description": "The complete solution fits in 20 lines when the length-counting lives in its own helper function."
+      "name": "Neat and tidy",
+      "description": "The shortest solution fits in 20 lines. Can you find it?"
     }
   },
   "checks": {
-    "tooManyLines": "Almost! See if you can solve it in fewer lines by leaning on a helper function instead of repeating the length-counting loop."
+    "tooManyLines": "Keep going! See if you can solve it in fewer lines."
   },
   "hints": {
     "checkStartsWith": {

--- a/curriculum/src/exercises/niche-named-party/locales/hu/translation.json
+++ b/curriculum/src/exercises/niche-named-party/locales/hu/translation.json
@@ -3,6 +3,10 @@
     "checkTheName": {
       "name": "Check the name",
       "description": "Write a `handleGuest` function that checks whether the person's name starts with the allowed letters for tonight's party. Return `true` if it does, or `false` if it doesn't."
+    },
+    "solveTightly": {
+      "name": "Solve it in 20 lines",
+      "description": "Bonus: with the length-counting pulled out into a helper function that `handleGuest` reuses, the whole solution fits in 20 lines. Can you match it?"
     }
   },
   "scenarios": {
@@ -29,7 +33,14 @@
     "cherCherParty": {
       "name": "Cher Party: Cher arrives",
       "description": "Tonight only names starting with \"Cher\" are allowed. Cher's name is exactly \"Cher\" — let her in!"
+    },
+    "nicheNamedPartyBonusLineCount": {
+      "name": "Tight and tidy",
+      "description": "The complete solution fits in 20 lines when the length-counting lives in its own helper function."
     }
+  },
+  "checks": {
+    "tooManyLines": "Almost! See if you can solve it in fewer lines by leaning on a helper function instead of repeating the length-counting loop."
   },
   "hints": {
     "checkStartsWith": {

--- a/curriculum/src/exercises/niche-named-party/scenarios.ts
+++ b/curriculum/src/exercises/niche-named-party/scenarios.ts
@@ -1,4 +1,18 @@
-import type { Task, IOScenario } from "../types";
+import type { Task, IOScenario, CodeCheck } from "../types";
+
+// Bonus: reward leaning on the helper function to keep the solution tight.
+// The reference decomposition (getLength + handleGuest) lands on exactly these
+// counts, so a student who duplicates the length-counting loop instead of
+// reusing the helper will overshoot.
+const lineCountCheck: CodeCheck[] = [
+  {
+    pass: (result, language) => {
+      const limit = language === "python" ? 14 : 20;
+      return result.assertors.assertMaxLinesOfCode(limit);
+    },
+    errorKey: "checks.tooManyLines"
+  }
+];
 
 export const tasks = [
   {
@@ -15,6 +29,14 @@ export const tasks = [
       "cher-cher-party"
     ],
     bonus: false
+  },
+  {
+    id: "solve-tightly" as const,
+    name: "tasks.solveTightly.name",
+    description: "tasks.solveTightly.description",
+    hints: [],
+    requiredScenarios: ["niche-named-party-bonus-line-count"],
+    bonus: true
   }
 ] as const satisfies readonly Task[];
 
@@ -72,5 +94,15 @@ export const scenarios: IOScenario[] = [
     functionName: "handle_guest",
     args: ["Cher", "Cher"],
     expected: true
+  },
+  {
+    slug: "niche-named-party-bonus-line-count",
+    name: "scenarios.nicheNamedPartyBonusLineCount.name",
+    description: "scenarios.nicheNamedPartyBonusLineCount.description",
+    taskId: "solve-tightly",
+    functionName: "handle_guest",
+    args: ["Bradley", "Brad"],
+    expected: true,
+    codeChecks: lineCountCheck
   }
 ];

--- a/curriculum/tests/exercises/niche-named-party-bonus.test.ts
+++ b/curriculum/tests/exercises/niche-named-party-bonus.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { runExerciseTests } from "../runScenarioTest";
+import nicheNamedPartyExercise from "../../src/exercises/niche-named-party";
+
+// The bonus task ("solve-tightly") is excluded from all-exercises.test.ts, so
+// guard here that the reference JavaScript solution actually meets the line
+// limit the bonus advertises. JavaScript is the launch language and the only
+// one all-exercises validates.
+describe("niche-named-party bonus line-count check", () => {
+  it("javascript reference solution passes the bonus", async () => {
+    const slug = "niche-named-party";
+    const solution = (await import(`../../src/exercises/${slug}/solution.javascript?raw`)).default;
+
+    const bonusScenarios = nicheNamedPartyExercise.scenarios.filter(
+      (s) => s.slug === "niche-named-party-bonus-line-count"
+    );
+    const testExercise = { ...nicheNamedPartyExercise, scenarios: bonusScenarios };
+
+    const results = runExerciseTests(testExercise, solution, "javascript");
+    expect(results.length).toBeGreaterThan(0);
+    for (const result of results) {
+      expect(result.status, JSON.stringify(result.expects, null, 2)).toBe("pass");
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds an optional **"Solve it in 20 lines"** bonus task to the `niche-named-party` exercise, backed by a single hidden scenario (`niche-named-party-bonus-line-count`) that runs `assertMaxLinesOfCode`:

- **20 lines** for JavaScript / Jikiscript
- **14 lines** for Python

## Why

The instructions already promised this bonus — *"The bonus scenario challenges you to solve this in the minimum number of lines possible"* — but no scenario backed it. The check rewards pulling the length-counting loop into a single `getLength` helper that `handleGuest` reuses for both the prefix and the name, rather than inlining the counting loop twice. The reference solution lands on exactly these counts.

## Changes

- `scenarios.ts` — new `solve-tightly` bonus task + `niche-named-party-bonus-line-count` scenario with a `lineCountCheck` code check
- `llm-metadata.ts` — entry for the new task (how to coach a student who overshoots)
- `locales/en` + `locales/hu` — `tasks.solveTightly`, `scenarios.nicheNamedPartyBonusLineCount`, `checks.tooManyLines` (hu stubbed from en, untranslated)
- `tests/exercises/niche-named-party-bonus.test.ts` — regression guard that the reference JavaScript solution meets the advertised limit (all-exercises excludes bonus scenarios)

## Note (pre-existing, out of scope)

While verifying, I found `solution.py` fails to parse (`SyntaxError: Missing ':'` on its `repeat(...)` statement) — even against the existing non-bonus scenarios. The CI suite only runs JavaScript solutions, so this was never caught. Left untouched here; flagging for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)