### PR TITLE
Refine challenge-unlocked modal copy and spacing

### DIFF
--- a/app/app/styles/components/modals.module.css
+++ b/app/app/styles/components/modals.module.css
@@ -92,7 +92,6 @@
     font-size: 24px;
     font-weight: 700;
     color: #1a202c;
-    margin-top: 5px;
     margin-bottom: 8px;
     white-space: nowrap;
 }
@@ -135,6 +134,10 @@
 }
 
 /* Challenge modal special styling */
+.challengeModalOverlay {
+    padding-top: 36px;
+}
+
 .challengeModalOverlay .modal {
     background: white;
 }

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1272,9 +1272,9 @@
       },
       "challengeUnlocked": {
         "title": "Challenge unlocked!",
-        "message": "All that practice means you're ready to take on a tougher challenge.",
+        "message": "Congratulations! All that practice means you're ready to take on a tougher challenge.",
         "newLabel": "New",
-        "premiumInfo": "<strong>Exclusively for Premium members.</strong> <link>Upgrade your account</link> to access all the Challenges as you unlock them."
+        "premiumInfo": "<strong>Exclusively for Premium members.</strong> <link>Upgrade your account</link> to access Challenges as you unlock them."
       }
     },
     "premiumUpgrade": {


### PR DESCRIPTION
Small copy and spacing tweaks to the challenge-unlocked modal.

- Add "Congratulations!" to the challenge-unlocked message
- Drop "all the" from the premium upgrade prompt ("…to access Challenges as you unlock them.")
- Remove the modal title's `margin-top`
- Add 36px top padding to the challenge modal overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134sWV4Zyj6skWFuchuxC32