### PR TITLE
hu: finish the maze-solve-basic exercise translation

### DIFF
--- a/curriculum/src/exercise-categories/maze/locales/hu/translation.json
+++ b/curriculum/src/exercise-categories/maze/locales/hu/translation.json
@@ -1,13 +1,13 @@
 {
   "errors": {
-    "fellOffEdge": "Oh no - you tried to fall off the edge of the maze!",
-    "hitWall": "Ouch - you walked into a wall!",
-    "walkedIntoFire": "Ouch! You walked into the fire!",
-    "walkedIntoPoop": "Ewww! You walked into the poop! 💩💩💩"
+    "fellOffEdge": "Jaj ne, majdnem leléptél a labirintus széléről!",
+    "hitWall": "Aú, nekimentél a falnak!",
+    "walkedIntoFire": "Aú! Belesétáltál a tűzbe!",
+    "walkedIntoPoop": "Fúj! Belesétáltál a kakiba! 💩💩💩"
   },
   "describers": {
-    "move": "Move the character forward one cell",
-    "turnLeft": "Turn the character 90 degrees left",
-    "turnRight": "Turn the character 90 degrees right"
+    "move": "Egy mezővel előre viszi a figurát",
+    "turnLeft": "90 fokkal balra fordítja a figurát",
+    "turnRight": "90 fokkal jobbra fordítja a figurát"
   }
 }

--- a/curriculum/src/exercises/dnd-roll/locales/hu/translation.json
+++ b/curriculum/src/exercises/dnd-roll/locales/hu/translation.json
@@ -6,9 +6,9 @@
     "damageNumber": "A sebzésnek számnak kell lennie"
   },
   "describers": {
-    "roll": "rolled a die and got ${return}",
-    "announce": "announced ${arg1}",
-    "strike": "struck the goblin with attack ${arg1} and damage ${arg2}"
+    "roll": "feldobott egy kockát, és ${return} lett az eredmény",
+    "announce": "bejelentette ezt az értéket: ${arg1}",
+    "strike": "lecsapott a koboldra ${arg1} támadással és ${arg2} sebzéssel"
   },
   "checks": {
     "announcementCount": "3 bejelentést vártunk, de {{got}} érkezett. Ügyelj arra, hogy minden dobást bejelents.",

--- a/curriculum/src/exercises/maze-solve-basic/instructions/hu.md
+++ b/curriculum/src/exercises/maze-solve-basic/instructions/hu.md
@@ -1,20 +1,20 @@
 ---
 title: "Oldd meg a labirintust!"
 description: "Vezesd végig Jikit a labirintuson egyszerű utasításokkal."
-en_md5: 4322b635396aac63128074a1c041d458
+en_md5: bbd838559fba4dcf527a55ba135703cd
 ---
 
 Üdvözlünk az első feladatodban!
 
-Ez a feladat azt a célt szolgálja, hogy megismerkedj a tanulási környezet működésével. Az a dolgod, hogy megoldd a bal oldalon látható labirintust úgy, hogy utasításokat adsz a kis figurának. Leírod az összes utasítást, amit a figurának követnie kell, majd a **Run Code** gombra kattintasz, hogy végre is hajtsa őket.
+Ez a feladat azt a célt szolgálja, hogy megismerkedj a tanulási környezet működésével. Az a dolgod, hogy megoldd a bal oldalon látható labirintust úgy, hogy utasításokat adsz a kis figurának. Leírod az összes utasítást, amit a figurának követnie kell, majd a **Kód futtatása** gombra kattintasz, hogy végre is hajtsa őket.
 
 Ezt a három utasítást használhatod:
 
-- `move()` egy lépéssel előre viszi a figurát
-- `turnLeft()` balra fordítja a figurát (ahhoz képest, amerre éppen néz)
-- `turnRight()` jobbra fordítja a figurát (ahhoz képest, amerre éppen néz)
+- `move()` (mozogj) egy lépéssel előre viszi a figurát
+- `turnLeft()` (fordulj balra) balra fordítja a figurát (ahhoz képest, amerre éppen néz)
+- `turnRight()` (fordulj jobbra) jobbra fordítja a figurát (ahhoz képest, amerre éppen néz)
 
-A bal oldalon láthatod, hogy az első három utasítást már leírtuk helyetted. Először kattints a **„Run Code”** gombra, és nézd meg, mit csinálnak. Ezután **adj hozzá további utasításokat**, hogy a figurád eljusson a labirintus végéig. Minden utasítást külön sorba írj, majd nyomd meg a **Run Code** gombot, hogy mind lefusson.
+A bal oldalon láthatod, hogy az első három utasítást már leírtuk helyetted. Először kattints a **„Kód futtatása”** gombra, és nézd meg, mit csinálnak. Ezután **adj hozzá további utasításokat**, hogy a figurád eljusson a labirintus végéig. Minden utasítást külön sorba írj, majd nyomd meg a **Kód futtatása** gombot, hogy mind lefusson.
 
 Érdemes rászoknod arra, hogy a kódodat rendszeresen lefuttasd!
 

--- a/curriculum/src/exercises/maze-solve-basic/locales/hu/translation.json
+++ b/curriculum/src/exercises/maze-solve-basic/locales/hu/translation.json
@@ -1,27 +1,27 @@
 {
   "checks": {
-    "didNotReachEnd": "You didn't reach the end of the maze."
+    "didNotReachEnd": "Nem jutottál el a labirintus végéig."
   },
   "tasks": {
     "solveMaze": {
-      "name": "Guide the person to the end of the maze",
-      "description": "Navigate through the maze to reach the green target"
+      "name": "Vezesd el a figurát a labirintus végéig",
+      "description": "Juss át a labirintuson a zöld célmezőig"
     }
   },
   "scenarios": {
     "maze1": {
-      "name": "Guide the person to the end of the maze",
-      "description": "Your job is to navigate your person through the maze to the green goal square."
+      "name": "Vezesd el a figurát a labirintus végéig",
+      "description": "Az a dolgod, hogy átvezesd a figurádat a labirintuson a zöld célmezőig."
     }
   },
   "hints": {
     "whatAmIMoving": {
-      "question": "What am I moving where?",
-      "answer": "You're moving the little person, who starts at the top-left, to the green circle at the bottom right, avoiding any red striped cells."
+      "question": "Mit hova kell mozgatnom?",
+      "answer": "A bal felső sarokból induló kis figurát kell eljuttatnod a jobb alsó sarokban lévő zöld körig, közben pedig kerüld el a piros csíkos mezőket."
     },
     "turnLeftTurnsRight": {
-      "question": "When I turn left, the person turns right!",
-      "answer": "The person turns relative to the position they're facing. So if you are facing right, and turn left, the person will change to face up."
+      "question": "Balra fordítom, mégis jobbra fordul a figura!",
+      "answer": "A figura mindig ahhoz képest fordul, amerre éppen néz. Ha tehát jobbra néz, és balra fordítod, akkor utána felfelé fog nézni."
     }
   }
 }


### PR DESCRIPTION
Completes the first Hungarian exercise end to end, so it can go on the review site as the worked example for the Translatathon.

- Translates the message catalogs that were still English stubs: `maze-solve-basic` (task, scenario, hint and check strings), the shared `maze` category (error messages and function describers), and `dnd-roll`'s describers.
- Localises the **Run Code** button name in the instructions, matching the localised website copy.
- Expands the `<define>` glosses the source tags on `move()`, `turnLeft()` and `turnRight()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)