### PR TITLE
Redirect to dashboard with a toast on a 422 when starting a lesson

### DIFF
--- a/app/components/dashboard/exercise-path/ExercisePath.tsx
+++ b/app/components/dashboard/exercise-path/ExercisePath.tsx
@@ -13,6 +13,7 @@ import { CompletionCert } from "./ui/CompletionCert";
 import { ComingSoonCard } from "./ui/ComingSoonCard";
 import { ScrollToActiveLessonButton } from "./ui/ScrollToActiveLessonButton";
 import { useEffect, useMemo, useRef } from "react";
+import { toastError } from "@/lib/toast";
 
 export default function ExercisePath() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -61,6 +62,19 @@ export default function ExercisePath() {
       });
     }
   }, [triggerCompletionAnimation]);
+
+  // A lesson that failed to open (e.g. a 422 on start) hard-redirects here with a
+  // `?lessonError=<slug>` param. Surface a toast on arrival, then strip the param so
+  // a refresh doesn't re-fire it.
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get("lessonError")) {
+      toastError("lesson.loadFailed");
+      const newUrl = new URL(window.location.href);
+      newUrl.searchParams.delete("lessonError");
+      window.history.replaceState({}, "", newUrl);
+    }
+  }, []);
 
   const handleLessonClick = (lessonSlug: string, route: string) => {
     setClickedLessonSlug(lessonSlug);

--- a/app/components/dashboard/exercise-path/ExercisePath.tsx
+++ b/app/components/dashboard/exercise-path/ExercisePath.tsx
@@ -64,7 +64,7 @@ export default function ExercisePath() {
   }, [triggerCompletionAnimation]);
 
   // A lesson that failed to open (e.g. a 422 on start) hard-redirects here with a
-  // `?lessonError=<slug>` param. Surface a toast on arrival, then strip the param so
+  // `?lessonError=1` flag. Surface a toast on arrival, then strip the param so
   // a refresh doesn't re-fire it.
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);

--- a/app/components/lesson/Lesson.tsx
+++ b/app/components/lesson/Lesson.tsx
@@ -68,9 +68,10 @@ export default function Lesson({ slug }: LessonProps) {
           // A 422 means this lesson can't be opened for this user (invalid/
           // unavailable state). Rather than stranding them on a dead error screen,
           // bounce back to the dashboard with a hard navigation so everything
-          // reloads cleanly, and surface a toast there (see ExercisePath).
+          // reloads cleanly. `lessonError` is a presence-only flag that tells the
+          // dashboard to surface a toast (see ExercisePath).
           if (err instanceof ApiError && err.status === 422) {
-            window.location.href = `/dashboard?lessonError=${encodeURIComponent(slug)}`;
+            window.location.href = "/dashboard?lessonError=1";
             return;
           }
           setError(err instanceof Error ? err.message : t("loadError"));

--- a/app/components/lesson/Lesson.tsx
+++ b/app/components/lesson/Lesson.tsx
@@ -2,6 +2,7 @@
 
 import LessonLoadingModal from "@/components/common/LessonLoadingModal/LessonLoadingModal";
 import { fetchUserCourse } from "@/lib/api/courses";
+import { ApiError } from "@/lib/api/client";
 import { fetchLesson, startLesson } from "@/lib/api/lessons";
 import type { UserCourse } from "@/types/course";
 import type { LessonWithData } from "@/types/lesson";
@@ -62,7 +63,16 @@ export default function Lesson({ slug }: LessonProps) {
         if (!cancelled) {
           console.error("Failed to fetch lesson:", err);
           // Auth/network/rate-limit errors never reach here (handled globally)
-          // Only application errors (404, 500, validation) reach this catch block
+          // Only application errors (404, 500, validation) reach this catch block.
+          //
+          // A 422 means this lesson can't be opened for this user (invalid/
+          // unavailable state). Rather than stranding them on a dead error screen,
+          // bounce back to the dashboard with a hard navigation so everything
+          // reloads cleanly, and surface a toast there (see ExercisePath).
+          if (err instanceof ApiError && err.status === 422) {
+            window.location.href = `/dashboard?lessonError=${encodeURIComponent(slug)}`;
+            return;
+          }
           setError(err instanceof Error ? err.message : t("loadError"));
         }
       } finally {

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1085,6 +1085,9 @@
       "chatSaveFailed": "Couldn't save this message. It won't be here when you come back.",
       "chatSaveCaptchaFailed": "Verification failed while saving. This message won't be here when you come back.",
       "lessonSaveError": "Sorry, the lesson could not be completed. Please try again. If this continues, please report on <link>https://forum.jiki.io</link>"
+    },
+    "lesson": {
+      "loadFailed": "Sorry, we couldn't open that lesson. Please try again."
     }
   },
   "modals": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1087,7 +1087,7 @@
       "lessonSaveError": "Sajnáljuk, a leckét nem sikerült befejezni. Próbáld újra. Ha a hiba továbbra is fennáll, jelezd itt: <link>https://forum.jiki.io</link>"
     },
     "lesson": {
-      "loadFailed": "Sorry, we couldn't open that lesson. Please try again."
+      "loadFailed": "Sajnáljuk, nem sikerült megnyitni a leckét. Próbáld újra."
     }
   },
   "modals": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1085,6 +1085,9 @@
       "chatSaveFailed": "Nem sikerült menteni ezt az üzenetet. Amikor visszatérsz, már nem lesz itt.",
       "chatSaveCaptchaFailed": "Mentés közben nem sikerült az ellenőrzés. Ez az üzenet nem lesz itt, amikor visszatérsz.",
       "lessonSaveError": "Sajnáljuk, a leckét nem sikerült befejezni. Próbáld újra. Ha a hiba továbbra is fennáll, jelezd itt: <link>https://forum.jiki.io</link>"
