### PR TITLE
Fix pangram series loop caps + instruction typos

### DIFF
--- a/curriculum/AGENTS.md
+++ b/curriculum/AGENTS.md
@@ -408,6 +408,8 @@ Some exercises are a direct continuation of an earlier one — the student's job
 
 **Canonical example:** `src/exercises/maze-turn-around/stub.javascript` is the previous maze-solving exercise's solution; the student extracts a `turnAround()` function from it. `src/exercises/battle-procedures/stub.javascript` is the `scroll-and-shoot` solution; the student extracts a `shootIfAlienAbove()` function from it. Read `maze-turn-around/stub.javascript` before authoring a continuation stub.
 
+**⚠️ Carry the `interpreterOptions` cap forward too.** A continuation stub also carries the previous exercise's _runtime cost_. If the source exercise raised `interpreterOptions.maxTotalLoopIterations` (because its solutions are loop-heavy), the continuation exercise must set an **equal-or-higher** cap — otherwise the student opens the editor on carried-forward code that instantly trips the lower cap with a scary "your code loops too many times / infinite loop" error, before they've made any change. This applies even when the continuation's _intended_ solution is cheap (e.g. `methodic-pangram` teaches built-in `.toLowerCase()`/`.includes()` at ~26 iterations, but its `{{LESSON:pangram}}` starting code runs ~2200). The whole pangram series (`lower-pangram`, `pangram`, `methodic-pangram`) shares one cap for this reason. When you raise a cap on any exercise, check every exercise whose stub is `{{LESSON:<that-slug>}}` and match it.
+
 ## Integration with Frontend
 
 ### How Frontend Uses Curriculum

--- a/curriculum/src/exercises/lower-pangram/index.ts
+++ b/curriculum/src/exercises/lower-pangram/index.ts
@@ -17,7 +17,12 @@ const exerciseDefinition: IOExerciseCore = {
     "creating-functions",
     "string-iteration",
     "creating-functions-with-return-values"
-  ]
+  ],
+  // The intended lowercase-only solution peaks at ~600 iterations, but a student
+  // may over-engineer this first exercise with the full case-handling approach
+  // used later in the series (~2200+ iterations). Match the rest of the pangram
+  // series' cap so any correct manual solution passes.
+  interpreterOptions: { maxTotalLoopIterations: 32000 }
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/methodic-pangram/index.ts
+++ b/curriculum/src/exercises/methodic-pangram/index.ts
@@ -27,7 +27,14 @@ const exerciseDefinition: IOExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["methods", "string-iteration", "if"]
+  conceptSlugs: ["methods", "string-iteration", "if"],
+  // The stub carries the student's hand-written pangram code forward
+  // ({{LESSON:pangram}}), which scans the alphabet per character and runs ~2200
+  // loop iterations on the longest scenario — above the global default of 1000.
+  // The intended built-in `.toLowerCase()`/`.includes()` solution is ~26
+  // iterations, but a student running or mid-converting the carried code would
+  // otherwise hit the cap. Match pangram's cap so the starting code executes.
+  interpreterOptions: { maxTotalLoopIterations: 32000 }
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/pangram/index.ts
+++ b/curriculum/src/exercises/pangram/index.ts
@@ -20,10 +20,13 @@ const exerciseDefinition: IOExerciseCore = {
     "string-indexing",
     "if"
   ],
-  // The hand-written toLower helper scans the alphabet per character, so the
-  // longest scenarios run ~2000 loop iterations — above the global default of
-  // 1000. Raise the cap so valid (if inefficient) manual solutions pass.
-  interpreterOptions: { maxTotalLoopIterations: 10000 }
+  // Loop-heavy exercise: hand-written toLowerCase/indexOf/includes helpers scan
+  // the alphabet per character. The reference solution peaks at ~1600 iterations
+  // on the longest scenario, but valid-if-inefficient approaches run much higher:
+  // a no-helper "scan the sentence once per letter" solution hits ~16k, and
+  // re-lowercasing inside the 26-letter loop hits ~31k. Cap at 32k so all correct
+  // manual solutions pass regardless of structure.
+  interpreterOptions: { maxTotalLoopIterations: 32000 }
 };
 
 export default exerciseDefinition;

