### PR TITLE
Add while-loops concept

### DIFF
--- a/curriculum/src/concepts/break/config.json
+++ b/curriculum/src/concepts/break/config.json
@@ -1,5 +1,5 @@
 {
   "parent": "loops-group",
-  "order": 5,
+  "order": 6,
   "category": false
 }

--- a/curriculum/src/concepts/while-loops/config.json
+++ b/curriculum/src/concepts/while-loops/config.json
@@ -1,5 +1,5 @@
 {
   "parent": "loops-group",
-  "order": 7,
+  "order": 5,
   "category": false
 }

--- a/curriculum/src/concepts/while-loops/hu.md
+++ b/curriculum/src/concepts/while-loops/hu.md
@@ -1,0 +1,21 @@
+---
+title: "While Loops"
+description: "A loop that keeps running while some condition stays true."
+---
+
+The next loop to know about is a <define>while</define> loop.
+
+This says, "While some condition, run the loop." So we might have a rule that says you can only shoot five times in Space Invaders. So we'd have a loop here that says, well, while the number of shots is less than five, run a loop that allows someone to play the game.
+
+```javascript
+while (numShots < 5) {
+  // shoot alien
+  numShots++
+}
+```
+
+Each time someone shoots, we increase the `numShots` by one, and eventually we'll hit five and the loop will exit.
+
+Now, one problem with while loops is that it's quite easy to have bugs that mean the loop never ends. And these are called <define>infinite loops</define>, and they're one of the most common bugs in programs.
+
+When your computer slows down, the fans start spinning, everything gets loud, that's often because someone's left an infinite loop that never ends in their code.

--- a/curriculum/src/concepts/while-loops/source.md
+++ b/curriculum/src/concepts/while-loops/source.md
@@ -1,0 +1,21 @@
+---
+title: "While Loops"
+description: "A loop that keeps running while some condition stays true."
+---
+
+The next loop to know about is a <define>while</define> loop.
+
+This says, "While some condition, run the loop." So we might have a rule that says you can only shoot five times in Space Invaders. So we'd have a loop here that says, well, while the number of shots is less than five, run a loop that allows someone to play the game.
+
+```javascript
+while (numShots < 5) {
+  // shoot alien
+  numShots++
+}
+```
+
+Each time someone shoots, we increase the `numShots` by one, and eventually we'll hit five and the loop will exit.
+
+Now, one problem with while loops is that it's quite easy to have bugs that mean the loop never ends. And these are called <define>infinite loops</define>, and they're one of the most common bugs in programs.
+
+When your computer slows down, the fans start spinning, everything gets loud, that's often because someone's left an infinite loop that never ends in their code.

--- a/curriculum/src/exercises/digital-root/index.ts
+++ b/curriculum/src/exercises/digital-root/index.ts
@@ -27,7 +27,7 @@ const exerciseDefinition: IOExerciseCore = {
   tasks,
   scenarios,
   functions,
-  conceptSlugs: ["repeat-while", "string-iteration", "type-conversion"]
+  conceptSlugs: ["while-loops", "string-iteration", "type-conversion"]
 };
 
 export default exerciseDefinition;


### PR DESCRIPTION
Adds a `while-loops` concept, which was missing despite being taught in the `for-while-loops` video.

### Changes
- **New concept** `src/concepts/while-loops/` — copy transcribed faithfully from the while-loop section of the `for-while-loops` transcript (Space Invaders `numShots < 5` example, infinite-loops warning). `<define>` tags on *while* and *infinite loops* for the translator. `hu.md` stubbed from source (not translated).
- **Ordering** — `while-loops` sits at order 5 (right after `for-loops`); `break`/`continue` shift to 6/7, matching the video's for → while → break → continue flow.
- **digital-root** — its solution actually uses a `while` loop, so its `conceptSlugs` now points at `while-loops` instead of the Jikiscript-only `repeat-while`. It was the only Advanced Loops exercise using a while loop.

Paired with jiki-education/api#579 (seed entry, unlocked by `for-while-loops`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zPtK4zBYjbRUbKizdKsXX