### PR TITLE
after-party: quote the "Not on the list!" string in instructions

### DIFF
--- a/curriculum/src/exercises/after-party/instructions/source.md
+++ b/curriculum/src/exercises/after-party/instructions/source.md
@@ -13,7 +13,7 @@ Write a function called <define>`plusOnesFor`</define>. The function has three i
 
 Be careful, though. There's a queue forming, and these people do not queue quietly. "Brad" means Brad Pitt, not Bradley Cooper. And one or two of them are famous enough to have dropped their surname altogether.
 
-Some guests are invited but aren't allowed to bring anyone with them, so `0` is a perfectly good answer for a name that's on the list. Someone who isn't on the list at all is a different matter entirely, and for them you should return the string <literal>`Not on the list!`</literal>, exactly as written.
+Some guests are invited but aren't allowed to bring anyone with them, so `0` is a perfectly good answer for a name that's on the list. Someone who isn't on the list at all is a different matter entirely, and for them you should return the string <literal>`"Not on the list!"`</literal>, exactly as written.
 
 ### Array Methods & Properties
 

--- a/curriculum/src/exercises/after-party/locales/en/translation.json
+++ b/curriculum/src/exercises/after-party/locales/en/translation.json
@@ -2,7 +2,7 @@
   "tasks": {
     "lookUpPlusOnes": {
       "name": "Check the Plus-Ones",
-      "description": "Someone gives you their first name. Return the number of extra guests they're allowed to bring in, or `Not on the list!` if they're not invited."
+      "description": "Someone gives you their first name. Return the number of extra guests they're allowed to bring in, or `\"Not on the list!\"` if they're not invited."
     }
   },
   "scenarios": {
@@ -62,7 +62,7 @@
     },
     "notOnTheList": {
       "question": "What do I do when they're not on the list?",
-      "answer": "Then they get the string `Not on the list!`, exactly as written. Two things are worth thinking about here. First, at what point can you be *certain* that someone isn't on the list? Second, notice that this is a genuinely different answer from a guest who's invited but allowed 0 extra guests, so make sure your function never confuses the two."
+      "answer": "Then they get the string `\"Not on the list!\"`, exactly as written. Two things are worth thinking about here. First, at what point can you be *certain* that someone isn't on the list? Second, notice that this is a genuinely different answer from a guest who's invited but allowed 0 extra guests, so make sure your function never confuses the two."
     }
   },
   "functions": {


### PR DESCRIPTION
Forum feedback from Isaac (After Party bug report):

> `and for them you should return the string Not on the list!, exactly as written.`
> Should that string be quoted? I believe until this point, strings are shown in quotes.

He's right. Every other exercise shows string literals in quotes (`"Alpha"`, `"ballgown"`, `"Even"`, etc.), but after-party displayed the sentinel unquoted. This quotes it in the three English source spots:

- `instructions/source.md` — the exact line Isaac quoted
- `locales/en/translation.json` — the task description and the "not on the list" hint answer

Code files (`solution.*`, `scenarios.ts`, `llm-metadata.ts`) already used `"Not on the list!"` with quotes, so no change needed there.

Note: Hungarian translations still show the unquoted form and will pick up the quotes on the next translation pass. `formal-dinner` has the same convention slip (`No table found`) — left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbbzxkQ5gQdz6s4E6r5eRS