### PR TITLE
Rename Functions panel to Functions & Methods

### DIFF
--- a/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/informationTooltip.module.css
+++ b/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/informationTooltip.module.css
@@ -80,6 +80,7 @@
 .error :not(pre) > code {
     background-color: var(--color-red-50);
     color: var(--color-red-600);
+    font-size: 15px;
 }
 
 .informationTooltip pre + p {

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1484,9 +1484,9 @@
     },
     "instructionsPanel": {
       "instructionsTitle": "Instructions",
-      "functionsTitle": "Functions",
+      "functionsTitle": "Functions & Methods",
       "conceptLibraryTitle": "Concept Library",
-      "functionsIntro": "These are the functions you can use in this exercise",
+      "functionsIntro": "These are the functions and methods you can use in this exercise.",
       "functionsExamplesLabel": "Examples:",
       "loadingConcepts": "Loading concepts...",
       "premiumChallenge": "Premium Challenge",


### PR DESCRIPTION
## What

Small copy + styling tweaks to the coding-exercise instructions panel that were sitting in the working tree.

## Changes

- **`messages/en.json`**: `instructionsPanel.functionsTitle` "Functions" → "Functions & Methods", and `functionsIntro` updated to "These are the functions and methods you can use in this exercise."
- **`informationTooltip.module.css`**: add `font-size: 15px` to error `code` in the end-of-line information tooltip for legibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)