### PR TITLE
niche-named-party: add too-short-matching-prefix scenario

### DIFF
--- a/curriculum/src/exercises/niche-named-party/locales/en/translation.json
+++ b/curriculum/src/exercises/niche-named-party/locales/en/translation.json
@@ -22,6 +22,10 @@
       "name": "Brad Party: Bradley arrives",
       "description": "Tonight only names starting with \"Brad\" are allowed. Bradley should get in!"
     },
+    "bradBradleyParty": {
+      "name": "Bradley Party: Brad arrives",
+      "description": "Tonight only names starting with \"Bradley\" are allowed. Brad is too short, so he's not allowed."
+    },
     "brianBradParty": {
       "name": "Brad Party: Brian arrives",
       "description": "Tonight only names starting with \"Brad\" are allowed. Brian should be turned away."

--- a/curriculum/src/exercises/niche-named-party/locales/hu/translation.json
+++ b/curriculum/src/exercises/niche-named-party/locales/hu/translation.json
@@ -22,6 +22,10 @@
       "name": "Brad Party: Bradley arrives",
       "description": "Tonight only names starting with \"Brad\" are allowed. Bradley should get in!"
     },
+    "bradBradleyParty": {
+      "name": "Bradley Party: Brad arrives",
+      "description": "Tonight only names starting with \"Bradley\" are allowed. Brad is too short, so he's not allowed."
+    },
     "brianBradParty": {
       "name": "Brad Party: Brian arrives",
       "description": "Tonight only names starting with \"Brad\" are allowed. Brian should be turned away."

--- a/curriculum/src/exercises/niche-named-party/scenarios.ts
+++ b/curriculum/src/exercises/niche-named-party/scenarios.ts
@@ -24,6 +24,7 @@ export const tasks = [
       "sarah-s-party",
       "brad-s-party",
       "bradley-brad-party",
+      "brad-bradley-party",
       "brian-brad-party",
       "silence",
       "cher-cher-party"
@@ -67,6 +68,15 @@ export const scenarios: IOScenario[] = [
     functionName: "handle_guest",
     args: ["Bradley", "Brad"],
     expected: true
+  },
+  {
+    slug: "brad-bradley-party",
+    name: "scenarios.bradBradleyParty.name",
+    description: "scenarios.bradBradleyParty.description",
+    taskId: "check-the-name",
+    functionName: "handle_guest",
+    args: ["Brad", "Bradley"],
+    expected: false
   },
   {
     slug: "brian-brad-party",


### PR DESCRIPTION
## What

Adds one scenario to `niche-named-party`: `handle_guest("Brad", "Bradley")` → `false`, wired into the `check-the-name` task and translated in `en` (and the `hu` stub).

## Why

`handleGuest` must return `false` when the name is a strict, *matching* prefix of `allowedPrefix` (e.g. `"Brad"` vs `"Bradley"`). This is the only scenario shape that actually exercises the length guard — every prior false-case mismatches a character *before* running off the end of the name (`Brad/S` at index 0, `Brian/Brad` at index 2, `silence` via the empty guard).

Because that shape was untested, a guard-less solution passed all scenarios. Under our interpreter (which errors on out-of-bounds string reads rather than returning `undefined`), such a solution instead runs past the end of the shorter name and now fails this scenario — matching the reference solution's explicit `getLength(allowedPrefix) > getLength(name)` guard.

## Verification

- `all-exercises.test.ts` (runs each `solution.*` against its non-bonus scenarios): reference solution passes.
- Probed the guard-less student solution against all scenarios: passes the original six, **fails** the new `brad-bradley-party` (`Expected handle_guest("Brad", "Bradley") to return false, but got undefined`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)