### PR TITLE
Make the coding-exercise LHS bottom panel reach a 300px minimum

### DIFF
--- a/app/components/coding-exercise/CodingExercise.module.css
+++ b/app/components/coding-exercise/CodingExercise.module.css
@@ -3,6 +3,10 @@
     grid-template-columns: 1fr 1fr;
     grid-template-rows: min(342px, 50vh) 1fr;
     flex: 1;
+    /* Constrain to the flex allocation (100vh) so a large editor row + the
+       bottom panel's 300px min-height can't grow this past the viewport and
+       scroll the page. Pairs with overflow: hidden to clip the grid. */
+    min-height: 0;
     background: var(--color-gray-50);
     overflow: hidden;
     position: relative;
@@ -203,7 +207,7 @@
     flex-direction: column;
     border-radius: 8px 8px 0 8px;
     border: 1px solid var(--color-gray-200);
-    min-height: 200px;
+    min-height: 300px;
     margin: 4px 4px 8px 8px;
 }
 

--- a/app/components/coding-exercise/useResize.tsx
+++ b/app/components/coding-exercise/useResize.tsx
@@ -6,6 +6,10 @@ type Direction = "horizontal" | "vertical";
 
 const STORAGE_KEY = "coding-exercise-panel-sizes";
 const LHS_MIN_PIXELS = 400;
+// Minimum height of the bottom (test results) panel in the LHS top/bottom split.
+// The top editor row is allowed to grow up to `containerHeight - BOTTOM_MIN_PIXELS`,
+// which makes this the smallest the bottom panel can actually be dragged to.
+const BOTTOM_MIN_PIXELS = 300;
 
 function clampVerticalPercentage(percentage: number, containerWidth: number) {
   const minPercentage = Math.min(70, Math.max(30, (LHS_MIN_PIXELS / containerWidth) * 100));
@@ -101,14 +105,15 @@ export function useResizablePanels() {
     applyVertical(container, verticalDividerRef.current, verticalPercentage);
 
     if (typeof stored.horizontalPixels === "number") {
-      const maxHorizontalPixels = container.getBoundingClientRect().height - 200;
-      if (maxHorizontalPixels >= 200) {
-        const clamped = Math.min(Math.max(stored.horizontalPixels, 200), maxHorizontalPixels);
-        // The 50vh cap keeps the editor row from forcing the grid taller than
-        // the viewport if the window shrinks after the size was stored.
-        container.style.gridTemplateRows = `min(${clamped}px, 50vh) 1fr`;
+      // Clamp to the live container so the editor row can never force the grid
+      // taller than the viewport, and the bottom panel keeps its 300px minimum
+      // even if the window shrank after the size was stored.
+      const maxHorizontalPixels = container.getBoundingClientRect().height - BOTTOM_MIN_PIXELS;
+      if (maxHorizontalPixels >= BOTTOM_MIN_PIXELS) {
+        const clamped = Math.min(Math.max(stored.horizontalPixels, BOTTOM_MIN_PIXELS), maxHorizontalPixels);
+        container.style.gridTemplateRows = `${clamped}px 1fr`;
         if (horizontalDividerRef.current) {
-          horizontalDividerRef.current.style.top = `min(${clamped}px, 50vh)`;
+          horizontalDividerRef.current.style.top = `${clamped}px`;
         }
       }
     }
@@ -199,10 +204,10 @@ export function useResizablePanels() {
       const offsetY = moveEvent.clientY - containerRect.top;
       const pixelPosition = offsetY;
 
-      if (pixelPosition >= 200 && pixelPosition <= containerRect.height - 200) {
+      if (pixelPosition >= BOTTOM_MIN_PIXELS && pixelPosition <= containerRect.height - BOTTOM_MIN_PIXELS) {
         latestPixels = pixelPosition;
-        horizontalDivider.style.top = `min(${pixelPosition}px, 50vh)`;
-        container.style.gridTemplateRows = `min(${pixelPosition}px, 50vh) 1fr`;
+        horizontalDivider.style.top = `${pixelPosition}px`;
+        container.style.gridTemplateRows = `${pixelPosition}px 1fr`;
       }
     };
 


### PR DESCRIPTION
## What

The LHS of the coding editor has a top (code editor) / bottom (test results) split. Previously the bottom panel could never be dragged below ~50% of the container, regardless of the intended 200px minimum.

## Why

The drag logic capped the top editor row at `min(pixelPosition, 50vh)`, so the top could never exceed 50vh and the bottom was pinned at `containerHeight - 50vh` (≈50%). The 200px clamp on the bottom was effectively dead.

## Changes

- **`useResize.tsx`**: introduce `BOTTOM_MIN_PIXELS = 300`. The top row now grows up to `containerHeight - 300` (dropping the `50vh` cap) on both live drag and mount-restore, so a 300px bottom is actually reachable. Restore clamps to the live container height, which also handles the window-shrink case the `50vh` was guarding against.
- **`CodingExercise.module.css`**: bump `.testResultsArea` `min-height` 200px → 300px, and add `min-height: 0` to `.exerciseContainer` so the taller editor row + 300px bottom can't overflow the `flex: 1` parent and scroll the page.

## Testing

- `pnpm typecheck` passes; pre-commit test suite (2134 tests) passes.
- Manually verified in-browser: the divider now drags the bottom panel down to 300px, and the page no longer vertically scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)