### PR TITLE
Add temporary pre-catalog Translatathon promo banner

### DIFF
--- a/app/app/(app)/layout.tsx
+++ b/app/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import { ClientAuthGuard } from "../../components/layout/auth/internal/ClientAuthGuard";
+import { TranslatathonBanner } from "@/components/i18n/TranslatathonBanner";
 import { CheckoutReturnHandler } from "@/components/checkout/CheckoutReturnHandler";
 import { WelcomeModalHandler } from "@/components/WelcomeModalHandler";
 import { AppModalRegistrar } from "@/lib/modal/AppModalRegistrar";
@@ -33,6 +34,7 @@ export default function AppLayout({
   return (
     <ClientAuthGuard>
       <AppModalRegistrar />
+      <TranslatathonBanner />
       {children}
       <CheckoutReturnHandler />
       <WelcomeModalHandler />

--- a/app/app/(hybrid)/[locale]/layout.tsx
+++ b/app/app/(hybrid)/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { isSupportedLocale } from "@/lib/i18n/config";
 import { alternatesFromRequest } from "@/lib/seo/alternates";
 import JsonLd from "@/components/seo/JsonLd";
+import { TranslatathonBanner } from "@/components/i18n/TranslatathonBanner";
 import { organizationSchema, websiteSchema } from "@/lib/seo/schemas";
 
 // Emit hreflang alternates + a self-referential canonical for every public page
@@ -34,6 +35,7 @@ export default async function LocaleLayout({
   return (
     <>
       <JsonLd data={[organizationSchema(), websiteSchema(locale)]} />
+      <TranslatathonBanner />
       {children}
     </>
   );

--- a/app/components/i18n/TranslatathonBanner.module.css
+++ b/app/components/i18n/TranslatathonBanner.module.css
@@ -1,0 +1,31 @@
+.banner {
+    position: relative;
+    color: var(--color-gray-700);
+    border-bottom: 1px solid var(--color-amber-300);
+    background: var(--color-amber-200);
+    font-size: 15px;
+    font-weight: 500;
+    padding: 8px 40px;
+    text-align: center;
+
+    a {
+        color: var(--color-blue-600);
+        font-weight: 600;
+        text-decoration: underline;
+        display: inline;
+    }
+}
+
+.close {
+    position: absolute;
+    top: 50%;
+    inset-inline-end: 12px;
+    transform: translateY(-50%);
+    border: none;
+    background: transparent;
+    color: var(--color-gray-700);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px;
+}

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useAuthStore } from "@/lib/auth/authStore";
+import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
+import { ALL_LOCALES } from "@/lib/locales";
+import Link from "next/link";
+import { useEffect, useLayoutEffect, useState } from "react";
+import styles from "./TranslatathonBanner.module.css";
+
+/**
+ * Temporary, pre-catalog promo banner for the Big Jiki & Exercism Translatathon.
+ *
+ * Deliberately NOT wired into next-intl: the whole point is to reach speakers of
+ * languages we do NOT yet ship in the catalog, so its copy can't come from the
+ * catalog. This is different from the catalog-driven LocaleBanner (which offers to
+ * switch to a language we already support) — see `components/i18n/LocaleBanner.tsx`.
+ *
+ * It targets the first non-English language in the viewer's own language list
+ * (`navigator.languages`, i.e. their browser's ordered preference list) that we
+ * don't already ship. Everyone in that bucket sees the banner:
+ * - English copy by default, with their language's name filled in;
+ * - or, once we have a hand-written translation for that language in COPY below,
+ *   the whole banner in that language.
+ *
+ * Rendering client-side is intentional: navigator.languages IS the "language
+ * list", and it keeps this out of the edge-cached SSR HTML (whose cache key can't
+ * distinguish which off-catalog language a viewer prefers).
+ *
+ * The whole banner is temporary and self-removes after the event (see END).
+ */
+
+interface TranslatathonCopy {
+  /** Sentence text before the linked call-to-action (may be empty). */
+  pre: string;
+  /** The linked call-to-action text (the "Join the Translatathon" part). */
+  link: string;
+  /** Sentence text after the linked call-to-action (may be empty). */
+  post: string;
+  /** Accessible label for the dismiss button, in this language. */
+  close: string;
+}
+
+/**
+ * Hand-written, fully-translated copy per base language code (lowercased, region
+ * stripped: "fr", "es", "pt", ...). Optional: a language absent here falls back to
+ * the English banner with its name filled in (see englishCopy). Add a language to
+ * upgrade its speakers from the English fallback to a native-language banner. Each
+ * string MUST be written in that language (including its own name for itself).
+ */
+const COPY: Partial<Record<string, TranslatathonCopy>> = {
+  // e.g.
+  // fr: {
+  //   pre: "Vous voulez nous aider à traduire Jiki en français ? ",
+  //   link: "Rejoignez le Translatathon",
+  //   post: "",
+  //   close: "Fermer"
+  // },
+};
+
+// The event weekend is 31 Jul – 2 Aug 2026; keep the banner up through 3 Aug.
+// After this instant the banner never renders. Remove the component entirely
+// once the event is well past.
+const END = new Date("2026-08-04T00:00:00Z");
+
+const DISMISS_KEY_PREFIX = "translatathon-banner-dismissed:";
+
+// useLayoutEffect on the client (decide before paint, no flash); useEffect on the
+// server (it can't run layout effects and would warn). Same pattern as LocaleBannerBar.
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export function TranslatathonBanner() {
+  const routes = useLocaleRoutes();
+  // Signed-in users only. We read the current auth state and don't wait for the
+  // auth check to settle: if we don't yet know they're authed, we simply show
+  // nothing (and re-render once the store flips). This lets the same component
+  // sit in the public/hybrid layout without ever showing to logged-out visitors.
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  // Both the server render and the first client render produce null (lang === null),
+  // so there is no hydration mismatch; the effect then reveals the banner if it applies.
+  const [lang, setLang] = useState<string | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    if (new Date() >= END) {
+      return;
+    }
+    const languages = typeof navigator !== "undefined" ? navigator.languages : [];
+    const picked = pickLanguage(languages);
+    if (picked && !isDismissed(picked)) {
+      setLang(picked);
+    }
+  }, []);
+
+  if (!isAuthenticated || !lang) {
+    return null;
+  }
+
+  const copy = COPY[lang] ?? englishCopy(lang);
+  if (!copy) {
+    return null;
+  }
+
+  return (
+    <div className={styles.banner} role="region" aria-label={copy.close}>
+      <span>{copy.pre}</span>
+      <Link href={routes.blogPost("translatathon")} target="_blank" rel="noopener noreferrer">
+        {copy.link}
+      </Link>
+      <span>{copy.post}</span>
+      <button
+        type="button"
+        onClick={() => {
+          dismiss(lang);
+          setLang(null);
+        }}
+        aria-label={copy.close}
+        className={styles.close}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+// Base languages we already ship in the catalog (e.g. "en", "hu"): their speakers
+// get the real catalog LocaleBanner offering an in-app switch, so there is nothing
+// to recruit and we never show them the Translatathon banner.
+const CATALOG_LANGUAGES = new Set(ALL_LOCALES.map((locale) => locale.split("-")[0].toLowerCase()));
+
+/**
+ * First language in the viewer's list that we don't already ship — the one we'd
+ * recruit them to help translate. Returns the base code (e.g. "fr"), or undefined
+ * when their whole list is English / catalog languages.
+ */
+function pickLanguage(languages: readonly string[]): string | undefined {
+  for (const tag of languages) {
+    const base = tag.split("-")[0]?.toLowerCase();
+    if (base && !CATALOG_LANGUAGES.has(base)) {
+      return base;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The English fallback banner for a language we have no hand-written copy for, with
+ * the language's English name filled in. Returns null when the code resolves to no
+ * real language name (so we never render "translate Jiki to xyz").
+ */
+function englishCopy(lang: string): TranslatathonCopy | null {
+  const name = languageName(lang);
+  if (!name) {
+    return null;
+  }
+  return {
+    pre: `Want to help us translate Jiki to ${name}? `,
+    link: "Join the Translatathon",
+    post: "",
+    close: "Close this notice"
+  };
+}
+
+/** The English display name for a base language code, or undefined if it isn't a real language. */
+function languageName(lang: string): string | undefined {
+  try {
+    const name = new Intl.DisplayNames(["en"], { type: "language" }).of(lang);
+    // DisplayNames echoes the input back for unknown codes; treat that as "no name".
+    return name && name.toLowerCase() !== lang.toLowerCase() ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isDismissed(lang: string): boolean {
+  try {
+    return window.localStorage.getItem(`${DISMISS_KEY_PREFIX}${lang}`) === "1";
+  } catch {
+    // Storage disabled (private mode etc.) — just show the banner.
+    return false;
+  }
+}
+
+function dismiss(lang: string): void {
+  try {
+    window.localStorage.setItem(`${DISMISS_KEY_PREFIX}${lang}`, "1");
+  } catch {
+    // Ignore storage failures; the banner still closes for this view.
+  }
+}

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useAuthStore } from "@/lib/auth/authStore";
-import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import { ALL_LOCALES } from "@/lib/locales";
 import Link from "next/link";
 import { useEffect, useLayoutEffect, useState } from "react";
@@ -34,7 +33,7 @@ import styles from "./TranslatathonBanner.module.css";
 interface TranslatathonCopy {
   /** Sentence text before the linked call-to-action (may be empty). */
   pre: string;
-  /** The linked call-to-action text (the "Join the Translatathon" part). */
+  /** The linked call-to-action text (the "Join the translation session" part). */
   link: string;
   /** Sentence text after the linked call-to-action (may be empty). */
   post: string;
@@ -42,174 +41,179 @@ interface TranslatathonCopy {
   close: string;
 }
 
+// Where the call-to-action goes (opens in a new tab).
+const TRANSLATATHON_URL = "https://i18n.jiki.io";
+
 /**
  * Fully-translated copy for each language in the Translatathon program, keyed by
  * the program's own locale ids (matching ../../translator/languages/names.json,
  * minus `hu` which we already ship). Multi-variant languages have one entry per
  * variant (es-419/es-ES, pt-BR/pt-pt, zh-CN/zh-TW); resolveTarget maps a browser
  * tag to the right one. Each string is written in that language, with the
- * language's own name for itself; "Jiki" and "Translatathon" stay as proper nouns.
+ * language's own name for itself and a translated phrase for the translation
+ * session (we don't leave "Translatathon" untranslated); only "Jiki" stays as a
+ * proper noun.
  */
 const COPY: Record<string, TranslatathonCopy> = {
   ar: {
     pre: "هل تريد مساعدتنا في ترجمة Jiki إلى العربية؟ ",
-    link: "انضمّ إلى Translatathon",
+    link: "انضمّ إلى جلسة الترجمة",
     post: "",
     close: "إغلاق"
   },
   bn: {
     pre: "Jiki-কে বাংলায় অনুবাদ করতে আমাদের সাহায্য করতে চান? ",
-    link: "Translatathon-এ যোগ দিন",
+    link: "অনুবাদ সেশনে যোগ দিন",
     post: "",
     close: "বন্ধ করুন"
   },
   ca: {
     pre: "Vols ajudar-nos a traduir Jiki al català? ",
-    link: "Uneix-te al Translatathon",
+    link: "Uneix-te a la sessió de traducció",
     post: "",
     close: "Tanca"
   },
   de: {
     pre: "Möchtest du uns helfen, Jiki ins Deutsche zu übersetzen? ",
-    link: "Mach beim Translatathon mit",
+    link: "Mach bei der Übersetzungssession mit",
     post: "",
     close: "Schließen"
   },
   el: {
     pre: "Θέλεις να μας βοηθήσεις να μεταφράσουμε το Jiki στα Ελληνικά; ",
-    link: "Λάβε μέρος στο Translatathon",
+    link: "Λάβε μέρος στη μεταφραστική συνεδρία",
     post: "",
     close: "Κλείσιμο"
   },
   "es-419": {
     pre: "¿Quieres ayudarnos a traducir Jiki al español? ",
-    link: "Únete al Translatathon",
+    link: "Únete a la sesión de traducción",
     post: "",
     close: "Cerrar"
   },
   "es-ES": {
     pre: "¿Quieres ayudarnos a traducir Jiki al español? ",
-    link: "Únete al Translatathon",
+    link: "Únete a la sesión de traducción",
     post: "",
     close: "Cerrar"
   },
   fa: {
     pre: "می‌خواهید در ترجمهٔ Jiki به فارسی به ما کمک کنید؟ ",
-    link: "به Translatathon بپیوندید",
+    link: "به نشست ترجمه بپیوندید",
     post: "",
     close: "بستن"
   },
   fr: {
     pre: "Vous voulez nous aider à traduire Jiki en français ? ",
-    link: "Rejoignez le Translatathon",
+    link: "Rejoignez la session de traduction",
     post: "",
     close: "Fermer"
   },
   hi: {
     pre: "क्या आप Jiki का हिन्दी में अनुवाद करने में हमारी मदद करना चाहते हैं? ",
-    link: "Translatathon में शामिल हों",
+    link: "अनुवाद सत्र में शामिल हों",
     post: "",
     close: "बंद करें"
   },
   id: {
     pre: "Ingin membantu kami menerjemahkan Jiki ke Bahasa Indonesia? ",
-    link: "Ikuti Translatathon",
+    link: "Ikuti sesi terjemahan",
     post: "",
     close: "Tutup"
   },
   it: {
     pre: "Vuoi aiutarci a tradurre Jiki in italiano? ",
-    link: "Partecipa al Translatathon",
+    link: "Partecipa alla sessione di traduzione",
     post: "",
     close: "Chiudi"
   },
   ja: {
     pre: "Jiki を日本語に翻訳するのを手伝いませんか？",
-    link: "Translatathon に参加する",
+    link: "翻訳セッションに参加する",
     post: "",
     close: "閉じる"
   },
   ko: {
     pre: "Jiki를 한국어로 번역하는 데 도움을 주시겠어요? ",
-    link: "Translatathon에 참여하세요",
+    link: "번역 세션에 참여하세요",
     post: "",
     close: "닫기"
   },
   nl: {
     pre: "Wil je ons helpen Jiki naar het Nederlands te vertalen? ",
-    link: "Doe mee aan de Translatathon",
+    link: "Doe mee aan de vertaalsessie",
     post: "",
     close: "Sluiten"
   },
   pl: {
     pre: "Chcesz pomóc nam przetłumaczyć Jiki na polski? ",
-    link: "Dołącz do Translatathonu",
+    link: "Dołącz do sesji tłumaczeniowej",
     post: "",
     close: "Zamknij"
   },
   "pt-BR": {
     pre: "Quer nos ajudar a traduzir o Jiki para o português? ",
-    link: "Participe do Translatathon",
+    link: "Participe da sessão de tradução",
     post: "",
     close: "Fechar"
   },
   "pt-pt": {
     pre: "Quer ajudar-nos a traduzir o Jiki para português? ",
-    link: "Junte-se ao Translatathon",
+    link: "Junte-se à sessão de tradução",
     post: "",
     close: "Fechar"
   },
   ru: {
     pre: "Хотите помочь нам перевести Jiki на русский? ",
-    link: "Присоединяйтесь к Translatathon",
+    link: "Присоединяйтесь к сессии перевода",
     post: "",
     close: "Закрыть"
   },
   sr: {
     pre: "Желите да нам помогнете да преведемо Jiki на српски? ",
-    link: "Придружите се Translatathon-у",
+    link: "Придружите се преводилачкој сесији",
     post: "",
     close: "Затвори"
   },
   sw: {
     pre: "Ungependa kutusaidia kutafsiri Jiki kwa Kiswahili? ",
-    link: "Jiunge na Translatathon",
+    link: "Jiunge na kikao cha tafsiri",
     post: "",
     close: "Funga"
   },
   tr: {
     pre: "Jiki'yi Türkçeye çevirmemize yardım etmek ister misin? ",
-    link: "Translatathon'a katıl",
+    link: "Çeviri oturumuna katıl",
     post: "",
     close: "Kapat"
   },
   uk: {
     pre: "Хочете допомогти нам перекласти Jiki українською? ",
-    link: "Долучайтеся до Translatathon",
+    link: "Долучайтеся до сесії перекладу",
     post: "",
     close: "Закрити"
   },
   ur: {
     pre: "کیا آپ Jiki کا اردو میں ترجمہ کرنے میں ہماری مدد کرنا چاہتے ہیں؟ ",
-    link: "Translatathon میں شامل ہوں",
+    link: "ترجمے کے سیشن میں شامل ہوں",
     post: "",
     close: "بند کریں"
   },
   vi: {
     pre: "Bạn muốn giúp chúng tôi dịch Jiki sang Tiếng Việt? ",
-    link: "Tham gia Translatathon",
+    link: "Tham gia buổi dịch thuật",
     post: "",
     close: "Đóng"
   },
   "zh-CN": {
     pre: "想帮我们把 Jiki 翻译成中文吗？",
-    link: "加入 Translatathon",
+    link: "加入翻译活动",
     post: "",
     close: "关闭"
   },
   "zh-TW": {
     pre: "想幫我們把 Jiki 翻譯成中文嗎？",
-    link: "加入 Translatathon",
+    link: "加入翻譯活動",
     post: "",
     close: "關閉"
   }
@@ -237,7 +241,6 @@ interface Target {
 const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export function TranslatathonBanner() {
-  const routes = useLocaleRoutes();
   // Signed-in users only. We read the current auth state and don't wait for the
   // auth check to settle: if we don't yet know they're authed, we simply show
   // nothing (and re-render once the store flips). This lets the same component
@@ -267,7 +270,7 @@ export function TranslatathonBanner() {
   return (
     <div className={styles.banner} dir={dir}>
       <span>{copy.pre}</span>
-      <Link href={routes.blogPost("translatathon")} target="_blank" rel="noopener noreferrer">
+      <Link href={TRANSLATATHON_URL} target="_blank" rel="noopener noreferrer">
         {copy.link}
       </Link>
       <span>{copy.post}</span>
@@ -353,7 +356,7 @@ function englishCopy(lang: string): TranslatathonCopy | null {
   }
   return {
     pre: `Want to help us translate Jiki to ${name}? `,
-    link: "Join the Translatathon",
+    link: "Join the translation session",
     post: "",
     close: "Close this notice"
   };

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -356,7 +356,7 @@ function englishCopy(lang: string): TranslatathonCopy | null {
   }
   return {
     pre: `Want to help us translate Jiki to ${name}? `,
-    link: "Join the translation session",
+    link: "Join the Translatathon",
     post: "",
     close: "Close this notice"
   };

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -15,18 +15,20 @@ import styles from "./TranslatathonBanner.module.css";
  * catalog. This is different from the catalog-driven LocaleBanner (which offers to
  * switch to a language we already support) — see `components/i18n/LocaleBanner.tsx`.
  *
- * It targets the first non-English language in the viewer's own language list
- * (`navigator.languages`, i.e. their browser's ordered preference list) that we
- * don't already ship. Everyone in that bucket sees the banner:
- * - English copy by default, with their language's name filled in;
- * - or, once we have a hand-written translation for that language in COPY below,
- *   the whole banner in that language.
+ * It targets the first non-catalog language in the viewer's own language list
+ * (`navigator.languages`, i.e. their browser's ordered preference list), shown to
+ * signed-in users only:
+ * - a language we run in the Translatathon program (COPY below) gets the whole
+ *   banner IN that language;
+ * - any other non-English language gets the English banner with its name filled in.
  *
  * Rendering client-side is intentional: navigator.languages IS the "language
- * list", and it keeps this out of the edge-cached SSR HTML (whose cache key can't
- * distinguish which off-catalog language a viewer prefers).
+ * list", and it keeps this out of the edge-cached SSR HTML.
  *
  * The whole banner is temporary and self-removes after the event (see END).
+ *
+ * NOTE: the translated strings below were drafted for the event and should be
+ * sanity-checked by native speakers / the Translatathon translators.
  */
 
 interface TranslatathonCopy {
@@ -41,21 +43,180 @@ interface TranslatathonCopy {
 }
 
 /**
- * Hand-written, fully-translated copy per base language code (lowercased, region
- * stripped: "fr", "es", "pt", ...). Optional: a language absent here falls back to
- * the English banner with its name filled in (see englishCopy). Add a language to
- * upgrade its speakers from the English fallback to a native-language banner. Each
- * string MUST be written in that language (including its own name for itself).
+ * Fully-translated copy for each language in the Translatathon program, keyed by
+ * the program's own locale ids (matching ../../translator/languages/names.json,
+ * minus `hu` which we already ship). Multi-variant languages have one entry per
+ * variant (es-419/es-ES, pt-BR/pt-pt, zh-CN/zh-TW); resolveTarget maps a browser
+ * tag to the right one. Each string is written in that language, with the
+ * language's own name for itself; "Jiki" and "Translatathon" stay as proper nouns.
  */
-const COPY: Partial<Record<string, TranslatathonCopy>> = {
-  // e.g.
-  // fr: {
-  //   pre: "Vous voulez nous aider à traduire Jiki en français ? ",
-  //   link: "Rejoignez le Translatathon",
-  //   post: "",
-  //   close: "Fermer"
-  // },
+const COPY: Record<string, TranslatathonCopy> = {
+  ar: {
+    pre: "هل تريد مساعدتنا في ترجمة Jiki إلى العربية؟ ",
+    link: "انضمّ إلى Translatathon",
+    post: "",
+    close: "إغلاق"
+  },
+  bn: {
+    pre: "Jiki-কে বাংলায় অনুবাদ করতে আমাদের সাহায্য করতে চান? ",
+    link: "Translatathon-এ যোগ দিন",
+    post: "",
+    close: "বন্ধ করুন"
+  },
+  ca: {
+    pre: "Vols ajudar-nos a traduir Jiki al català? ",
+    link: "Uneix-te al Translatathon",
+    post: "",
+    close: "Tanca"
+  },
+  de: {
+    pre: "Möchtest du uns helfen, Jiki ins Deutsche zu übersetzen? ",
+    link: "Mach beim Translatathon mit",
+    post: "",
+    close: "Schließen"
+  },
+  el: {
+    pre: "Θέλεις να μας βοηθήσεις να μεταφράσουμε το Jiki στα Ελληνικά; ",
+    link: "Λάβε μέρος στο Translatathon",
+    post: "",
+    close: "Κλείσιμο"
+  },
+  "es-419": {
+    pre: "¿Quieres ayudarnos a traducir Jiki al español? ",
+    link: "Únete al Translatathon",
+    post: "",
+    close: "Cerrar"
+  },
+  "es-ES": {
+    pre: "¿Quieres ayudarnos a traducir Jiki al español? ",
+    link: "Únete al Translatathon",
+    post: "",
+    close: "Cerrar"
+  },
+  fa: {
+    pre: "می‌خواهید در ترجمهٔ Jiki به فارسی به ما کمک کنید؟ ",
+    link: "به Translatathon بپیوندید",
+    post: "",
+    close: "بستن"
+  },
+  fr: {
+    pre: "Vous voulez nous aider à traduire Jiki en français ? ",
+    link: "Rejoignez le Translatathon",
+    post: "",
+    close: "Fermer"
+  },
+  hi: {
+    pre: "क्या आप Jiki का हिन्दी में अनुवाद करने में हमारी मदद करना चाहते हैं? ",
+    link: "Translatathon में शामिल हों",
+    post: "",
+    close: "बंद करें"
+  },
+  id: {
+    pre: "Ingin membantu kami menerjemahkan Jiki ke Bahasa Indonesia? ",
+    link: "Ikuti Translatathon",
+    post: "",
+    close: "Tutup"
+  },
+  it: {
+    pre: "Vuoi aiutarci a tradurre Jiki in italiano? ",
+    link: "Partecipa al Translatathon",
+    post: "",
+    close: "Chiudi"
+  },
+  ja: {
+    pre: "Jiki を日本語に翻訳するのを手伝いませんか？",
+    link: "Translatathon に参加する",
+    post: "",
+    close: "閉じる"
+  },
+  ko: {
+    pre: "Jiki를 한국어로 번역하는 데 도움을 주시겠어요? ",
+    link: "Translatathon에 참여하세요",
+    post: "",
+    close: "닫기"
+  },
+  nl: {
+    pre: "Wil je ons helpen Jiki naar het Nederlands te vertalen? ",
+    link: "Doe mee aan de Translatathon",
+    post: "",
+    close: "Sluiten"
+  },
+  pl: {
+    pre: "Chcesz pomóc nam przetłumaczyć Jiki na polski? ",
+    link: "Dołącz do Translatathonu",
+    post: "",
+    close: "Zamknij"
+  },
+  "pt-BR": {
+    pre: "Quer nos ajudar a traduzir o Jiki para o português? ",
+    link: "Participe do Translatathon",
+    post: "",
+    close: "Fechar"
+  },
+  "pt-pt": {
+    pre: "Quer ajudar-nos a traduzir o Jiki para português? ",
+    link: "Junte-se ao Translatathon",
+    post: "",
+    close: "Fechar"
+  },
+  ru: {
+    pre: "Хотите помочь нам перевести Jiki на русский? ",
+    link: "Присоединяйтесь к Translatathon",
+    post: "",
+    close: "Закрыть"
+  },
+  sr: {
+    pre: "Желите да нам помогнете да преведемо Jiki на српски? ",
+    link: "Придружите се Translatathon-у",
+    post: "",
+    close: "Затвори"
+  },
+  sw: {
+    pre: "Ungependa kutusaidia kutafsiri Jiki kwa Kiswahili? ",
+    link: "Jiunge na Translatathon",
+    post: "",
+    close: "Funga"
+  },
+  tr: {
+    pre: "Jiki'yi Türkçeye çevirmemize yardım etmek ister misin? ",
+    link: "Translatathon'a katıl",
+    post: "",
+    close: "Kapat"
+  },
+  uk: {
+    pre: "Хочете допомогти нам перекласти Jiki українською? ",
+    link: "Долучайтеся до Translatathon",
+    post: "",
+    close: "Закрити"
+  },
+  ur: {
+    pre: "کیا آپ Jiki کا اردو میں ترجمہ کرنے میں ہماری مدد کرنا چاہتے ہیں؟ ",
+    link: "Translatathon میں شامل ہوں",
+    post: "",
+    close: "بند کریں"
+  },
+  vi: {
+    pre: "Bạn muốn giúp chúng tôi dịch Jiki sang Tiếng Việt? ",
+    link: "Tham gia Translatathon",
+    post: "",
+    close: "Đóng"
+  },
+  "zh-CN": {
+    pre: "想帮我们把 Jiki 翻译成中文吗？",
+    link: "加入 Translatathon",
+    post: "",
+    close: "关闭"
+  },
+  "zh-TW": {
+    pre: "想幫我們把 Jiki 翻譯成中文嗎？",
+    link: "加入 Translatathon",
+    post: "",
+    close: "關閉"
+  }
 };
+
+// Program languages that read right-to-left; the banner element gets dir="rtl".
+const RTL_TARGETS = new Set(["ar", "fa", "ur"]);
 
 // The event weekend is 31 Jul – 2 Aug 2026; keep the banner up through 3 Aug.
 // After this instant the banner never renders. Remove the component entirely
@@ -63,6 +224,13 @@ const COPY: Partial<Record<string, TranslatathonCopy>> = {
 const END = new Date("2026-08-04T00:00:00Z");
 
 const DISMISS_KEY_PREFIX = "translatathon-banner-dismissed:";
+
+interface Target {
+  copy: TranslatathonCopy;
+  dir: "ltr" | "rtl";
+  /** Identity the dismissal is remembered under (program locale id, or base language). */
+  dismissId: string;
+}
 
 // useLayoutEffect on the client (decide before paint, no flash); useEffect on the
 // server (it can't run layout effects and would warn). Same pattern as LocaleBannerBar.
@@ -75,32 +243,29 @@ export function TranslatathonBanner() {
   // nothing (and re-render once the store flips). This lets the same component
   // sit in the public/hybrid layout without ever showing to logged-out visitors.
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  // Both the server render and the first client render produce null (lang === null),
+  // Both the server render and the first client render produce null (target === null),
   // so there is no hydration mismatch; the effect then reveals the banner if it applies.
-  const [lang, setLang] = useState<string | null>(null);
+  const [target, setTarget] = useState<Target | null>(null);
 
   useIsomorphicLayoutEffect(() => {
     if (new Date() >= END) {
       return;
     }
     const languages = typeof navigator !== "undefined" ? navigator.languages : [];
-    const picked = pickLanguage(languages);
-    if (picked && !isDismissed(picked)) {
-      setLang(picked);
+    const resolved = resolveTarget(languages);
+    if (resolved && !isDismissed(resolved.dismissId)) {
+      setTarget(resolved);
     }
   }, []);
 
-  if (!isAuthenticated || !lang) {
+  if (!isAuthenticated || !target) {
     return null;
   }
 
-  const copy = COPY[lang] ?? englishCopy(lang);
-  if (!copy) {
-    return null;
-  }
+  const { copy, dir } = target;
 
   return (
-    <div className={styles.banner} role="region" aria-label={copy.close}>
+    <div className={styles.banner} dir={dir}>
       <span>{copy.pre}</span>
       <Link href={routes.blogPost("translatathon")} target="_blank" rel="noopener noreferrer">
         {copy.link}
@@ -109,8 +274,8 @@ export function TranslatathonBanner() {
       <button
         type="button"
         onClick={() => {
-          dismiss(lang);
-          setLang(null);
+          dismiss(target.dismissId);
+          setTarget(null);
         }}
         aria-label={copy.close}
         className={styles.close}
@@ -127,24 +292,59 @@ export function TranslatathonBanner() {
 const CATALOG_LANGUAGES = new Set(ALL_LOCALES.map((locale) => locale.split("-")[0].toLowerCase()));
 
 /**
- * First language in the viewer's list that we don't already ship — the one we'd
- * recruit them to help translate. Returns the base code (e.g. "fr"), or undefined
- * when their whole list is English / catalog languages.
+ * Resolve the viewer's language list to the banner we should show. Walks the list
+ * in order, takes the first language we don't already ship, and returns either its
+ * in-program translated banner or the English fallback with its name filled in.
  */
-function pickLanguage(languages: readonly string[]): string | undefined {
+function resolveTarget(languages: readonly string[]): Target | null {
   for (const tag of languages) {
     const base = tag.split("-")[0]?.toLowerCase();
-    if (base && !CATALOG_LANGUAGES.has(base)) {
-      return base;
+    if (!base || CATALOG_LANGUAGES.has(base)) {
+      continue;
     }
+    const key = programLocale(tag, base);
+    if (key) {
+      return { copy: COPY[key], dir: RTL_TARGETS.has(base) ? "rtl" : "ltr", dismissId: key };
+    }
+    const english = englishCopy(base);
+    return english ? { copy: english, dir: "ltr", dismissId: base } : null;
   }
-  return undefined;
+  return null;
 }
 
 /**
- * The English fallback banner for a language we have no hand-written copy for, with
- * the language's English name filled in. Returns null when the code resolves to no
- * real language name (so we never render "translate Jiki to xyz").
+ * Map a browser language tag to the program locale id whose copy we show, or
+ * undefined if the language isn't in the program. Multi-variant languages collapse
+ * by region/script (mirrors the API's variant handling); every other program
+ * language is keyed by its bare base code.
+ */
+function programLocale(tag: string, base: string): string | undefined {
+  if (base === "es") {
+    return region(tag) === "ES" ? "es-ES" : "es-419";
+  }
+  if (base === "pt") {
+    return region(tag) === "PT" ? "pt-pt" : "pt-BR";
+  }
+  if (base === "zh") {
+    const r = region(tag);
+    return /hant/i.test(tag) || r === "TW" || r === "HK" || r === "MO" ? "zh-TW" : "zh-CN";
+  }
+  return base in COPY ? base : undefined;
+}
+
+/** The region subtag (first 2-alpha or 3-digit subtag), uppercased, or undefined. */
+function region(tag: string): string | undefined {
+  return tag
+    .split("-")
+    .slice(1)
+    .find((part) => /^([A-Za-z]{2}|\d{3})$/.test(part))
+    ?.toUpperCase();
+}
+
+/**
+ * The English fallback banner for a non-program language, with the language's
+ * English name filled in. Returns null when the code resolves to no real language
+ * name (so we never render "translate Jiki to xyz").
  */
 function englishCopy(lang: string): TranslatathonCopy | null {
   const name = languageName(lang);
@@ -170,18 +370,18 @@ function languageName(lang: string): string | undefined {
   }
 }
 
-function isDismissed(lang: string): boolean {
+function isDismissed(id: string): boolean {
   try {
-    return window.localStorage.getItem(`${DISMISS_KEY_PREFIX}${lang}`) === "1";
+    return window.localStorage.getItem(`${DISMISS_KEY_PREFIX}${id}`) === "1";
   } catch {
     // Storage disabled (private mode etc.) — just show the banner.
     return false;
   }
 }
 
-function dismiss(lang: string): void {
+function dismiss(id: string): void {
   try {
-    window.localStorage.setItem(`${DISMISS_KEY_PREFIX}${lang}`, "1");
+    window.localStorage.setItem(`${DISMISS_KEY_PREFIX}${id}`, "1");
   } catch {
     // Ignore storage failures; the banner still closes for this view.
   }

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -3,6 +3,7 @@
 import { useAuthStore } from "@/lib/auth/authStore";
 import { ALL_LOCALES } from "@/lib/locales";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useLayoutEffect, useState } from "react";
 import styles from "./TranslatathonBanner.module.css";
 
@@ -246,6 +247,10 @@ export function TranslatathonBanner() {
   // nothing (and re-render once the store flips). This lets the same component
   // sit in the public/hybrid layout without ever showing to logged-out visitors.
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  // The full-screen coding-exercise views (lesson/challenge) are hard-sized to
+  // 100vh, so an in-flow banner above them scrolls the whole page. Suppress the
+  // banner there; it still shows on every other app page (dashboard, lists, …).
+  const pathname = usePathname();
   // Both the server render and the first client render produce null (target === null),
   // so there is no hydration mismatch; the effect then reveals the banner if it applies.
   const [target, setTarget] = useState<Target | null>(null);
@@ -261,7 +266,7 @@ export function TranslatathonBanner() {
     }
   }, []);
 
-  if (!isAuthenticated || !target) {
+  if (!isAuthenticated || !target || isFullScreenExercisePath(pathname)) {
     return null;
   }
 
@@ -287,6 +292,16 @@ export function TranslatathonBanner() {
       </button>
     </div>
   );
+}
+
+// The full-screen exercise routes: /lesson/<slug> and /challenges/<slug> (an
+// optional leading locale segment is tolerated). The bare /challenges list is
+// NOT matched — it needs a slug — so the banner still shows there.
+function isFullScreenExercisePath(pathname: string | null): boolean {
+  if (!pathname) {
+    return false;
+  }
+  return /^(?:\/[a-z]{2}(?:-[a-z]+)?)?\/(?:lesson|challenges)\/[^/]+/i.test(pathname);
 }
 
 // Base languages we already ship in the catalog (e.g. "en", "hu"): their speakers


### PR DESCRIPTION
## What

A standalone, dismissible banner recruiting translators for the **Big Jiki & Exercism Translatathon**.

Unlike the catalog-driven `LocaleBanner` (which offers to switch to a language we already ship), this is deliberately **not** wired into next-intl — its whole purpose is to reach speakers of languages we don't yet ship, so the copy lives in the component itself.

## How it works

- Targets the **first non-catalog language** in the viewer's `navigator.languages` (their own browser language list).
- **Signed-in users only**: the component reads `isAuthenticated` from `useAuthStore` and returns `null` otherwise (no waiting on the auth check to settle), so it can safely sit in the public/hybrid layout without ever showing to logged-out visitors.
- **English copy by default**, with the language's name filled in via `Intl.DisplayNames` (e.g. "Want to help us translate Jiki to French?"). An optional per-language `COPY` map can override with a fully-translated banner as strings become available — empty for now.
- Renders **client-side** (navigator.languages is client-only), which also keeps it out of the edge-cached SSR HTML.
- **Dismissible per-language** via `localStorage` (`translatathon-banner-dismissed:<lang>`).
- **Self-removes after the event** (hardcoded `END` = 2026-08-04).
- The "Join the Translatathon" link points at the existing `/blog/translatathon` post and opens in a new tab.

## Mounting

Mounted deliberately in two places (not the root layout):
- `app/(app)/layout.tsx` — authenticated app pages
- `app/(hybrid)/[locale]/layout.tsx` — public/hybrid pages (blog, help, …)

## Notes

- Temporary by design — the whole component can be deleted after the event.
- `hu`/`en` speakers see nothing (hu is in the catalog, so its speakers get the real switch-banner instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)