+    },
+    "lesson": {
+      "loadFailed": "Sorry, we couldn't open that lesson. Please try again."
     }
   },
   "modals": {

--- a/app/tests/unit/components/dashboard/exercise-path/ExercisePath.test.tsx
+++ b/app/tests/unit/components/dashboard/exercise-path/ExercisePath.test.tsx
@@ -58,7 +58,7 @@ describe("ExercisePath", () => {
 
   it("shows an error toast and strips the param when arriving with ?lessonError", async () => {
     mockFetchLevels.mockResolvedValue([createLevel("level-cutoff", [createLesson({ slug: "l1" })])]);
-    window.history.replaceState({}, "", "/dashboard?lessonError=methods-and-strings");
+    window.history.replaceState({}, "", "/dashboard?lessonError=1");
 
     render(<ExercisePath />);
 

--- a/app/tests/unit/components/dashboard/exercise-path/ExercisePath.test.tsx
+++ b/app/tests/unit/components/dashboard/exercise-path/ExercisePath.test.tsx
@@ -1,5 +1,6 @@
 import ExercisePath from "@/components/dashboard/exercise-path/ExercisePath";
 import { fetchLevelsWithProgress } from "@/lib/api/levels";
+import { toastError } from "@/lib/toast";
 import type { LessonWithProgress, LevelWithProgress } from "@/types/levels";
 import { render, screen, waitFor } from "@testing-library/react";
 
@@ -16,7 +17,12 @@ jest.mock("@/lib/constants/course", () => ({
   LAST_PUBLISHED_LEVEL_SLUG: "level-cutoff"
 }));
 
+jest.mock("@/lib/toast", () => ({
+  toastError: jest.fn()
+}));
+
 const mockFetchLevels = fetchLevelsWithProgress as jest.MockedFunction<typeof fetchLevelsWithProgress>;
+const mockToastError = toastError as jest.MockedFunction<typeof toastError>;
 
 function createLesson(overrides: Partial<LessonWithProgress> = {}): LessonWithProgress {
   return {
@@ -47,6 +53,27 @@ describe("ExercisePath", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    window.history.replaceState({}, "", "/dashboard");
+  });
+
+  it("shows an error toast and strips the param when arriving with ?lessonError", async () => {
+    mockFetchLevels.mockResolvedValue([createLevel("level-cutoff", [createLesson({ slug: "l1" })])]);
+    window.history.replaceState({}, "", "/dashboard?lessonError=methods-and-strings");
+
+    render(<ExercisePath />);
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("lesson.loadFailed"));
+    expect(new URLSearchParams(window.location.search).has("lessonError")).toBe(false);
+  });
+
+  it("does not show an error toast on a normal dashboard visit", async () => {
+    mockFetchLevels.mockResolvedValue([createLevel("level-cutoff", [createLesson({ slug: "l1" })])]);
+    window.history.replaceState({}, "", "/dashboard");
+
+    render(<ExercisePath />);
+
+    await waitFor(() => expect(mockFetchLevels).toHaveBeenCalled());
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 
   it("renders the ComingSoonCard when all lessons in the cutoff level are completed", async () => {

--- a/app/tests/unit/components/lesson/Lesson.test.tsx
+++ b/app/tests/unit/components/lesson/Lesson.test.tsx
@@ -27,6 +27,7 @@ jest.mock("@/components/common/LessonLoadingModal/LessonLoadingModal", () => ({
 
 import { fetchLesson, startLesson } from "@/lib/api/lessons";
 import { fetchUserCourse } from "@/lib/api/courses";
+import { ApiError } from "@/lib/api/client";
 
 const mockedFetchLesson = fetchLesson as jest.MockedFunction<typeof fetchLesson>;
 const mockedStartLesson = startLesson as jest.MockedFunction<typeof startLesson>;
@@ -75,11 +76,27 @@ describe("Lesson starts the lesson on mount", () => {
     await waitFor(() => expect(screen.getByTestId("lesson-content")).toHaveAttribute("data-completed", "false"));
   });
 
-  it("shows an error when start fails", async () => {
-    mockedStartLesson.mockRejectedValue(new Error("API Error: 422"));
+  it("shows the error screen for a non-422 failure", async () => {
+    mockedStartLesson.mockRejectedValue(new ApiError(500, "Internal Server Error"));
 
     render(<Lesson slug={SLUG} />);
 
-    await waitFor(() => expect(screen.queryByTestId("lesson-content")).not.toBeInTheDocument());
+    // The LessonError screen (with its "Back to Dashboard" button) renders in place.
+    await waitFor(() => expect(screen.getByText("Back to Dashboard")).toBeInTheDocument());
+    expect(screen.queryByTestId("lesson-content")).not.toBeInTheDocument();
+  });
+
+  it("redirects to the dashboard instead of showing the error screen on a 422", async () => {
+    // jsdom can't intercept the `window.location.href` hard navigation (it logs
+    // "Not implemented: navigation" and no-ops), so assert the observable outcome:
+    // the LessonError screen is NOT rendered because the catch block redirects and
+    // returns before setError runs.
+    mockedStartLesson.mockRejectedValue(new ApiError(422, "Unprocessable Entity"));
+
+    render(<Lesson slug={SLUG} />);
+
+    await waitFor(() => expect(screen.getByTestId("lesson-loading")).toBeInTheDocument());
+    expect(screen.queryByText("Back to Dashboard")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("lesson-content")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
On a `422` when starting a lesson, users were stranded on a dead full-screen error ("Error: API Error: 422" + a soft "Back to Dashboard" link) reported by a student.

## Change
- **`components/lesson/Lesson.tsx`** — when the lesson load (`fetchLesson` / `fetchUserCourse` / `startLesson`) fails with a `422` specifically, hard-redirect (`window.location.href`) to `/dashboard?lessonError=<slug>` so the app fully reloads into a clean state instead of showing a broken lesson. Non-422 errors (404/500/…) still render the existing `LessonError` screen.
- **`components/dashboard/exercise-path/ExercisePath.tsx`** — on mount, read `?lessonError`, fire an error toast, and strip the param via `replaceState` (same pattern the existing `completed`/`unlocked` handling uses).
- **`messages/en.json` + `messages/hu.json`** — add `toasts.lesson.loadFailed`: "Sorry, we couldn't open that lesson. Please try again." (hu stubbed with the English string; the catalog test requires identical key trees).

The 422 continues to be reported to Sentry automatically by the API client, so observability is unchanged.

## Verification
- `pnpm typecheck` (app): clean
- ESLint + Prettier on all changed files: clean
- Unit tests (74 passing) including new cases: Lesson redirects vs. shows the error screen (422 vs. non-422); ExercisePath fires + strips the toast on `?lessonError` and stays silent on a normal visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)