### PR TITLE
Fix duplicate describer-less frame on JS for-of/for-in loop line

### DIFF
--- a/interpreters/src/javascript/executor/executeForInStatement.ts
+++ b/interpreters/src/javascript/executor/executeForInStatement.ts
@@ -4,10 +4,12 @@ import { Environment } from "../environment";
 import { JSDictionary, JSString } from "../jikiObjects";
 
 export function executeForInStatement(executor: Executor, statement: ForInStatement): void {
-  // Evaluate the object expression
-  const objectResult = executor.executeFrame(statement.object, () => {
-    return executor.evaluate(statement.object);
-  });
+  // Evaluate the object expression. This does NOT generate its own frame:
+  // the object value is surfaced as part of each ForInStatement iteration frame
+  // (and the empty-object frame). Generating a separate frame here produced an
+  // extra, describer-less frame on the `for` line ("There is no information
+  // available for this line").
+  const objectResult = executor.evaluate(statement.object);
 
   const obj = objectResult.jikiObject;
 

--- a/interpreters/src/javascript/executor/executeForOfStatement.ts
+++ b/interpreters/src/javascript/executor/executeForOfStatement.ts
@@ -4,10 +4,12 @@ import { Environment } from "../environment";
 import { JSArray, JSString } from "../jikiObjects";
 
 export function executeForOfStatement(executor: Executor, statement: ForOfStatement): void {
-  // Evaluate the iterable expression
-  const iterableResult = executor.executeFrame(statement.iterable, () => {
-    return executor.evaluate(statement.iterable);
-  });
+  // Evaluate the iterable expression. This does NOT generate its own frame:
+  // the iterable value is surfaced as part of each ForOfStatement iteration frame
+  // (and the empty-iterable frame). Generating a separate frame here produced an
+  // extra, describer-less frame on the `for` line ("There is no information
+  // available for this line").
+  const iterableResult = executor.evaluate(statement.iterable);
 
   const iterable = iterableResult.jikiObject;
 


### PR DESCRIPTION
## Problem

Students hit a scrubber tooltip reading **"There is no information available for this line. Show us your code in Discord and we'll improve this!"** on the `for` line of a `for...of` loop. Clicking Next then shows the real "Set `letter` to …" description on the *same* line.

Two frames were being generated for the loop line.

## Cause

In the JavaScript interpreter, `executeForOfStatement` (and `executeForInStatement`) evaluated the iterable/object expression inside its own `executor.executeFrame(...)` call. That produced a standalone frame whose context is an `IdentifierExpression` (e.g. `str`). `generateDescription` in `frameDescribers.ts` returns `null` for `IdentifierExpression`, so that frame falls back to the "no information available" message, appearing right before the real iteration frame on the same line.

JikiScript (`visitForeachStatement`) and Python (`executeForInStatement`) already evaluate the iterable with a plain `evaluate(...)` and were unaffected.

## Fix

Evaluate the iterable/object with `executor.evaluate(...)` directly, without wrapping it in a frame. The value is already surfaced within each iteration frame (and the empty-iterable frame), so no information is lost.

## Testing

- `pnpm test tests/javascript/` — 1784 passed, 77 skipped
- `pnpm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)