### PR TITLE
js: clear error + operand highlight when comparing an undefined function result

### DIFF
--- a/app/components/coding-exercise/codemirror.css
+++ b/app/components/coding-exercise/codemirror.css
@@ -122,10 +122,11 @@
         opacity: 0.6;
         filter: grayscale(0.6);
     }
-    .ͼ1 .cm-underline {
-        background: var(--color-red-200);
-        border-bottom: 2px solid var(--color-red-500);
-        text-decoration: none;
+    .cm-underline {
+        background: var(--color-red-100);
+        text-decoration: underline 2px red;
+        text-decoration-skip-ink: none;
+        text-underline-offset: 3px;
     }
 }
 
@@ -148,7 +149,8 @@
 
 .cm-highlightedLine {
     position: relative;
-    outline: 1.5px solid var(--highlighted-line-border-color);
+    outline: 1.5px solid var(--color-blue-300);
+    background: var(--color-blue-50);
     border-radius: 2px;
     margin-inline: 2px;
 }
@@ -165,12 +167,6 @@
     &.cm-activeLine {
         background-color: #d6ecfa80;
     }
-    &.cm-highlightedLine--error {
-        background-color: #ff000011;
-        &.cm-activeLine {
-            background-color: #ff000011;
-        }
-    }
 }
 
 /* Dark theme highlighted line colors */
@@ -179,10 +175,15 @@
     &.cm-activeLine {
         background-color: #374151;
     }
-    &.cm-highlightedLine--error {
-        background-color: rgba(239, 68, 68, 0.08);
-        &.cm-activeLine {
-            background-color: rgba(239, 68, 68, 0.08);
-        }
+}
+
+/* Error-highlighted line. Kept top-level rather than nested under .cm-theme-*,
+   which is never applied to the editor DOM, so these styles actually match. The
+   two-class selector outranks the base .cm-highlightedLine outline above. */
+.cm-highlightedLine.cm-highlightedLine--error {
+    outline: 1.5px solid var(--color-red-300);
+    background: var(--color-red-50);
+    &.cm-activeLine {
+        background: var(--color-red-50);
     }
 }

