### PR TITLE
Clarify sprouting-flower shape-check errors: name the frame, not an ordinal

### DIFF
--- a/curriculum/src/exercises/sprouting-flower/locales/en/translation.json
+++ b/curriculum/src/exercises/sprouting-flower/locales/en/translation.json
@@ -1,15 +1,15 @@
 {
   "checks": {
-    "firstFlowerHeadWrong": "The first Flower Head isn't correct.",
-    "finalFlowerHeadWrong": "The final Flower Head isn't correct.",
-    "firstPistilWrong": "The first Pistil isn't correct.",
-    "finalPistilWrong": "The final Pistil isn't correct.",
-    "firstStemWrong": "The first Stem isn't correct.",
-    "finalStemWrong": "The final Stem isn't correct.",
-    "firstLeftLeafWrong": "The first Left Leaf isn't correct.",
-    "finalLeftLeafWrong": "The final Left Leaf isn't correct.",
-    "firstRightLeafWrong": "The first Right Leaf isn't correct.",
-    "finalRightLeafWrong": "The final Right Leaf isn't correct."
+    "firstFlowerHeadWrong": "The flower head on the first frame isn't correct.",
+    "finalFlowerHeadWrong": "The flower head on the last frame isn't correct.",
+    "firstPistilWrong": "The pistil on the first frame isn't correct.",
+    "finalPistilWrong": "The pistil on the last frame isn't correct.",
+    "firstStemWrong": "The stem on the first frame isn't correct.",
+    "finalStemWrong": "The stem on the last frame isn't correct.",
+    "firstLeftLeafWrong": "The left leaf on the first frame isn't correct.",
+    "finalLeftLeafWrong": "The left leaf on the last frame isn't correct.",
+    "firstRightLeafWrong": "The right leaf on the first frame isn't correct.",
+    "finalRightLeafWrong": "The right leaf on the last frame isn't correct."
   },
   "tasks": {
     "drawScene": {


### PR DESCRIPTION
## What

The `sprouting-flower` shape checks reported errors as "The first/final <Shape> isn't correct." But "first" and "final" here don't mean an ordinal among several shapes — there's one of each shape, checked at the **first** vs **last frame** of the growth animation. Students read "first" as "the first one I drew" (or wondered which of several was wrong).

Reworded all ten keys to:

> The <shape> on the first frame isn't correct.
> The <shape> on the last frame isn't correct.

"Frame" is already established student-facing vocabulary in this exercise (its hints say "values for this frame" / "values at that frame", and the instructions image is captioned "Frames showing a flower growing…"). Shape names are lowercased to read naturally in the new sentence.

## Not included / follow-ups

- **hu translation** left untouched — to be re-triggered through the translation pipeline, not hand-edited.
- The coordinate hints still open with "On the first/last **iteration**" while everything else now says "frame". Left as-is pending a decision on standardising the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)