### PR TITLE
Clarify prefix wording + quote a/z range in pangram/party instructions

### DIFF
--- a/curriculum/src/exercises/lower-pangram/instructions/source.md
+++ b/curriculum/src/exercises/lower-pangram/instructions/source.md
@@ -9,7 +9,7 @@ The next three exercises are all going to be about determining if sentences are 
 
 In this first exercise, you only need to handle lowercase letters. The input will only contain lowercase letters and other characters like spaces, numbers, or punctuation, but no uppercase letters.
 
-Your task is to write <define>`isPangram(sentence)`</define>, which takes a sentence as an input and returns `true` if it contains every letter from a to z at least once, or `false` if it doesn't.
+Your task is to write <define>`isPangram(sentence)`</define>, which takes a sentence as an input and returns `true` if it contains every letter from "a" to "z" at least once, or `false` if it doesn't.
 
 ### Helper functions
 

--- a/curriculum/src/exercises/niche-named-party/instructions/source.md
+++ b/curriculum/src/exercises/niche-named-party/instructions/source.md
@@ -3,7 +3,7 @@ title: "Niche Named Party"
 description: "Work out who's allowed into a very exclusive party."
 ---
 
-Tonight's party is very exclusive - only people whose names start with a specific set of letters are allowed in!
+Tonight's party is very exclusive - only people whose names start with a specific sequence of letters are allowed in!
 
 Your job is to write a function called <define>`handleGuest`</define> that takes two inputs:
 


### PR DESCRIPTION
Addresses forum feedback from Isaac on two exercises.

## niche-named-party
> "only people whose names start with a specific **set of letters** are allowed in"

"Set of letters" implied several single letters, any of which could match. The exercise actually requires a fixed **prefix** (the name must start with an exact sequence — `"Brad"` lets in Brad/Bradley but not Brian). Reworded to "specific **sequence** of letters" to match the behaviour and the `allowedPrefix` framing in the body.

## lower-pangram (Simple Pangram)
> returns `true` if it contains every letter from **a to z** at least once

Quoted the range endpoints — `from "a" to "z"` — so the literal letters read clearly in prose.

The related colon nit Isaac raised ("the best known English pangram is: ...") is already gone from the English source; it only survives in the `hu.md` translations, which are regenerated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)