### PR TITLE
js: short-circuit && and || evaluation

### DIFF
--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -1,5 +1,17 @@
 # JavaScript Interpreter Evolution
 
+## 2026-07-28: Short-circuit `&&` / `||` evaluation
+
+`executeLogicalExpression` evaluated **both** operands up front before applying the operator, so the right side always ran even when the left side already decided the result. A forum-reported bug surfaced this: an `&&`/`||` chain ending in `name[person.length] === " "` threw `StringIndexOutOfRange` on the out-of-bounds index access even though the earlier operand short-circuited the expression, matching neither real JavaScript nor JikiScript/Python (both of which already short-circuit).
+
+The executor now evaluates the left operand, computes its truthiness via the shared `isTruthy` helper (same helper `if`/`while` use — it enforces `TruthinessDisabled` in strict mode and applies real JS ToBoolean rules when `allowTruthiness` is on), and only evaluates the right operand when the operator requires it (`&&` with a truthy left, `||` with a falsy left). The result is the **deciding operand's** `jikiObject` verbatim, preserving JS value-returning semantics (`0 && x` → `0`, `"first" || y` → `"first"`) rather than a coerced boolean.
+
+Consequences:
+
+- The right operand is no longer verified when short-circuited. In strict mode (`allowTruthiness: false`), `false && 5` used to error on the non-boolean `5`; it now returns `false` without inspecting the right side. This matches JikiScript/Python (they only verify the side they evaluate) and is the intended behavior.
+- `EvaluationResultLogicalExpression.right` is now `EvaluationResultExpression | null` and a `shortCircuited: boolean` flag was added. `describeLogicalExpression` renders a "did not need to look at the right side" step when short-circuited (mirroring JikiScript's describer).
+- New regression tests in `tests/javascript/regression/logical-short-circuit.test.ts`.
+
 ## 2026-07-25: Reject storing `undefined` in a variable/element/property
 
 Follow-up to the out-of-bounds/comparison change below. JikiScript has no `undefined` at all — it guards every expression in `evaluate()` (`guardNull` → `ExpressionEvaluatedToNullValue`) and re-raises a friendlier error when a set-variable statement tries to store a none-value. JS can't guard inside `evaluate()` (a bare `f();` calling a void function is a legitimate `ExpressionStatement` that must be allowed to discard its result), so JS guards at the **storage points** instead:

--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -9,7 +9,7 @@ The executor now evaluates the left operand, computes its truthiness via the sha
 Consequences:
 
 - The right operand is no longer verified when short-circuited. In strict mode (`allowTruthiness: false`), `false && 5` used to error on the non-boolean `5`; it now returns `false` without inspecting the right side. This matches JikiScript/Python (they only verify the side they evaluate) and is the intended behavior.
-- `EvaluationResultLogicalExpression.right` is now `EvaluationResultExpression | null` and a `shortCircuited: boolean` flag was added. `describeLogicalExpression` renders a "did not need to look at the right side" step when short-circuited (mirroring JikiScript's describer).
+- `EvaluationResultLogicalExpression` is now a discriminated union on a new `shortCircuited` flag: `shortCircuited: true` carries `right: null`, `shortCircuited: false` carries a real `right`. This lets `describeLogicalExpression` narrow `right` from `if (result.shortCircuited)` alone, with no cast. When short-circuited it renders a "Jiki saw `&&` was `false` and so continued" step instead of describing the unevaluated right side.
 - New regression tests in `tests/javascript/regression/logical-short-circuit.test.ts`.
 
 ## 2026-07-25: Reject storing `undefined` in a variable/element/property

--- a/interpreters/.context/javascript/evolution.md
+++ b/interpreters/.context/javascript/evolution.md
@@ -9,7 +9,7 @@ The executor now evaluates the left operand, computes its truthiness via the sha
 Consequences:
 
 - The right operand is no longer verified when short-circuited. In strict mode (`allowTruthiness: false`), `false && 5` used to error on the non-boolean `5`; it now returns `false` without inspecting the right side. This matches JikiScript/Python (they only verify the side they evaluate) and is the intended behavior.
-- `EvaluationResultLogicalExpression` is now a discriminated union on a new `shortCircuited` flag: `shortCircuited: true` carries `right: null`, `shortCircuited: false` carries a real `right`. This lets `describeLogicalExpression` narrow `right` from `if (result.shortCircuited)` alone, with no cast. When short-circuited it renders a "Jiki saw `&&` was `false` and so continued" step instead of describing the unevaluated right side.
+- `EvaluationResultLogicalExpression` is now a discriminated union on a new `shortCircuited` flag: `shortCircuited: true` carries `right: null`, `shortCircuited: false` carries a real `right`. This lets `describeLogicalExpression` narrow `right` from `if (result.shortCircuited)` alone, with no cast. When short-circuited it renders a "Jiki saw the left side of the `&&` was `false` and so did not bother looking at the right side" step (matching JikiScript's phrasing) instead of describing the unevaluated right side.
 - New regression tests in `tests/javascript/regression/logical-short-circuit.test.ts`.
 
 ## 2026-07-25: Reject storing `undefined` in a variable/element/property

--- a/interpreters/src/javascript/describers/describeLogicalExpression.ts
+++ b/interpreters/src/javascript/describers/describeLogicalExpression.ts
@@ -37,9 +37,9 @@ function describeShortCircuitedExpression(
 
   return [
     ...leftSteps,
-    `<li>Jiki saw ${codeTag(
+    `<li>Jiki saw the left side of the ${codeTag(
       expression.operator.lexeme,
       expression.operator.location
-    )} was ${codeTag(leftRes, expression.left.location)} and so continued.</li>`,
+    )} was ${codeTag(leftRes, expression.left.location)} and so did not bother looking at the right side.</li>`,
   ];
 }

--- a/interpreters/src/javascript/describers/describeLogicalExpression.ts
+++ b/interpreters/src/javascript/describers/describeLogicalExpression.ts
@@ -9,6 +9,10 @@ export function describeLogicalExpression(
   result: EvaluationResultLogicalExpression,
   context: DescriptionContext
 ) {
+  if (result.shortCircuited || result.right === null) {
+    return describeShortCircuitedExpression(expression, result, context);
+  }
+
   const leftSteps = describeExpression(expression.left, result.left, context);
   const rightSteps = describeExpression(expression.right, result.right, context);
 
@@ -21,4 +25,21 @@ export function describeLogicalExpression(
     expression.location
   )} and determined it was ${codeTag(result.immutableJikiObject, expression.location)}.</li>`;
   return [...leftSteps, ...rightSteps, finalStep];
+}
+
+function describeShortCircuitedExpression(
+  expression: LogicalExpression,
+  result: EvaluationResultLogicalExpression,
+  context: DescriptionContext
+) {
+  const leftSteps = describeExpression(expression.left, result.left, context);
+  const leftRes = formatJSObject(result.left.immutableJikiObject);
+
+  return [
+    ...leftSteps,
+    `<li>Jiki saw the left side of the ${codeTag(
+      expression.operator.lexeme,
+      expression.operator.location
+    )} was ${codeTag(leftRes, expression.left.location)} and so did not need to look at the right side.</li>`,
+  ];
 }

--- a/interpreters/src/javascript/describers/describeLogicalExpression.ts
+++ b/interpreters/src/javascript/describers/describeLogicalExpression.ts
@@ -9,7 +9,7 @@ export function describeLogicalExpression(
   result: EvaluationResultLogicalExpression,
   context: DescriptionContext
 ) {
-  if (result.shortCircuited || result.right === null) {
+  if (result.shortCircuited) {
     return describeShortCircuitedExpression(expression, result, context);
   }
 
@@ -37,9 +37,9 @@ function describeShortCircuitedExpression(
 
   return [
     ...leftSteps,
-    `<li>Jiki saw the left side of the ${codeTag(
+    `<li>Jiki saw ${codeTag(
       expression.operator.lexeme,
       expression.operator.location
-    )} was ${codeTag(leftRes, expression.left.location)} and so did not need to look at the right side.</li>`,
+    )} was ${codeTag(leftRes, expression.left.location)} and so continued.</li>`,
   ];
 }

--- a/interpreters/src/javascript/evaluation-result.ts
+++ b/interpreters/src/javascript/evaluation-result.ts
@@ -92,9 +92,10 @@ export interface EvaluationResultBinaryExpression {
 export interface EvaluationResultLogicalExpression {
   type: "LogicalExpression";
   left: EvaluationResultExpression;
-  right: EvaluationResultExpression;
+  right: EvaluationResultExpression | null;
   jikiObject: JikiObject;
   immutableJikiObject: JikiObject;
+  shortCircuited: boolean;
 }
 
 export interface EvaluationResultUnaryExpression {

--- a/interpreters/src/javascript/evaluation-result.ts
+++ b/interpreters/src/javascript/evaluation-result.ts
@@ -89,14 +89,25 @@ export interface EvaluationResultBinaryExpression {
   immutableJikiObject: JikiObject;
 }
 
-export interface EvaluationResultLogicalExpression {
-  type: "LogicalExpression";
-  left: EvaluationResultExpression;
-  right: EvaluationResultExpression | null;
-  jikiObject: JikiObject;
-  immutableJikiObject: JikiObject;
-  shortCircuited: boolean;
-}
+// Discriminated union on `shortCircuited` so TypeScript narrows `right` on its
+// own: when we short-circuit there is no right side, otherwise there always is.
+export type EvaluationResultLogicalExpression =
+  | {
+      type: "LogicalExpression";
+      shortCircuited: true;
+      left: EvaluationResultExpression;
+      right: null;
+      jikiObject: JikiObject;
+      immutableJikiObject: JikiObject;
+    }
+  | {
+      type: "LogicalExpression";
+      shortCircuited: false;
+      left: EvaluationResultExpression;
+      right: EvaluationResultExpression;
+      jikiObject: JikiObject;
+      immutableJikiObject: JikiObject;
+    };
 
 export interface EvaluationResultUnaryExpression {
   type: "UnaryExpression";

--- a/interpreters/src/javascript/executor/executeLogicalExpression.ts
+++ b/interpreters/src/javascript/executor/executeLogicalExpression.ts
@@ -1,7 +1,6 @@
 import type { Executor } from "../executor";
 import type { LogicalExpression } from "../expression";
 import type { EvaluationResultLogicalExpression, EvaluationResultExpression } from "../evaluation-result";
-import type { JikiObject } from "../jikiObjects";
 import { isTruthy } from "../helpers";
 import { InterpreterInternalError } from "../error";
 
@@ -23,12 +22,12 @@ export function executeLogicalExpression(
   switch (expression.operator.type) {
     case "LOGICAL_AND":
       if (!leftTruthy) {
-        return buildResult(leftResult, null, leftResult.jikiObject);
+        return shortCircuitResult(leftResult);
       }
       break;
     case "LOGICAL_OR":
       if (leftTruthy) {
-        return buildResult(leftResult, null, leftResult.jikiObject);
+        return shortCircuitResult(leftResult);
       }
       break;
     default:
@@ -39,20 +38,23 @@ export function executeLogicalExpression(
 
   const rightResult = executor.evaluate(expression.right);
   executor.verifyBoolean(rightResult.jikiObject, expression.right.location);
-  return buildResult(leftResult, rightResult, rightResult.jikiObject);
-}
-
-function buildResult(
-  leftResult: EvaluationResultExpression,
-  rightResult: EvaluationResultExpression | null,
-  jikiObject: JikiObject
-): EvaluationResultLogicalExpression {
   return {
     type: "LogicalExpression",
+    shortCircuited: false,
     left: leftResult,
     right: rightResult,
-    jikiObject,
-    immutableJikiObject: jikiObject.clone(),
-    shortCircuited: rightResult === null,
+    jikiObject: rightResult.jikiObject,
+    immutableJikiObject: rightResult.jikiObject.clone(),
+  };
+}
+
+function shortCircuitResult(leftResult: EvaluationResultExpression): EvaluationResultLogicalExpression {
+  return {
+    type: "LogicalExpression",
+    shortCircuited: true,
+    left: leftResult,
+    right: null,
+    jikiObject: leftResult.jikiObject,
+    immutableJikiObject: leftResult.jikiObject.clone(),
   };
 }

--- a/interpreters/src/javascript/executor/executeLogicalExpression.ts
+++ b/interpreters/src/javascript/executor/executeLogicalExpression.ts
@@ -1,7 +1,8 @@
 import type { Executor } from "../executor";
 import type { LogicalExpression } from "../expression";
-import type { EvaluationResultLogicalExpression } from "../evaluation-result";
-import { createJSObject } from "../jikiObjects";
+import type { EvaluationResultLogicalExpression, EvaluationResultExpression } from "../evaluation-result";
+import type { JikiObject } from "../jikiObjects";
+import { isTruthy } from "../helpers";
 import { InterpreterInternalError } from "../error";
 
 export function executeLogicalExpression(
@@ -9,21 +10,26 @@ export function executeLogicalExpression(
   expression: LogicalExpression
 ): EvaluationResultLogicalExpression {
   const leftResult = executor.evaluate(expression.left);
-  const rightResult = executor.evaluate(expression.right);
+  // isTruthy enforces the TruthinessDisabled check (when truthiness is off, a
+  // non-boolean operand errors here) and otherwise computes JS truthiness the
+  // same way if/while conditions do - keeping all three consistent.
+  const leftTruthy = isTruthy(executor, leftResult.jikiObject, expression.left.location);
 
-  executor.verifyBoolean(leftResult.jikiObject, expression.left.location);
-  executor.verifyBoolean(rightResult.jikiObject, expression.right.location);
-
-  const left = leftResult.jikiObject.value;
-  const right = rightResult.jikiObject.value;
-
-  let value: boolean;
+  // Short-circuit: only evaluate the right side when the operator requires it.
+  // This matches JavaScript semantics - `false && x` and `true || x` must never
+  // evaluate `x` (which may itself throw, e.g. an out-of-bounds index access).
+  // Logical operators return the operand that decided the result, not a coerced
+  // boolean, so we hand back the relevant side's jikiObject verbatim.
   switch (expression.operator.type) {
     case "LOGICAL_AND":
-      value = left && right;
+      if (!leftTruthy) {
+        return buildResult(leftResult, null, leftResult.jikiObject);
+      }
       break;
     case "LOGICAL_OR":
-      value = left || right;
+      if (leftTruthy) {
+        return buildResult(leftResult, null, leftResult.jikiObject);
+      }
       break;
     default:
       // The parser only emits LogicalExpression for && and ||, so reaching
@@ -31,13 +37,22 @@ export function executeLogicalExpression(
       throw new InterpreterInternalError(`Unsupported logical operator: ${expression.operator.type}`);
   }
 
-  const result = createJSObject(value);
+  const rightResult = executor.evaluate(expression.right);
+  executor.verifyBoolean(rightResult.jikiObject, expression.right.location);
+  return buildResult(leftResult, rightResult, rightResult.jikiObject);
+}
 
+function buildResult(
+  leftResult: EvaluationResultExpression,
+  rightResult: EvaluationResultExpression | null,
+  jikiObject: JikiObject
+): EvaluationResultLogicalExpression {
   return {
     type: "LogicalExpression",
     left: leftResult,
     right: rightResult,
-    jikiObject: result,
-    immutableJikiObject: result.clone(),
-  } as any;
+    jikiObject,
+    immutableJikiObject: jikiObject.clone(),
+    shortCircuited: rightResult === null,
+  };
 }

--- a/interpreters/tests/javascript/regression/logical-short-circuit.test.ts
+++ b/interpreters/tests/javascript/regression/logical-short-circuit.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "vitest";
+import type { TestAugmentedFrame } from "@shared/frames";
+import { interpret } from "@javascript/interpreter";
+
+// Regression for a forum-reported bug: the right side of a `&&`/`||` chain was
+// evaluated eagerly, so a short-circuited sub-expression that would throw (e.g.
+// an out-of-bounds index access) still crashed the program even though real
+// JavaScript would never reach it.
+describe("JavaScript logical short-circuit regression tests", () => {
+  test("&& does not evaluate the right side when the left is false", () => {
+    // name[person.length] would be name[4] on a 4-char string and throw, but the
+    // false left side (person !== name) must short-circuit before it is reached.
+    const code = `
+      let name = "Cher";
+      let person = "Cher";
+      let result = false;
+      if (person !== name && name[person.length] === " ") {
+        result = true;
+      }
+    `;
+    const { frames, error } = interpret(code);
+    expect(error).toBeNull();
+    const finalFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(finalFrame.status).toBe("SUCCESS");
+    expect(finalFrame.variables.result.value).toBe(false);
+  });
+
+  test("|| does not evaluate the right side when the left is true", () => {
+    const code = `
+      let name = "Cher";
+      let person = "Cher";
+      let result = false;
+      if (person === name || name[person.length] === " ") {
+        result = true;
+      }
+    `;
+    const { frames, error } = interpret(code);
+    expect(error).toBeNull();
+    const finalFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(finalFrame.status).toBe("SUCCESS");
+    expect(finalFrame.variables.result.value).toBe(true);
+  });
+
+  test("the out-of-bounds access still throws when actually reached", () => {
+    const code = `
+      let name = "Cher";
+      let x = name[10];
+    `;
+    const { frames } = interpret(code);
+    const errorFrame = frames.find(f => (f as TestAugmentedFrame).status === "ERROR") as TestAugmentedFrame;
+    expect(errorFrame).toBeDefined();
+    expect(errorFrame.error?.type).toBe("StringIndexOutOfRange");
+  });
+
+  test("full after-party style condensed expression works for exact match", () => {
+    const code = `
+      function matches(person, name) {
+        return person === name || (name.startsWith(person) && person.length <= name.length && name[person.length] === " ");
+      }
+      let a = matches("Cher", "Cher");
+      let b = matches("Cheryl", "Cher");
+      let c = matches("Cher", "Cher Lloyd");
+    `;
+    const { frames, error } = interpret(code);
+    expect(error).toBeNull();
+    const finalFrame = frames[frames.length - 1] as TestAugmentedFrame;
+    expect(finalFrame.status).toBe("SUCCESS");
+    expect(finalFrame.variables.a.value).toBe(true);
+    expect(finalFrame.variables.b.value).toBe(false);
+    expect(finalFrame.variables.c.value).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

A [forum bug report](https://jiki.io/r/forum) surfaced this: in the after-party exercise, a condensed `&&`/`||` chain ending in `name[person.length] === " "` threw

> This string only has 4 characters, but you tried to access index 4.

even though the out-of-bounds access sits at the end of a chain that should short-circuit before reaching it (e.g. `person === name || (... && name[person.length] === " ")` with `person === name` already true).

Root cause: `executeLogicalExpression` evaluated **both** operands up front before applying the operator, so the right side always ran — the opposite of JavaScript semantics, and inconsistent with JikiScript and Python, which already short-circuit.

## Fix

The executor now:
1. Evaluates the left operand and computes its truthiness via the shared `isTruthy` helper (the same one `if`/`while` use — it enforces `TruthinessDisabled` in strict mode and applies real JS ToBoolean rules when `allowTruthiness` is on).
2. Only evaluates the right operand when the operator requires it (`&&` with a truthy left, `||` with a falsy left).
3. Returns the **deciding operand's** `jikiObject` verbatim, preserving JS value-returning semantics (`0 && x` → `0`, `"first" || y` → `"first"`).

### Notable behavior change

The right operand is no longer verified when short-circuited. In strict mode (`allowTruthiness: false`), `false && 5` previously errored on the non-boolean `5`; it now returns `false` without inspecting the right side. This matches JikiScript/Python (they only verify the side they actually evaluate) and is the intended short-circuit behavior.

## Other changes

- `EvaluationResultLogicalExpression.right` is now `EvaluationResultExpression | null`, with a new `shortCircuited: boolean` flag.
- `describeLogicalExpression` renders a "did not need to look at the right side" step when short-circuited (mirroring JikiScript's describer).
- New regression tests in `tests/javascript/regression/logical-short-circuit.test.ts`.
- Evolution doc updated.

## Testing

Full interpreters suite green (3613 passed), typecheck clean, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)