--- a/curriculum/src/exercises/pangram/instructions/source.md
+++ b/curriculum/src/exercises/pangram/instructions/source.md
@@ -13,9 +13,9 @@ We've given you your previous code as a starting point.
 
 ### Helper Functions
 
-In addition to your existing helper function (which we suggested you called `includes`), we recommend you create two new helper functions to help you solve this. The functions names are standard names, which we recommend sticking too:
+In addition to your existing helper function (which we suggested you called `includes`), we recommend you create two new helper functions to help you solve this. The functions names are standard names, which we recommend sticking to:
 
-1. `indexOf(haystack, needle)`:A function that calculates **where** the needle is in the haystack. So rather than returning `true`/`false` like `includes`, it returns the **index** of the needle. For example, `indexOf("Jeremy", "r")` would return `2` (remember we count from 0).
+1. `indexOf(haystack, needle)`: A function that calculates **where** the needle is in the haystack. So rather than returning `true`/`false` like `includes`, it returns the **index** of the needle. For example, `indexOf("Jeremy", "r")` would return `2` (remember we count from 0).
 2. `toLowerCase(someString)`: A function that takes a string and returns it converted to lowercase. For example, `toLowerCase("JeReMy")` would return `"jeremy"`.
 
 Have fun!


### PR DESCRIPTION
Addresses forum feedback on the **pangram** series. The reported symptom — "your code loops too many times... maximum is **1000**" — turned out to be on a different exercise than the one with the existing 10k cap.

## The actual bug: `methodic-pangram`

The student's hand-written `toLowerCase`/`indexOf`/`contains` code was hitting **1000** (the default), not the 10k cap on `pangram`. Root cause:

- `methodic-pangram`'s stub is `{{LESSON:pangram}}` — it **carries the student's loop-heavy hand-written pangram code forward** as the starting point.
- But `methodic-pangram` had **no `interpreterOptions` override**, so it fell back to the 1000 default.
- That carried code runs **~2,200 iterations** on the longest scenario → students hit a scary "infinite loop" error on their own starting code before they've converted to the built-in methods the exercise teaches.

**Fix:** give `methodic-pangram` the same 32,000 cap as `pangram`. The intended built-in `.toLowerCase()`/`.includes()` solution runs ~26 iterations, so this only matters for the carried-forward starting code.

Verified `interpreterOptions` genuinely reaches the executor (loader spreads the module at `useExerciseLoader.tsx:82` → `runTests.ts:36` → JS executor).

## All three exercises now share the 32k cap

To keep the series consistent and future-proof against students over-engineering an early exercise with the full case-handling approach, **all three** pangram exercises now carry `maxTotalLoopIterations: 32000`.

| Exercise / approach | max iters | old cap | status |
|---|---|---|---|
| lower-pangram — intended | 611 | 1000 | ✅ (capped 32k defensively) |
| **methodic-pangram — carried hand-written code** | **2,204** | **1000** | ❌ → fixed (32k) |
| pangram — reference | 1,629 | 10000 | ✅ |
| pangram — no-helper O(26·n) | 15,873 | 10000 | ❌ → fixed (32k) |
| pangram — re-lowercase in loop | 30,701 | 10000 | ❌ → fixed (32k) |

The caps are per-scenario (fresh executor each run) and only ever tick on interpreted loops — native `.toLowerCase()`/`.includes()` don't count. 32k comfortably admits every correct manual solution across the series regardless of structure.

## Instruction typos (`pangram/instructions/source.md`)
- `sticking too` → `sticking to`
- missing space after `` `indexOf(haystack, needle)`: ``

🤖 Generated with [Claude Code](https://claude.com/claude-code)