--- a/app/components/coding-exercise/lib/orchestrator/store.ts
+++ b/app/components/coding-exercise/lib/orchestrator/store.ts
@@ -396,15 +396,24 @@ export function createOrchestratorStore(
           const infoWidgetHtml = processMessageContent(rawContent);
 
           // Runtime error frames highlight the line in red (cm-highlightedLine--error);
-          // success frames use the default info styling. Unlike syntax errors, runtime
-          // error frames do NOT underline a specific location.
+          // success frames use the default info styling. Error frames also underline the
+          // exact span the error points at (e.g. the offending function call in a
+          // comparison), matching how syntax errors are surfaced. Absolute offsets are
+          // 1-based in the interpreter, so we shift to CodeMirror's 0-based positions.
           const isError = frame.status === "ERROR";
+          const errorLocation = isError ? frame.error?.location : undefined;
+          const underlineRange = errorLocation
+            ? {
+                from: Math.max(0, errorLocation.absolute.begin - 1),
+                to: Math.max(0, errorLocation.absolute.end - 1)
+              }
+            : undefined;
 
           set({
             currentFrame: frame,
             highlightedLine: frame.line,
             highlightedLineColor: isError ? ERROR_HIGHLIGHT_COLOR : INFO_HIGHLIGHT_COLOR,
-            underlineRange: undefined,
+            underlineRange,
             // Update information widget data whenever frame changes
             informationWidgetData: {
               html: infoWidgetHtml,

--- a/app/tests/unit/components/coding-exercise/orchestrator/store-frame-changes.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/store-frame-changes.test.ts
@@ -100,8 +100,8 @@ describe("Store Frame Changes", () => {
       state.setCurrentFrame(testFrame);
 
       const newState = store.getState();
-      // Runtime error frames highlight the line in red, but never underline a range
-      // (only syntax errors underline a specific location).
+      // Runtime error frames highlight the line in red. When the error carries no
+      // location (as with this bare mock frame) there is nothing to underline.
       expect(newState.highlightedLineColor).toBe(ERROR_HIGHLIGHT_COLOR);
       expect(newState.underlineRange).toBeUndefined();
       expect(newState.informationWidgetData).toEqual({
@@ -109,6 +109,55 @@ describe("Store Frame Changes", () => {
         line: 10,
         status: "ERROR"
       });
+    });
+
+    it("should underline the exact span an error frame points at", () => {
+      const exercise = createMockExercise({
+        slug: "test-uuid",
+        stubs: { javascript: "test code", python: "test code", jikiscript: "test code" }
+      });
+      const store = createOrchestratorStore(exercise, "javascript", { type: "lesson", slug: "test-lesson" });
+      const state = store.getState();
+
+      // Absolute offsets are 1-based in the interpreter; the underline is shifted to
+      // CodeMirror's 0-based positions (begin - 1, end - 1).
+      const errorFrame = createMockFrame(100000, {
+        line: 8,
+        status: "ERROR",
+        error: {
+          type: "ComparisonWithUndefinedFromFunction",
+          message: "You tried to compare the result of a function that didn't return anything.",
+          location: {
+            line: 8,
+            relative: { begin: 9, end: 33 },
+            absolute: { begin: 100, end: 124 }
+          }
+        }
+      } as any);
+
+      state.setShouldPlayOnTestChange(false);
+      state.setCurrentTest({
+        frames: [errorFrame],
+        slug: "test-1",
+        name: "Test 1",
+        status: "fail",
+        expects: [],
+        view: document.createElement("div"),
+        animationTimeline: {
+          play: jest.fn(),
+          onUpdate: jest.fn(),
+          onComplete: jest.fn(),
+          clearUpdateCallbacks: jest.fn(),
+          clearCompleteCallbacks: jest.fn(),
+          duration: 100000
+        }
+      } as any);
+
+      state.setCurrentFrame(errorFrame);
+
+      const newState = store.getState();
+      expect(newState.highlightedLineColor).toBe(ERROR_HIGHLIGHT_COLOR);
+      expect(newState.underlineRange).toEqual({ from: 99, to: 123 });
     });
 
     it("should update navigation frames after setting current frame", () => {

--- a/interpreters/src/javascript/executor.ts
+++ b/interpreters/src/javascript/executor.ts
@@ -119,6 +119,7 @@ export type RuntimeErrorType =
   | "IndexOutOfRange"
   | "StringIndexOutOfRange"
   | "ComparisonWithUndefined"
+  | "ComparisonWithUndefinedFromFunction"
   | "AssignmentToUndefined"
   | "AssignmentToUndefinedFromFunction"
   | "TypeError"

--- a/interpreters/src/javascript/executor/executeBinaryExpression.ts
+++ b/interpreters/src/javascript/executor/executeBinaryExpression.ts
@@ -1,5 +1,5 @@
 import type { Executor } from "../executor";
-import type { BinaryExpression } from "../expression";
+import { CallExpression, IdentifierExpression, MemberExpression, type BinaryExpression } from "../expression";
 import type { EvaluationResultBinaryExpression, EvaluationResultExpression } from "../evaluation-result";
 import { createJSObject, type JikiObject, JSDictionary, JSArray, type JSNumber } from "../jikiObjects";
 import { numberArithmetic, arithmeticWithCoercion } from "./arithmetic";
@@ -147,6 +147,14 @@ function handleBinaryOperation(
 // value) rather than something a student did on purpose. Every other operator
 // already rejects undefined; equality was the last gap that let it through
 // silently. Rejecting it here keeps JS in line with Python and JikiScript.
+//
+// The overwhelmingly common cause is comparing the result of a function (or
+// method) that doesn't return a value - a completely normal thing to try - so
+// that case gets its own, clearer message (mirroring the assignment guard). The
+// generic `ComparisonWithUndefined` is left as the last-resort catch for the
+// genuinely odd ways a student might conjure an undefined operand. The error is
+// anchored on the offending operand, not the whole comparison, so the highlight
+// lands on the value that wasn't set.
 function verifyNotUndefinedForComparison(
   executor: Executor,
   expression: BinaryExpression,
@@ -154,17 +162,46 @@ function verifyNotUndefinedForComparison(
   rightResult: EvaluationResultExpression
 ): void {
   if (leftResult.jikiObject.type === "undefined") {
-    executor.error("ComparisonWithUndefined", expression.location, {
-      operator: expression.operator.lexeme,
-      side: "left",
-    });
+    errorForUndefinedOperand(executor, expression, expression.left, "left");
   }
   if (rightResult.jikiObject.type === "undefined") {
-    executor.error("ComparisonWithUndefined", expression.location, {
-      operator: expression.operator.lexeme,
-      side: "right",
-    });
+    errorForUndefinedOperand(executor, expression, expression.right, "right");
   }
+}
+
+function errorForUndefinedOperand(
+  executor: Executor,
+  expression: BinaryExpression,
+  operand: BinaryExpression["left"],
+  side: "left" | "right"
+): never {
+  const context = { operator: expression.operator.lexeme, side };
+
+  // A call whose function name we can name gets the specific, helpful message.
+  // Anything else (an exotic callee, a bare undefined literal, ...) falls back to
+  // the generic catch-all.
+  if (operand instanceof CallExpression) {
+    const name = functionNameOf(operand);
+    if (name !== null) {
+      executor.error("ComparisonWithUndefinedFromFunction", operand.location, { ...context, name });
+    }
+  }
+
+  executor.error("ComparisonWithUndefined", operand.location, context);
+}
+
+// Best-effort name of the function being called, for the error message: plain
+// calls (`includes(...)`) and method calls (`text.includes(...)`). Returns null
+// for anything more exotic so the caller can fall back to the generic message.
+function functionNameOf(call: CallExpression): string | null {
+  const callee = call.callee;
+  if (callee instanceof IdentifierExpression) {
+    return callee.name.lexeme;
+  }
+  if (callee instanceof MemberExpression && callee.property instanceof IdentifierExpression) {
+    return callee.property.name.lexeme;
+  }
+  return null;
 }
 
 function verifyNumbersForComparison(

--- a/interpreters/src/javascript/locales/en/translation.json
+++ b/interpreters/src/javascript/locales/en/translation.json
@@ -91,6 +91,7 @@
       "IndexOutOfRange": "This array only has {{length}} elements, but you tried to access index {{index}}. Remember the first element is index 0 in JavaScript.",
       "StringIndexOutOfRange": "This string only has {{length}} characters, but you tried to access index {{index}}. Remember the first character is index 0 in JavaScript.",
       "ComparisonWithUndefined": "You tried to compare two values but one of which was not set to anything. You shouldn't be able to do this in Jiki, so please open an issue on the forum with your code so we can investigate.",
+      "ComparisonWithUndefinedFromFunction": "You tried to compare the result of a function that didn't return anything. Make sure the `{{name}}` function returns a value in all situations before you compare its result.",
       "AssignmentToUndefined": "You tried to store a value that isn't set to anything. A variable should always hold an actual value.",
       "AssignmentToUndefinedFromFunction": "You tried to store the result of a function that doesn't return anything. Make sure the function returns a value before you store its result.",
       "UpdateOperatorRequiresNumber": "Jiki can't use {{operator}} on a {{type}} - only on numbers.",

--- a/interpreters/src/javascript/locales/hu/translation.json
+++ b/interpreters/src/javascript/locales/hu/translation.json
@@ -91,6 +91,7 @@
       "IndexOutOfRange": "Ennek a tömbnek csak {{length}} eleme van, de te a(z) {{index}} indexet próbáltad elérni. Ne feledd: JavaScriptben az első elem indexe 0.",
       "StringIndexOutOfRange": "This string only has {{length}} characters, but you tried to access index {{index}}. Remember the first character is index 0 in JavaScript.",
       "ComparisonWithUndefined": "You tried to compare two values but one of which was not set to anything. You shouldn't be able to do this in Jiki, so please open an issue on the forum with your code so we can investigate.",
+      "ComparisonWithUndefinedFromFunction": "You tried to compare the result of a function that didn't return anything. Make sure the `{{name}}` function returns a value in all situations before you compare its result.",
       "AssignmentToUndefined": "You tried to store a value that isn't set to anything. A variable should always hold an actual value.",
       "AssignmentToUndefinedFromFunction": "You tried to store the result of a function that doesn't return anything. Make sure the function returns a value before you store its result.",
       "UpdateOperatorRequiresNumber": "Jiki a(z) {{operator}} operátort csak számokon tudja használni, {{type}} típuson nem.",

--- a/interpreters/src/javascript/locales/system/translation.json
+++ b/interpreters/src/javascript/locales/system/translation.json
@@ -91,6 +91,7 @@
       "IndexOutOfRange": "IndexOutOfRange: index: {{index}}: length: {{length}}",
       "StringIndexOutOfRange": "StringIndexOutOfRange: index: {{index}}: length: {{length}}",
       "ComparisonWithUndefined": "ComparisonWithUndefined: operator: {{operator}}: side: {{side}}",
+      "ComparisonWithUndefinedFromFunction": "ComparisonWithUndefinedFromFunction: operator: {{operator}}: side: {{side}}: function: {{name}}",
       "AssignmentToUndefined": "AssignmentToUndefined",
       "AssignmentToUndefinedFromFunction": "AssignmentToUndefinedFromFunction",
       "UpdateOperatorRequiresNumber": "UpdateOperatorRequiresNumber: operator: {{operator}}: type: {{type}}",

--- a/interpreters/tests/cross-validation/LIMITATIONS.md
+++ b/interpreters/tests/cross-validation/LIMITATIONS.md
@@ -56,7 +56,9 @@ unit tests in `tests/javascript/` instead of here:
   returning `undefined` (native returns `undefined`). Matches Python `IndexError`
   and JikiScript `IndexOutOfBounds`.
 - **Comparing with `undefined` errors.** `===`/`!==`/`==`/`!=` with an `undefined`
-  operand raise `ComparisonWithUndefined`.
+  operand raise `ComparisonWithUndefined`, or `ComparisonWithUndefinedFromFunction`
+  when that operand is a function/method call that returned nothing. The error is
+  anchored on the offending operand, not the whole comparison.
 - **Storing `undefined` errors.** Assigning `undefined` to a variable, element, or
   property raises `AssignmentToUndefined`. This covers a forgotten/void `return`,
   the explicit `undefined` literal, `x && undefined`, and any stdlib call that

--- a/interpreters/tests/javascript/interpreter/null-undefined.test.ts
+++ b/interpreters/tests/javascript/interpreter/null-undefined.test.ts
@@ -98,6 +98,42 @@ describe("JavaScript Interpreter: null and undefined", () => {
       expect(lastFrame.error?.type).toBe("ComparisonWithUndefined");
     });
 
+    // Comparing the result of a function that returns nothing is a completely
+    // normal mistake (unlike conjuring an `undefined` literal), so it gets its own
+    // clearer message rather than the generic "open an issue" catch-all.
+    test("comparing the result of a non-returning function errors with a specific message", () => {
+      const code = `function nothing() {}\nlet r = nothing() === 5;`;
+      const result = interpret(code);
+      expect(result.error).toBe(null);
+      expect(result.success).toBe(false);
+      const lastFrame = result.frames[result.frames.length - 1];
+      expect(lastFrame.status).toBe("ERROR");
+      expect(lastFrame.error?.type).toBe("ComparisonWithUndefinedFromFunction");
+    });
+
+    // The error carries the offending function's name so the message can point the
+    // student at the specific function to fix. Assert on the structured context
+    // (tests run in the "system" language, not English).
+    test("the specific error carries the function name as context", () => {
+      const code = `function nothing() {}\nlet r = nothing() === 5;`;
+      const result = interpret(code);
+      const lastFrame = result.frames[result.frames.length - 1];
+      expect(lastFrame.error?.type).toBe("ComparisonWithUndefinedFromFunction");
+      expect(lastFrame.error?.context?.name).toBe("nothing");
+    });
+
+    // The error must highlight the offending operand (the call), not the whole line.
+    test("the error is anchored on the undefined operand, not the full comparison", () => {
+      const code = `function nothing() {}\nlet r = nothing() === 5;`;
+      const result = interpret(code);
+      const lastFrame = result.frames[result.frames.length - 1];
+      const line2 = code.split("\n")[1];
+      const begin = line2.indexOf("nothing()") + 1;
+      expect(lastFrame.error?.location.line).toBe(2);
+      expect(lastFrame.error?.location.relative.begin).toBe(begin);
+      expect(lastFrame.error?.location.relative.end).toBe(begin + "nothing()".length);
+    });
+
     test("uninitialized variable with requireVariableInstantiation disabled", () => {
       const code = "let x;";
       const result = interpret(code, { languageFeatures: { requireVariableInstantiation: false } });


### PR DESCRIPTION
## Summary

Comparing the result of a function that returns nothing (e.g. `fn() === false` where `fn` forgets a `return`) is a completely normal student mistake. It previously hit the generic `ComparisonWithUndefined` catch-all ("open a forum issue"), which is meant only for genuinely odd ways of conjuring `undefined`. This gives that case its own clear, named message and makes the editor highlight the exact offending value.

## Interpreter (`@jiki/interpreters`)

- **New `ComparisonWithUndefinedFromFunction`** — fired when the `undefined` operand of a comparison is a call whose function can be named (plain calls `includes(...)` and method calls). The message names the function — *"Make sure the `includes` function returns a value in all situations before you compare its result."* — so the student knows which one to fix. The generic `ComparisonWithUndefined` stays as the last-resort catch for exotic cases.
- **Operand-anchored location** — both errors now point at the offending operand (`operand.location`) instead of the whole binary expression, so the highlight lands on the value that wasn't set.
- Follows the i18n rule: `en` + `system` keys, structured context (`name`) only; `hu` stubbed with English.

## App (`@jiki/app`)

- **`setCurrentFrame`** now derives `underlineRange` from the error frame's absolute location (1-based → 0-based) instead of hardcoding `undefined`, so runtime error frames underline the exact span — matching how syntax errors are surfaced (mirrors `TestSuiteManager`).
- **Dead CodeMirror selectors fixed** — `.ͼ1 …` (the generated theme class lives *on* `.cm-editor`, not a descendant) and `.cm-theme-light`/`.cm-theme-dark` wrappers (never applied) never matched the editor DOM. Underline and highlighted-line styling are now scoped correctly (top-level / `.cm-editor`), with `text-decoration-skip-ink: none` so the underline no longer breaks around descenders like `(` `)` `,`.

## Tests

- Interpreter: new error type + `name` context + operand-anchored location (system language).
- App: `underlineRange` derived from an error frame's location; corrected the stale test that asserted error frames never underline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7sZQwrd85MXqrnSiiGBuV