### PR TITLE
formal-dinner: quote the "No table found" string in instructions

### DIFF
--- a/curriculum/src/exercises/formal-dinner/instructions/source.md
+++ b/curriculum/src/exercises/formal-dinner/instructions/source.md
@@ -17,7 +17,7 @@ Write a function called <define info="looks up the table a guest is seated at">`
 - The second is the list of table names, in the same order as the guests
 - The third is the arriving guest, formatted as an honorific followed by their surname (e.g. "Mr Pitt")
 
-Return the name of the table the guest is sitting at. If they're not on the seating plan at all, return the string <literal>`No table found`</literal> instead (no chancers here!).
+Return the name of the table the guest is sitting at. If they're not on the seating plan at all, return the string <literal>`"No table found"`</literal> instead (no chancers here!).
 
 The honorific is always exactly one word, and everything after it is the guest's surname. Most surnames are one word, but a few grand ones run to two.
 

--- a/curriculum/src/exercises/formal-dinner/locales/en/translation.json
+++ b/curriculum/src/exercises/formal-dinner/locales/en/translation.json
@@ -2,7 +2,7 @@
   "tasks": {
     "findGuestTable": {
       "name": "Find the Guest's Table",
-      "description": "Write a function that takes the list of guests' full names, the matching list of table names, and an arriving guest announced as an honorific and a surname. Return the name of the table that guest is sitting at, or `No table found` if they aren't on the seating plan."
+      "description": "Write a function that takes the list of guests' full names, the matching list of table names, and an arriving guest announced as an honorific and a surname. Return the name of the table that guest is sitting at, or `\"No table found\"` if they aren't on the seating plan."
     },
     "solveTightly": {
       "name": "Solve it tightly",
@@ -66,7 +66,7 @@
     },
     "noMatch": {
       "question": "What should I return when nobody matches?",
-      "answer": "The string `No table found`, exactly as written. The trickier bit is knowing when you're allowed to say it. If you've checked the very first guest on the plan and they're not your man, do you actually know yet that he isn't seated somewhere?"
+      "answer": "The string `\"No table found\"`, exactly as written. The trickier bit is knowing when you're allowed to say it. If you've checked the very first guest on the plan and they're not your man, do you actually know yet that he isn't seated somewhere?"
     }
   },
   "checks": {


### PR DESCRIPTION
Forum feedback (Isaac, After Party thread): string literals are shown in quotes everywhere else in the curriculum, but the `formal-dinner` exercise displayed the `No table found` sentinel unquoted.

Quote it for consistency, matching the same fix already made to `after-party` (#979).

Changes (English only — `hu` left untouched, per translation workflow):
- `instructions/source.md`
- `locales/en/translation.json` (task description + hint answer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)