### PR TITLE
Trim trailing syntax from missing-quote suggestion

### DIFF
--- a/interpreters/src/javascript/scanner.ts
+++ b/interpreters/src/javascript/scanner.ts
@@ -427,7 +427,7 @@ export class Scanner {
 
     if (this.isAtEndOfLine()) {
       this.error("MissingDoubleQuoteToTerminateString", {
-        string: this.sourceCode.substring(this.start + 1, this.current),
+        string: trimTrailingSyntaxChars(this.sourceCode.substring(this.start + 1, this.current)),
       });
     }
 
@@ -457,7 +457,7 @@ export class Scanner {
 
     if (this.isAtEndOfLine()) {
       this.error("MissingDoubleQuoteToTerminateString", {
-        string: this.sourceCode.substring(this.start + 1, this.current),
+        string: trimTrailingSyntaxChars(this.sourceCode.substring(this.start + 1, this.current)),
       });
     }
 
@@ -834,4 +834,15 @@ export class Scanner {
 
 export function scan(sourceCode: string, ...args: [LanguageFeatures?]): Token[] {
   return new Scanner(...args).scanTokens(sourceCode);
+}
+
+// When a string is missing its closing quote, the scanner greedily captures
+// everything to end-of-line. That pulls trailing syntax the student clearly
+// meant to sit OUTSIDE the string (a closing paren, a semicolon, etc.) into the
+// suggested correction. Trim that trailing run of likely-syntax characters and
+// whitespace so `"orange)` suggests `"orange"` rather than `"orange)"`.
+// Internal punctuation (e.g. `"a, b);`) is preserved — only the trailing run is
+// removed.
+function trimTrailingSyntaxChars(captured: string): string {
+  return captured.replace(/[)\]},;\s]+$/, "");
 }

--- a/interpreters/tests/javascript/syntax-errors.test.ts
+++ b/interpreters/tests/javascript/syntax-errors.test.ts
@@ -1,4 +1,5 @@
 import { parse } from "@javascript/parser";
+import { interpret } from "@javascript/interpreter";
 
 describe("syntax errors", () => {
   describe("string errors", () => {
@@ -53,6 +54,41 @@ describe("syntax errors", () => {
         expect(err.message).toContain("Did you forget to add end quote?");
         expect(err.location.line).toBe(2);
       }
+    });
+
+    // When the closing quote is forgotten, the scanner greedily captures to
+    // end-of-line. The suggested correction must not pull trailing syntax (a
+    // closing paren, a semicolon, …) inside the string.
+    describe("suggested string trims trailing syntax characters", () => {
+      test.each([
+        ['ellipse(40, 93, 7, 4, "orange)', "orange"],
+        ['ellipse(40, 93, 7, 4, "orange);', "orange"],
+        ["ellipse(40, 93, 7, 4, 'orange)", "orange"],
+        ["ellipse(40, 93, 7, 4, 'orange);", "orange"],
+        ['let x = "orange]', "orange"],
+      ])("%s → context.string %s", (code: string, expected: string) => {
+        const { error } = interpret(code);
+        expect(error?.type).toBe("MissingDoubleQuoteToTerminateString");
+        expect(error?.context?.string).toBe(expected);
+      });
+
+      test("internal punctuation is preserved, only the trailing run is trimmed", () => {
+        const { error } = interpret('let x = "a, b);');
+        expect(error?.type).toBe("MissingDoubleQuoteToTerminateString");
+        expect(error?.context?.string).toBe("a, b");
+      });
+
+      test("single-quoted string preserves internal punctuation", () => {
+        const { error } = interpret("let x = 'a, b);");
+        expect(error?.type).toBe("MissingDoubleQuoteToTerminateString");
+        expect(error?.context?.string).toBe("a, b");
+      });
+
+      test("string that is entirely trailing syntax trims to empty", () => {
+        const { error } = interpret('foo(");');
+        expect(error?.type).toBe("MissingDoubleQuoteToTerminateString");
+        expect(error?.context?.string).toBe("");
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

When a student forgets a closing quotation mark in the JavaScript interpreter, e.g.:

```js
ellipse(40, 93, 7, 4, "orange)
```

the scanner correctly diagnoses a missing quotation mark (`MissingDoubleQuoteToTerminateString`), but it greedily captures everything to end-of-line as the string, so the suggested correction becomes the misleading `"orange)"` — pulling the closing paren *inside* the string. The student clearly meant `"orange")`.

Reported by Aron.

## Fix

A small helper strips a trailing run of `) ] } , ;` and whitespace from the captured string before it goes into the error context, applied in both `tokenizeString` and `tokenizeSingleQuoteString`:

```ts
function trimTrailingSyntaxChars(captured: string): string {
  return captured.replace(/[)\]},;\s]+$/, "");
}
```

So the suggestion becomes `"orange"` instead of `"orange)"`. Only the `context.string` value changes — error type, diagnosis, location, and token stream are untouched. Internal punctuation is preserved (`"a, b);` → suggests `"a, b"`).

No translation-file changes (no error keys added or renamed).

## Tests

Added cases in `tests/javascript/syntax-errors.test.ts` covering the reported case, the `);` variant, single-quote equivalents, internal-punctuation preservation, and the all-trailing-syntax edge (`foo(");` → empty string).

- `pnpm test`: 3605 passed / 117 skipped
- `pnpm run typecheck`: clean
- `pnpm run lint --max-warnings=0`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EnGdaSk7jTkCJqJ48ELQt