### PR TITLE
Forbid built-in method calls on the acronym exercise

### DIFF
--- a/curriculum/src/exercises/acronym/locales/en/translation.json
+++ b/curriculum/src/exercises/acronym/locales/en/translation.json
@@ -64,7 +64,8 @@
     }
   },
   "checks": {
-    "tooManyLines": "Keep going! See if you can solve it in fewer lines."
+    "tooManyLines": "Keep going! See if you can solve it in fewer lines.",
+    "noMethods": "This exercise is about building the tools yourself. Solve it without using any built-in methods."
   },
   "hints": {
     "pickLetters": {

--- a/curriculum/src/exercises/acronym/locales/hu/translation.json
+++ b/curriculum/src/exercises/acronym/locales/hu/translation.json
@@ -64,7 +64,8 @@
     }
   },
   "checks": {
-    "tooManyLines": "Keep going! See if you can solve it in fewer lines."
+    "tooManyLines": "Keep going! See if you can solve it in fewer lines.",
+    "noMethods": "This exercise is about building the tools yourself. Solve it without using any built-in methods."
   },
   "hints": {
     "pickLetters": {

--- a/curriculum/src/exercises/acronym/scenarios.ts
+++ b/curriculum/src/exercises/acronym/scenarios.ts
@@ -13,6 +13,19 @@ const lineCountCheck: CodeCheck[] = [
   }
 ];
 
+// The whole point of this exercise is to build the letter-testing and
+// case-swapping tools by hand. String methods aren't taught until a later
+// level. As a challenge, though, the exercise inherits the student's current
+// level's features, which may already unlock `.toUpperCase()`/`.includes()`.
+// This check enforces the exercise's intent regardless of level: no method
+// calls at all. It's applied to every scenario below.
+const noMethodsCheck: CodeCheck[] = [
+  {
+    pass: (result) => result.assertors.countMethodCalls() === 0,
+    errorKey: "checks.noMethods"
+  }
+];
+
 export const tasks = [
   {
     id: "create-acronym-function" as const,
@@ -45,7 +58,7 @@ export const tasks = [
   }
 ] as const satisfies readonly Task[];
 
-export const scenarios: IOScenario[] = [
+const baseScenarios: IOScenario[] = [
   {
     slug: "png",
     name: "scenarios.png.name",
@@ -165,3 +178,10 @@ export const scenarios: IOScenario[] = [
     codeChecks: lineCountCheck
   }
 ];
+
+// No method calls are allowed anywhere: append the no-methods check to every
+// scenario (preserving any scenario-specific checks like the bonus line count).
+export const scenarios: IOScenario[] = baseScenarios.map((scenario) => ({
+  ...scenario,
+  codeChecks: [...noMethodsCheck, ...(scenario.codeChecks ?? [])]
+}));

--- a/interpreters/src/javascript/executor.ts
+++ b/interpreters/src/javascript/executor.ts
@@ -191,6 +191,7 @@ export interface ExecutorResult {
     assertMaxLinesOfCode: (limit: number) => boolean;
     assertFunctionDefined: (name: string) => boolean;
     assertMethodCalled: (methodName: string) => boolean;
+    countMethodCalls: () => number;
     countArrayLiterals: () => number;
     assertFunctionCalledOutsideOwnDefinition: (funcName: string) => boolean;
     assertFunctionCallsAnotherFunction: (funcName: string) => boolean;
@@ -450,6 +451,7 @@ export class Executor {
           const formatted = formatIdentifier(methodName);
           return extractMethodCalls(statements).some(mc => mc.methodName === formatted);
         },
+        countMethodCalls: () => extractMethodCalls(statements).length,
         countArrayLiterals: () => countArrayExpressions(statements),
         assertFunctionCalledOutsideOwnDefinition: (funcName: string) => {
           const formatted = formatIdentifier(funcName);

--- a/interpreters/src/javascript/interpreter.ts
+++ b/interpreters/src/javascript/interpreter.ts
@@ -117,6 +117,7 @@ export function interpret(sourceCode: string, context: EvaluationContext = {}): 
         assertMaxLinesOfCode: () => true,
         assertFunctionDefined: () => true,
         assertMethodCalled: () => true,
+        countMethodCalls: () => 0,
         countArrayLiterals: () => 0,
         assertFunctionCalledOutsideOwnDefinition: () => true,
         assertFunctionCallsAnotherFunction: () => true,
@@ -252,6 +253,7 @@ export function evaluateFunction(
         const formatted = formatIdentifier(methodName);
         return extractMethodCalls(statements).some(mc => mc.methodName === formatted);
       },
+      countMethodCalls: () => extractMethodCalls(statements).length,
       countArrayLiterals: () => countArrayExpressions(statements),
       assertFunctionCalledOutsideOwnDefinition: (funcName: string) => {
         const formatted = formatIdentifier(funcName);

--- a/interpreters/src/jikiscript/executor.ts
+++ b/interpreters/src/jikiscript/executor.ts
@@ -363,6 +363,7 @@ export class Executor {
           const formatted = formatIdentifier(methodName);
           return extractMethodCallExpressions(statements).some(mc => mc.methodName.lexeme === formatted);
         },
+        countMethodCalls: () => extractMethodCallExpressions(statements).length,
         countArrayLiterals: () => countListExpressions(statements),
         assertFunctionCalledOutsideOwnDefinition: (funcName: string) => {
           const formatted = formatIdentifier(funcName);

--- a/interpreters/src/jikiscript/interpreter.ts
+++ b/interpreters/src/jikiscript/interpreter.ts
@@ -118,6 +118,7 @@ export function interpret(sourceCode: string, context: EvaluationContext = {}): 
         assertMaxLinesOfCode: () => true,
         assertFunctionDefined: () => true,
         assertMethodCalled: () => true,
+        countMethodCalls: () => 0,
         countArrayLiterals: () => 0,
         assertFunctionCalledOutsideOwnDefinition: () => true,
         assertFunctionCallsAnotherFunction: () => true,

--- a/interpreters/src/python/executor.ts
+++ b/interpreters/src/python/executor.ts
@@ -144,6 +144,7 @@ export interface ExecutorResult {
     assertMaxLinesOfCode: (limit: number) => boolean;
     assertFunctionDefined: (name: string) => boolean;
     assertMethodCalled: (methodName: string) => boolean;
+    countMethodCalls: () => number;
     countArrayLiterals: () => number;
     assertFunctionCalledOutsideOwnDefinition: (funcName: string) => boolean;
     assertFunctionCallsAnotherFunction: (funcName: string) => boolean;
@@ -323,6 +324,7 @@ export class Executor {
           const formatted = formatIdentifier(methodName);
           return extractMethodCalls(statements).some(mc => mc.methodName === formatted);
         },
+        countMethodCalls: () => extractMethodCalls(statements).length,
         countArrayLiterals: () => countListExpressions(statements),
         assertFunctionCalledOutsideOwnDefinition: (funcName: string) => {
           const formatted = formatIdentifier(funcName);

--- a/interpreters/src/python/interpreter.ts
+++ b/interpreters/src/python/interpreter.ts
@@ -97,6 +97,7 @@ export function interpret(sourceCode: string, context: EvaluationContext = {}): 
         assertMaxLinesOfCode: () => true,
         assertFunctionDefined: () => true,
         assertMethodCalled: () => true,
+        countMethodCalls: () => 0,
         countArrayLiterals: () => 0,
         assertFunctionCalledOutsideOwnDefinition: () => true,
         assertFunctionCallsAnotherFunction: () => true,
@@ -237,6 +238,7 @@ export function evaluateFunction(
         const formatted = formatIdentifier(methodName);
         return extractMethodCalls(statements).some(mc => mc.methodName === formatted);
       },
+      countMethodCalls: () => extractMethodCalls(statements).length,
       countArrayLiterals: () => countListExpressions(statements),
       assertFunctionCalledOutsideOwnDefinition: (funcName: string) => {
         const formatted = formatIdentifier(funcName);

--- a/interpreters/src/shared/interfaces.ts
+++ b/interpreters/src/shared/interfaces.ts
@@ -85,6 +85,7 @@ export interface InterpretResult {
     assertMaxLinesOfCode: (limit: number) => boolean;
     assertFunctionDefined: (name: string) => boolean;
     assertMethodCalled: (methodName: string) => boolean;
+    countMethodCalls: () => number;
     countArrayLiterals: () => number;
     assertFunctionCalledOutsideOwnDefinition: (funcName: string) => boolean;
     assertFunctionCallsAnotherFunction: (funcName: string) => boolean;


### PR DESCRIPTION
## Problem

[Reported on the forum](https://jiki.io/r/forum) by glennj: the Acronym challenge's "Heads up" section says string methods aren't available yet, but a solution using `.toUpperCase()` and `.includes()` works fine.

Acronym is authored for the `multiple-functions` level, where string methods aren't taught. Its instructions, hints, and reference solutions (JS/Python/Jikiscript) all assume the student hand-rolls uppercasing and letter-testing.

The interpreter *does* correctly block those methods at `multiple-functions`. The catch: Acronym is served as a **challenge**, and challenges run at the student's *current* level (`current_level_slug` in `Challenge.tsx`), not the exercise's authored level. Once a student reaches `methods-and-properties`, the accumulated features unlock `.toUpperCase()`/`.includes()`, trivialising the exercise and contradicting its own instructions.

## Fix

1. **New `countMethodCalls()` assertor** on all three interpreters (JavaScript, Python, Jikiscript) plus the shared `InterpretResult` type. AST-based, reusing the existing `extractMethodCalls`/`extractMethodCallExpressions` helpers — no string/regex matching.

2. **`noMethodsCheck` codeCheck** on the acronym exercise that fails when any method is called, applied to every scenario. A method-based solution then reads as "0/12, wrong approach" rather than a misleading "11/12, almost there", enforcing the exercise's intent regardless of the level it's surfaced at.

3. **`checks.noMethods` translation** (en + hu-stubbed-in-English), worded to state the constraint without giving away the technique.

## Scope note

This fixes acronym specifically. The general leak — any early-level exercise surfaced as a later-level challenge inherits features its instructions disown — is not addressed here (that would be a feature-ceiling change in the challenge loader). This is consistent with keeping method *syntax* generally allowed at the AST level and gating via per-exercise codeChecks instead.

## Verification

- Reference solutions (JS/Py/Jiki) all yield `countMethodCalls() === 0` → pass.
- `.toUpperCase()` / `.includes()` / `.upper()` solutions → count 1 → fail.
- Interpreter + curriculum packages typecheck clean.
- 1171 curriculum tests pass; interpreter suite passes (initial cross-validation "failures" were confirmed load flakes — 92/92 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)