### PR TITLE
Serve all locales, drive UI locale from /me `locales` (REVERT BEFORE MERGING!!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ app/public/static/content/
 app/public/static/exercises/
 app/public/static/interpreter-catalogs/
 app/public/static/search/
+
+# graphify knowledge-graph output (local only)
+graphify-out/

--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -242,11 +242,46 @@ What remains deferred is out of that sweep by design:
 
 Locales are defined in `lib/locales.ts`:
 
-- `ALL_LOCALES` — every locale the codebase knows about; the `Locale` type and message
-  catalogs (`messages/*.json`) are authored against this set.
-- `SUPPORTED_LOCALES` — the locales actually served in this environment. Production ships
-  `en` only; `next dev` serves the full set.
+- `ALL_LOCALES` — every locale the codebase knows about; the `Locale` type is derived from
+  this set. It mirrors the locale set the curriculum package ships translations for.
+- `SUPPORTED_LOCALES` — the locales actually served. On this branch it is `ALL_LOCALES`
+  unconditionally (see "Staging-Only Locale Expansion" below).
 - `DEFAULT_LOCALE` — `en`.
+- `RTL_LOCALES` — `ar`, `fa`, `ur`. Drives `dir="rtl"` on `<html>` via `getLocaleDirection()`.
+
+### UI Catalog Fallback
+
+`ALL_LOCALES` is far wider than the set of authored UI catalogs (`messages/{locale}.json`).
+`createCatalogLoader` therefore serves the `en` catalog for any locale with no entry in the
+`messageHashes` manifest, and rejects only when `en` itself is missing. Without this an
+unauthored locale would fail its request outright — there is no bundled fallback, so
+`/fr/blog` would 500 rather than render. The trade-off is that an untranslated locale renders
+English strings under its own locale route instead of failing loudly.
+
+## Staging-Only Locale Expansion
+
+**This branch serves every known locale and must never be deployed to production.**
+
+`SUPPORTED_LOCALES` has no environment gate. `ENVIRONMENT=staging` cannot be used for one:
+it is a Cloudflare Worker runtime var (`lib/env.ts`), so it exists only server-side and is not
+inlined into the client bundle. Gating on it would leave the server serving every locale while
+the browser still believed in `en` alone, desyncing locale routing and link-building from SSR.
+`NODE_ENV` is inlined into both bundles but cannot separate staging from production, because
+staging is a production build. The safety property is branch discipline, not code.
+
+## User Locale from the API
+
+`/internal/me` returns two locale fields on `user`:
+
+- `locale` — the persisted account preference.
+- `locales` — every locale the API parsed out of the browser's `Accept-Language` string that
+  it recognised as valid, in the browser's own preference order.
+
+`resolveUserLocale()` (`lib/i18n/userLocale.ts`) is the single resolver for both: it takes the
+first served entry of `locales`, falls back to `locale`, and returns `undefined` when neither
+yields a served locale (so callers keep the locale they already resolved). It is used by
+`ClientLocaleProvider` to pick the authoritative UI locale and by `authStore.setUser` to mirror
+that same value into the `NEXT_LOCALE` cookie, so the cookie cannot disagree with what renders.
 
 ## URL Structure
 
@@ -266,10 +301,11 @@ Locales are defined in `lib/locales.ts`:
 
 Some languages ship more than one content variant. The canonical ids (matching the API's
 `I18n::SUPPORTED_LOCALES`) are `es-ES` (Peninsular), `es-419` (neutral Latin American),
-`pt-PT` and `pt-BR`. The Portuguese pair is in `ALL_LOCALES`; the Spanish pair is not yet.
-The machinery below is built and tested for all four —
-`tests/unit/lib/i18n/futureLocales.test.ts` runs it against the full variant set with a mocked
-locale config, so it holds regardless of what is currently served.
+`pt-PT` and `pt-BR`. All four are in `ALL_LOCALES`; what they still lack is authored UI
+catalogs, so they fall back to the `en` catalog (see "UI Catalog Fallback"). The machinery
+below is built and tested for all four — `tests/unit/lib/i18n/futureLocales.test.ts` runs it
+against the full variant set with a mocked locale config, so it holds regardless of what is
+currently served.
 
 The casing is load-bearing, not cosmetic: the locale id is also the catalog filename
 (`messages/pt-PT.json`), the content filename (`pt-PT.md`), the curriculum locale directory

--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -271,17 +271,31 @@ staging is a production build. The safety property is branch discipline, not cod
 
 ## User Locale from the API
 
-`/internal/me` returns two locale fields on `user`:
+`/internal/me` returns three locale fields on `user`:
 
+- `explicit_locale` — the locale the user deliberately chose, or `null` if they never have.
 - `locale` — the persisted account preference.
 - `locales` — every locale the API parsed out of the browser's `Accept-Language` string that
   it recognised as valid, in the browser's own preference order.
 
-`resolveUserLocale()` (`lib/i18n/userLocale.ts`) is the single resolver for both: it takes the
-first served entry of `locales`, falls back to `locale`, and returns `undefined` when neither
-yields a served locale (so callers keep the locale they already resolved). It is used by
-`ClientLocaleProvider` to pick the authoritative UI locale and by `authStore.setUser` to mirror
-that same value into the `NEXT_LOCALE` cookie, so the cookie cannot disagree with what renders.
+`resolveUserLocale()` (`lib/i18n/userLocale.ts`) is the single resolver, in precedence order
+`explicit_locale` → first served entry of `locales` → `locale`, returning `undefined` when none
+yields a served locale (so callers keep the locale they already resolved). `explicit_locale`
+wins outright: a deliberate choice must not be overridden by what the browser happens to be
+asking for, or switching language would silently revert on the next load.
+
+It is used by `ClientLocaleProvider` to pick the authoritative UI locale and by
+`authStore.setUser` to mirror that same value into the `NEXT_LOCALE` cookie, so the cookie
+cannot disagree with what renders.
+
+### Dashboard Locale Switcher (staging-only)
+
+`components/i18n/LocaleSwitcher/` is a fixed-position picker in the bottom-left of the
+dashboard, for hand-testing the full locale set. It reads `explicit_locale` and writes via
+`settingsApi.updateLocale()` (`PATCH /internal/settings/locale`, body `{ value }`), then pushes
+the new value into the auth store — that store write, not a refetch, is what drives the catalog
+swap. `checkAuth()` cannot be used to refresh here because it early-returns once auth has been
+checked. It ships with the rest of this staging-only branch.
 
 ## URL Structure
 

--- a/app/app/(app)/dashboard/page.tsx
+++ b/app/app/(app)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import BetaTag from "@/components/common/BetaTag";
 import ChallengesSidebar from "@/components/dashboard/challenges-sidebar/ChallengesSidebar";
 import ExercisePath from "@/components/dashboard/exercise-path/ExercisePath";
+import { LocaleSwitcher } from "@/components/i18n/LocaleSwitcher/LocaleSwitcher";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import SidebarLayout from "../../../components/layout/SidebarLayout";
@@ -15,6 +16,9 @@ export default function DashboardPage() {
   return (
     <SidebarLayout activeItem="learn">
       <BetaTag />
+      {/* STAGING-ONLY: hand-testing affordance for the full locale set. Goes with
+          the rest of this branch and must not reach production. */}
+      <LocaleSwitcher />
       <div className={styles.dashboardContainer}>
         <div className={styles.mainContent}>
           <ExercisePath />

--- a/app/app/(app)/layout.tsx
+++ b/app/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import { ClientAuthGuard } from "../../components/layout/auth/internal/ClientAuthGuard";
+import { TranslatathonBanner } from "@/components/i18n/TranslatathonBanner";
 import { CheckoutReturnHandler } from "@/components/checkout/CheckoutReturnHandler";
 import { WelcomeModalHandler } from "@/components/WelcomeModalHandler";
 import { AppModalRegistrar } from "@/lib/modal/AppModalRegistrar";
@@ -33,6 +34,7 @@ export default function AppLayout({
   return (
     <ClientAuthGuard>
       <AppModalRegistrar />
+      <TranslatathonBanner />
       {children}
       <CheckoutReturnHandler />
       <WelcomeModalHandler />

--- a/app/app/(hybrid)/[locale]/layout.tsx
+++ b/app/app/(hybrid)/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { isSupportedLocale } from "@/lib/i18n/config";
 import { alternatesFromRequest } from "@/lib/seo/alternates";
 import JsonLd from "@/components/seo/JsonLd";
+import { TranslatathonBanner } from "@/components/i18n/TranslatathonBanner";
 import { organizationSchema, websiteSchema } from "@/lib/seo/schemas";
 
 // Emit hreflang alternates + a self-referential canonical for every public page
@@ -34,6 +35,7 @@ export default async function LocaleLayout({
   return (
     <>
       <JsonLd data={[organizationSchema(), websiteSchema(locale)]} />
+      <TranslatathonBanner />
       {children}
     </>
   );

--- a/app/app/global-error.tsx
+++ b/app/app/global-error.tsx
@@ -22,7 +22,12 @@ interface GlobalErrorCopy {
   actionLabel: string;
 }
 
-const COPY: Record<Locale, GlobalErrorCopy> = {
+// English is required (it is the fallback for every locale without an entry);
+// every other locale is optional, so adding a locale doesn't break the build —
+// it just falls back to English until its copy is hand-written here.
+type GlobalErrorCopyMap = Partial<Record<Locale, GlobalErrorCopy>> & { en: GlobalErrorCopy };
+
+const COPY: GlobalErrorCopyMap = {
   en: {
     title: "Something went wrong",
     message: "We encountered an unexpected error. Sorry about that!",
@@ -153,7 +158,7 @@ export function resolveGlobalErrorLocale(): Locale {
 // not present in the dictionary.
 export function getGlobalErrorCopy(locale: string): GlobalErrorCopy {
   const dictionary: Record<string, GlobalErrorCopy | undefined> = COPY;
-  return dictionary[locale] ?? COPY[DEFAULT_LOCALE];
+  return dictionary[locale] ?? COPY.en;
 }
 
 function readCookie(name: string): string | undefined {

--- a/app/components/coding-exercise/CodingExercise.module.css
+++ b/app/components/coding-exercise/CodingExercise.module.css
@@ -3,6 +3,10 @@
     grid-template-columns: 1fr 1fr;
     grid-template-rows: min(342px, 50vh) 1fr;
     flex: 1;
+    /* Constrain to the flex allocation (100vh) so a large editor row + the
+       bottom panel's 300px min-height can't grow this past the viewport and
+       scroll the page. Pairs with overflow: hidden to clip the grid. */
+    min-height: 0;
     background: var(--color-gray-50);
     overflow: hidden;
     position: relative;
@@ -203,7 +207,7 @@
     flex-direction: column;
     border-radius: 8px 8px 0 8px;
     border: 1px solid var(--color-gray-200);
-    min-height: 200px;
+    min-height: 300px;
     margin: 4px 4px 8px 8px;
 }
 

--- a/app/components/coding-exercise/useResize.tsx
+++ b/app/components/coding-exercise/useResize.tsx
@@ -6,6 +6,10 @@ type Direction = "horizontal" | "vertical";
 
 const STORAGE_KEY = "coding-exercise-panel-sizes";
 const LHS_MIN_PIXELS = 400;
+// Minimum height of the bottom (test results) panel in the LHS top/bottom split.
+// The top editor row is allowed to grow up to `containerHeight - BOTTOM_MIN_PIXELS`,
+// which makes this the smallest the bottom panel can actually be dragged to.
+const BOTTOM_MIN_PIXELS = 300;
 
 function clampVerticalPercentage(percentage: number, containerWidth: number) {
   const minPercentage = Math.min(70, Math.max(30, (LHS_MIN_PIXELS / containerWidth) * 100));
@@ -101,14 +105,15 @@ export function useResizablePanels() {
     applyVertical(container, verticalDividerRef.current, verticalPercentage);
 
     if (typeof stored.horizontalPixels === "number") {
-      const maxHorizontalPixels = container.getBoundingClientRect().height - 200;
-      if (maxHorizontalPixels >= 200) {
-        const clamped = Math.min(Math.max(stored.horizontalPixels, 200), maxHorizontalPixels);
-        // The 50vh cap keeps the editor row from forcing the grid taller than
-        // the viewport if the window shrinks after the size was stored.
-        container.style.gridTemplateRows = `min(${clamped}px, 50vh) 1fr`;
+      // Clamp to the live container so the editor row can never force the grid
+      // taller than the viewport, and the bottom panel keeps its 300px minimum
+      // even if the window shrank after the size was stored.
+      const maxHorizontalPixels = container.getBoundingClientRect().height - BOTTOM_MIN_PIXELS;
+      if (maxHorizontalPixels >= BOTTOM_MIN_PIXELS) {
+        const clamped = Math.min(Math.max(stored.horizontalPixels, BOTTOM_MIN_PIXELS), maxHorizontalPixels);
+        container.style.gridTemplateRows = `${clamped}px 1fr`;
         if (horizontalDividerRef.current) {
-          horizontalDividerRef.current.style.top = `min(${clamped}px, 50vh)`;
+          horizontalDividerRef.current.style.top = `${clamped}px`;
         }
       }
     }
@@ -199,10 +204,10 @@ export function useResizablePanels() {
       const offsetY = moveEvent.clientY - containerRect.top;
       const pixelPosition = offsetY;
 
-      if (pixelPosition >= 200 && pixelPosition <= containerRect.height - 200) {
+      if (pixelPosition >= BOTTOM_MIN_PIXELS && pixelPosition <= containerRect.height - BOTTOM_MIN_PIXELS) {
         latestPixels = pixelPosition;
-        horizontalDivider.style.top = `min(${pixelPosition}px, 50vh)`;
-        container.style.gridTemplateRows = `min(${pixelPosition}px, 50vh) 1fr`;
+        horizontalDivider.style.top = `${pixelPosition}px`;
+        container.style.gridTemplateRows = `${pixelPosition}px 1fr`;
       }
     };
 

--- a/app/components/i18n/ClientLocaleProvider.tsx
+++ b/app/components/i18n/ClientLocaleProvider.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/lib/auth/authStore";
 import { createCatalogLoader } from "@/lib/i18n/catalogLoader";
 import { DEFAULT_TIME_ZONE, getLocaleDirection, normalizeLocale, type Locale } from "@/lib/i18n/config";
 import { setLocaleCookie } from "@/lib/i18n/localeCookie";
+import { resolveUserLocale } from "@/lib/i18n/userLocale";
 import { NextIntlClientProvider, type AbstractIntlMessages } from "next-intl";
 import { useEffect, useState, type ReactNode } from "react";
 
@@ -22,8 +23,9 @@ interface ClientLocaleProviderProps {
  *
  * The provider renders `initialLocale`/`initialMessages` (the server-resolved
  * seed) for the first paint, so external/anon SSR is unaffected. Once the auth
- * check populates `user.locale` (the authoritative preference from /internal/me),
- * if it differs from the seed we load that catalog client-side and swap.
+ * check populates the user, we resolve their authoritative locale from /internal/me
+ * (`locales[0]`, else `locale` — see lib/i18n/userLocale.ts); if it differs from the
+ * seed we load that catalog client-side and swap.
  *
  * While a swap is in flight the provider renders `LoadingJiki` in place of its
  * children, so the app never paints in the wrong locale. "Swap pending" is
@@ -39,7 +41,7 @@ export function ClientLocaleProvider({ initialLocale, initialMessages, children 
   const [locale, setLocale] = useState(initialLocale);
   const [messages, setMessages] = useState(initialMessages);
   const [abandoned, setAbandoned] = useState<string | null>(null);
-  const userLocale = useAuthStore((state) => state.user?.locale);
+  const userLocale = useAuthStore((state) => resolveUserLocale(state.user));
 
   // For anon/logged-out users `user` is null, so `userLocale` is null and
   // `authoritative` collapses to `normalizeLocale(initialLocale)`, which equals

--- a/app/components/i18n/LocaleBanner.tsx
+++ b/app/components/i18n/LocaleBanner.tsx
@@ -1,6 +1,7 @@
 import { LocaleBannerBar } from "@/components/i18n/LocaleBannerBar";
 import { AUTHENTICATION_COOKIE_NAME } from "@/lib/auth/cookie-config";
 import { LOCALE_COOKIE_NAME, PATHNAME_HEADER } from "@/lib/i18n/config";
+import { languageName } from "@/lib/i18n/languageNames";
 import { resolveBannerOffer } from "@/lib/i18n/localeBanner";
 import { getTranslations } from "next-intl/server";
 import { cookies, headers } from "next/headers";
@@ -32,17 +33,14 @@ export async function LocaleBanner() {
     return null;
   }
 
-  const [t, names] = await Promise.all([
-    getTranslations({ locale: offer.offered, namespace: "layout.localeBanner" }),
-    getTranslations({ locale: offer.offered, namespace: "common.languageNames" })
-  ]);
+  const t = await getTranslations({ locale: offer.offered, namespace: "layout.localeBanner" });
 
   return (
     <LocaleBannerBar
       href={offer.href}
       offered={offer.offered}
-      prefix={t("prefix", { language: names(offer.current) })}
-      cta={t("cta", { language: names(offer.offered) })}
+      prefix={t("prefix", { language: languageName(offer.current, offer.offered) })}
+      cta={t("cta", { language: languageName(offer.offered, offer.offered) })}
       or={t("or")}
       close={t("close")}
     />

--- a/app/components/i18n/LocaleSwitcher/LocaleSwitcher.module.css
+++ b/app/components/i18n/LocaleSwitcher/LocaleSwitcher.module.css
@@ -2,7 +2,10 @@
     position: fixed;
     bottom: 16px;
     inset-inline-start: 16px;
-    z-index: var(--z-index-fixed);
+    /* Deliberately not a --z-index-* token: this staging-only widget has to sit
+       above everything, including the nav and any modal, and shouldn't have a
+       token minted for it in the shared scale. */
+    z-index: 9999999;
 
     display: flex;
     flex-direction: column;

--- a/app/components/i18n/LocaleSwitcher/LocaleSwitcher.module.css
+++ b/app/components/i18n/LocaleSwitcher/LocaleSwitcher.module.css
@@ -1,0 +1,60 @@
+.switcher {
+    position: fixed;
+    bottom: 16px;
+    inset-inline-start: 16px;
+    z-index: var(--z-index-fixed);
+
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-width: 220px;
+    padding: 10px 12px;
+
+    background: var(--color-background-primary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    color: var(--color-text-secondary);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.badge {
+    padding: 1px 5px;
+
+    background: var(--color-amber-100);
+    color: var(--color-amber-700);
+    border-radius: 4px;
+    font-size: 10px;
+    letter-spacing: 0;
+}
+
+.select {
+    padding: 5px 6px;
+
+    background: var(--color-background-primary);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: 6px;
+    font-size: 13px;
+}
+
+.select:disabled {
+    opacity: 0.6;
+    cursor: progress;
+}
+
+.error {
+    margin: 0;
+    color: var(--color-red-600);
+    font-size: 11px;
+}

--- a/app/components/i18n/LocaleSwitcher/LocaleSwitcher.tsx
+++ b/app/components/i18n/LocaleSwitcher/LocaleSwitcher.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { settingsApi } from "@/lib/api/settings";
+import { useAuthStore } from "@/lib/auth/authStore";
+import { languageName } from "@/lib/i18n/languageNames";
+import { ALL_LOCALES } from "@/lib/locales";
+import { useState } from "react";
+import styles from "./LocaleSwitcher.module.css";
+
+/**
+ * STAGING-ONLY: floating language picker, bottom-left of the dashboard.
+ *
+ * Exists so every served locale can be exercised by hand without touching the
+ * database. It reads `explicit_locale` from /internal/me (the locale the user
+ * deliberately chose, or null if they never have) and PATCHes
+ * /internal/settings/locale to change it.
+ *
+ * Changing it updates the auth store, which is what actually swaps the UI:
+ * ClientLocaleProvider watches the store via resolveUserLocale(), where
+ * `explicit_locale` outranks the browser's `locales`. authStore.setUser mirrors
+ * the same resolved value into the NEXT_LOCALE cookie, so the next SSR seed
+ * agrees and there's no flash back to the old language.
+ */
+export function LocaleSwitcher() {
+  const user = useAuthStore((state) => state.user);
+  const setUser = useAuthStore((state) => state.setUser);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!user) {
+    return null;
+  }
+
+  async function handleChange(value: string) {
+    if (!user) {
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await settingsApi.updateLocale(value);
+      // Drive the swap off the store rather than refetching /internal/me: the
+      // PATCH response carries settings, not a User, and checkAuth() early-returns
+      // once auth has been checked so it can't be used to refresh here.
+      setUser({ ...user, explicit_locale: value, locale: value });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change language");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Guarded rather than trusting the type, matching resolveUserLocale: `locales`
+  // is new on /internal/me and may not be there yet.
+  const autoLocale = Array.isArray(user.locales) && user.locales.length > 0 ? user.locales[0] : user.locale;
+
+  return (
+    <div className={styles.switcher}>
+      <label className={styles.label} htmlFor="staging-locale-switcher">
+        Language <span className={styles.badge}>staging</span>
+      </label>
+      <select
+        id="staging-locale-switcher"
+        className={styles.select}
+        value={user.explicit_locale ?? ""}
+        disabled={saving}
+        onChange={(event) => void handleChange(event.target.value)}
+      >
+        {/* No explicit choice yet: the UI locale comes from the browser's
+            Accept-Language instead. Selecting a real locale is one-way here —
+            the API has no "clear it again" endpoint, so this option is disabled. */}
+        <option value="" disabled>
+          Auto ({autoLocale})
+        </option>
+        {ALL_LOCALES.map((locale) => (
+          <option key={locale} value={locale}>
+            {languageName(locale, locale)} ({locale})
+          </option>
+        ))}
+      </select>
+      {error ? <p className={styles.error}>{error}</p> : null}
+    </div>
+  );
+}

--- a/app/components/i18n/TranslatathonBanner.module.css
+++ b/app/components/i18n/TranslatathonBanner.module.css
@@ -1,0 +1,31 @@
+.banner {
+    position: relative;
+    color: var(--color-gray-700);
+    border-bottom: 1px solid var(--color-amber-300);
+    background: var(--color-amber-200);
+    font-size: 15px;
+    font-weight: 500;
+    padding: 8px 40px;
+    text-align: center;
+
+    a {
+        color: var(--color-blue-600);
+        font-weight: 600;
+        text-decoration: underline;
+        display: inline;
+    }
+}
+
+.close {
+    position: absolute;
+    top: 50%;
+    inset-inline-end: 12px;
+    transform: translateY(-50%);
+    border: none;
+    background: transparent;
+    color: var(--color-gray-700);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px;
+}

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -49,7 +49,7 @@ const TRANSLATATHON_URL = "https://i18n.jiki.io";
  * Fully-translated copy for each language in the Translatathon program, keyed by
  * the program's own locale ids (matching ../../translator/languages/names.json,
  * minus `hu` which we already ship). Multi-variant languages have one entry per
- * variant (es-419/es-ES, pt-BR/pt-pt, zh-CN/zh-TW); resolveTarget maps a browser
+ * variant (es-419/es-ES, pt-BR/pt-PT, zh-CN/zh-TW); resolveTarget maps a browser
  * tag to the right one. Each string is written in that language, with the
  * language's own name for itself and a translated phrase for the translation
  * session (we don't leave "Translatathon" untranslated); only "Jiki" stays as a
@@ -158,7 +158,7 @@ const COPY: Record<string, TranslatathonCopy> = {
     post: "",
     close: "Fechar"
   },
-  "pt-pt": {
+  "pt-PT": {
     pre: "Quer ajudar-nos a traduzir o Jiki para português? ",
     link: "Junte-se à sessão de tradução",
     post: "",
@@ -341,7 +341,7 @@ function programLocale(tag: string, base: string): string | undefined {
     return region(tag) === "ES" ? "es-ES" : "es-419";
   }
   if (base === "pt") {
-    return region(tag) === "PT" ? "pt-pt" : "pt-BR";
+    return region(tag) === "PT" ? "pt-PT" : "pt-BR";
   }
   if (base === "zh") {
     const r = region(tag);

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useAuthStore } from "@/lib/auth/authStore";
+import { ALL_LOCALES } from "@/lib/locales";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useLayoutEffect, useState } from "react";
+import styles from "./TranslatathonBanner.module.css";
+
+/**
+ * Temporary, pre-catalog promo banner for the Big Jiki & Exercism Translatathon.
+ *
+ * Deliberately NOT wired into next-intl: the whole point is to reach speakers of
+ * languages we do NOT yet ship in the catalog, so its copy can't come from the
+ * catalog. This is different from the catalog-driven LocaleBanner (which offers to
+ * switch to a language we already support) — see `components/i18n/LocaleBanner.tsx`.
+ *
+ * It targets the first non-catalog language in the viewer's own language list
+ * (`navigator.languages`, i.e. their browser's ordered preference list), shown to
+ * signed-in users only:
+ * - a language we run in the Translatathon program (COPY below) gets the whole
+ *   banner IN that language;
+ * - any other non-English language gets the English banner with its name filled in.
+ *
+ * Rendering client-side is intentional: navigator.languages IS the "language
+ * list", and it keeps this out of the edge-cached SSR HTML.
+ *
+ * The whole banner is temporary and self-removes after the event (see END).
+ *
+ * NOTE: the translated strings below were drafted for the event and should be
+ * sanity-checked by native speakers / the Translatathon translators.
+ */
+
+interface TranslatathonCopy {
+  /** Sentence text before the linked call-to-action (may be empty). */
+  pre: string;
+  /** The linked call-to-action text (the "Join the translation session" part). */
+  link: string;
+  /** Sentence text after the linked call-to-action (may be empty). */
+  post: string;
+  /** Accessible label for the dismiss button, in this language. */
+  close: string;
+}
+
+// Where the call-to-action goes (opens in a new tab).
+const TRANSLATATHON_URL = "https://i18n.jiki.io";
+
+/**
+ * Fully-translated copy for each language in the Translatathon program, keyed by
+ * the program's own locale ids (matching ../../translator/languages/names.json,
+ * minus `hu` which we already ship). Multi-variant languages have one entry per
+ * variant (es-419/es-ES, pt-BR/pt-pt, zh-CN/zh-TW); resolveTarget maps a browser
+ * tag to the right one. Each string is written in that language, with the
+ * language's own name for itself and a translated phrase for the translation
+ * session (we don't leave "Translatathon" untranslated); only "Jiki" stays as a
+ * proper noun.
+ */
+const COPY: Record<string, TranslatathonCopy> = {
+  ar: {
+    pre: "هل تريد مساعدتنا في ترجمة Jiki إلى العربية؟ ",
+    link: "انضمّ إلى جلسة الترجمة",
+    post: "",
+    close: "إغلاق"
+  },
+  bn: {
+    pre: "Jiki-কে বাংলায় অনুবাদ করতে আমাদের সাহায্য করতে চান? ",
+    link: "অনুবাদ সেশনে যোগ দিন",
+    post: "",
+    close: "বন্ধ করুন"
+  },
+  ca: {
+    pre: "Vols ajudar-nos a traduir Jiki al català? ",
+    link: "Uneix-te a la sessió de traducció",
+    post: "",
+    close: "Tanca"
+  },
+  de: {
+    pre: "Möchtest du uns helfen, Jiki ins Deutsche zu übersetzen? ",
+    link: "Mach bei der Übersetzungssession mit",
+    post: "",
+    close: "Schließen"
+  },
+  el: {
+    pre: "Θέλεις να μας βοηθήσεις να μεταφράσουμε το Jiki στα Ελληνικά; ",
+    link: "Λάβε μέρος στη μεταφραστική συνεδρία",
+    post: "",
+    close: "Κλείσιμο"
+  },
+  "es-419": {
+    pre: "¿Quieres ayudarnos a traducir Jiki al español? ",
+    link: "Únete a la sesión de traducción",
+    post: "",
+    close: "Cerrar"
+  },
+  "es-ES": {
+    pre: "¿Quieres ayudarnos a traducir Jiki al español? ",
+    link: "Únete a la sesión de traducción",
+    post: "",
+    close: "Cerrar"
+  },
+  fa: {
+    pre: "می‌خواهید در ترجمهٔ Jiki به فارسی به ما کمک کنید؟ ",
+    link: "به نشست ترجمه بپیوندید",
+    post: "",
+    close: "بستن"
+  },
+  fr: {
+    pre: "Vous voulez nous aider à traduire Jiki en français ? ",
+    link: "Rejoignez la session de traduction",
+    post: "",
+    close: "Fermer"
+  },
+  hi: {
+    pre: "क्या आप Jiki का हिन्दी में अनुवाद करने में हमारी मदद करना चाहते हैं? ",
+    link: "अनुवाद सत्र में शामिल हों",
+    post: "",
+    close: "बंद करें"
+  },
+  id: {
+    pre: "Ingin membantu kami menerjemahkan Jiki ke Bahasa Indonesia? ",
+    link: "Ikuti sesi terjemahan",
+    post: "",
+    close: "Tutup"
+  },
+  it: {
+    pre: "Vuoi aiutarci a tradurre Jiki in italiano? ",
+    link: "Partecipa alla sessione di traduzione",
+    post: "",
+    close: "Chiudi"
+  },
+  ja: {
+    pre: "Jiki を日本語に翻訳するのを手伝いませんか？",
+    link: "翻訳セッションに参加する",
+    post: "",
+    close: "閉じる"
+  },
+  ko: {
+    pre: "Jiki를 한국어로 번역하는 데 도움을 주시겠어요? ",
+    link: "번역 세션에 참여하세요",
+    post: "",
+    close: "닫기"
+  },
+  nl: {
+    pre: "Wil je ons helpen Jiki naar het Nederlands te vertalen? ",
+    link: "Doe mee aan de vertaalsessie",
+    post: "",
+    close: "Sluiten"
+  },
+  pl: {
+    pre: "Chcesz pomóc nam przetłumaczyć Jiki na polski? ",
+    link: "Dołącz do sesji tłumaczeniowej",
+    post: "",
+    close: "Zamknij"
+  },
+  "pt-BR": {
+    pre: "Quer nos ajudar a traduzir o Jiki para o português? ",
+    link: "Participe da sessão de tradução",
+    post: "",
+    close: "Fechar"
+  },
+  "pt-pt": {
+    pre: "Quer ajudar-nos a traduzir o Jiki para português? ",
+    link: "Junte-se à sessão de tradução",
+    post: "",
+    close: "Fechar"
+  },
+  ru: {
+    pre: "Хотите помочь нам перевести Jiki на русский? ",
+    link: "Присоединяйтесь к сессии перевода",
+    post: "",
+    close: "Закрыть"
+  },
+  sr: {
+    pre: "Желите да нам помогнете да преведемо Jiki на српски? ",
+    link: "Придружите се преводилачкој сесији",
+    post: "",
+    close: "Затвори"
+  },
+  sw: {
+    pre: "Ungependa kutusaidia kutafsiri Jiki kwa Kiswahili? ",
+    link: "Jiunge na kikao cha tafsiri",
+    post: "",
+    close: "Funga"
+  },
+  tr: {
+    pre: "Jiki'yi Türkçeye çevirmemize yardım etmek ister misin? ",
+    link: "Çeviri oturumuna katıl",
+    post: "",
+    close: "Kapat"
+  },
+  uk: {
+    pre: "Хочете допомогти нам перекласти Jiki українською? ",
+    link: "Долучайтеся до сесії перекладу",
+    post: "",
+    close: "Закрити"
+  },
+  ur: {
+    pre: "کیا آپ Jiki کا اردو میں ترجمہ کرنے میں ہماری مدد کرنا چاہتے ہیں؟ ",
+    link: "ترجمے کے سیشن میں شامل ہوں",
+    post: "",
+    close: "بند کریں"
+  },
+  vi: {
+    pre: "Bạn muốn giúp chúng tôi dịch Jiki sang Tiếng Việt? ",
+    link: "Tham gia buổi dịch thuật",
+    post: "",
+    close: "Đóng"
+  },
+  "zh-CN": {
+    pre: "想帮我们把 Jiki 翻译成中文吗？",
+    link: "加入翻译活动",
+    post: "",
+    close: "关闭"
+  },
+  "zh-TW": {
+    pre: "想幫我們把 Jiki 翻譯成中文嗎？",
+    link: "加入翻譯活動",
+    post: "",
+    close: "關閉"
+  }
+};
+
+// Program languages that read right-to-left; the banner element gets dir="rtl".
+const RTL_TARGETS = new Set(["ar", "fa", "ur"]);
+
+// The event weekend is 31 Jul – 2 Aug 2026; keep the banner up through 3 Aug.
+// After this instant the banner never renders. Remove the component entirely
+// once the event is well past.
+const END = new Date("2026-08-04T00:00:00Z");
+
+const DISMISS_KEY_PREFIX = "translatathon-banner-dismissed:";
+
+interface Target {
+  copy: TranslatathonCopy;
+  dir: "ltr" | "rtl";
+  /** Identity the dismissal is remembered under (program locale id, or base language). */
+  dismissId: string;
+}
+
+// useLayoutEffect on the client (decide before paint, no flash); useEffect on the
+// server (it can't run layout effects and would warn). Same pattern as LocaleBannerBar.
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export function TranslatathonBanner() {
+  // Signed-in users only. We read the current auth state and don't wait for the
+  // auth check to settle: if we don't yet know they're authed, we simply show
+  // nothing (and re-render once the store flips). This lets the same component
+  // sit in the public/hybrid layout without ever showing to logged-out visitors.
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  // The full-screen coding-exercise views (lesson/challenge) are hard-sized to
+  // 100vh, so an in-flow banner above them scrolls the whole page. Suppress the
+  // banner there; it still shows on every other app page (dashboard, lists, …).
+  const pathname = usePathname();
+  // Both the server render and the first client render produce null (target === null),
+  // so there is no hydration mismatch; the effect then reveals the banner if it applies.
+  const [target, setTarget] = useState<Target | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    if (new Date() >= END) {
+      return;
+    }
+    const languages = typeof navigator !== "undefined" ? navigator.languages : [];
+    const resolved = resolveTarget(languages);
+    if (resolved && !isDismissed(resolved.dismissId)) {
+      setTarget(resolved);
+    }
+  }, []);
+
+  if (!isAuthenticated || !target || isFullScreenExercisePath(pathname)) {
+    return null;
+  }
+
+  const { copy, dir } = target;
+
+  return (
+    <div className={styles.banner} dir={dir}>
+      <span>{copy.pre}</span>
+      <Link href={TRANSLATATHON_URL} target="_blank" rel="noopener noreferrer">
+        {copy.link}
+      </Link>
+      <span>{copy.post}</span>
+      <button
+        type="button"
+        onClick={() => {
+          dismiss(target.dismissId);
+          setTarget(null);
+        }}
+        aria-label={copy.close}
+        className={styles.close}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+// The full-screen exercise routes: /lesson/<slug> and /challenges/<slug> (an
+// optional leading locale segment is tolerated). The bare /challenges list is
+// NOT matched — it needs a slug — so the banner still shows there.
+function isFullScreenExercisePath(pathname: string | null): boolean {
+  if (!pathname) {
+    return false;
+  }
+  return /^(?:\/[a-z]{2}(?:-[a-z]+)?)?\/(?:lesson|challenges)\/[^/]+/i.test(pathname);
+}
+
+// Base languages we already ship in the catalog (e.g. "en", "hu"): their speakers
+// get the real catalog LocaleBanner offering an in-app switch, so there is nothing
+// to recruit and we never show them the Translatathon banner.
+const CATALOG_LANGUAGES = new Set(ALL_LOCALES.map((locale) => locale.split("-")[0].toLowerCase()));
+
+/**
+ * Resolve the viewer's language list to the banner we should show. Walks the list
+ * in order, takes the first language we don't already ship, and returns either its
+ * in-program translated banner or the English fallback with its name filled in.
+ */
+function resolveTarget(languages: readonly string[]): Target | null {
+  for (const tag of languages) {
+    const base = tag.split("-")[0]?.toLowerCase();
+    if (!base || CATALOG_LANGUAGES.has(base)) {
+      continue;
+    }
+    const key = programLocale(tag, base);
+    if (key) {
+      return { copy: COPY[key], dir: RTL_TARGETS.has(base) ? "rtl" : "ltr", dismissId: key };
+    }
+    const english = englishCopy(base);
+    return english ? { copy: english, dir: "ltr", dismissId: base } : null;
+  }
+  return null;
+}
+
+/**
+ * Map a browser language tag to the program locale id whose copy we show, or
+ * undefined if the language isn't in the program. Multi-variant languages collapse
+ * by region/script (mirrors the API's variant handling); every other program
+ * language is keyed by its bare base code.
+ */
+function programLocale(tag: string, base: string): string | undefined {
+  if (base === "es") {
+    return region(tag) === "ES" ? "es-ES" : "es-419";
+  }
+  if (base === "pt") {
+    return region(tag) === "PT" ? "pt-pt" : "pt-BR";
+  }
+  if (base === "zh") {
+    const r = region(tag);
+    return /hant/i.test(tag) || r === "TW" || r === "HK" || r === "MO" ? "zh-TW" : "zh-CN";
+  }
+  return base in COPY ? base : undefined;
+}
+
+/** The region subtag (first 2-alpha or 3-digit subtag), uppercased, or undefined. */
+function region(tag: string): string | undefined {
+  return tag
+    .split("-")
+    .slice(1)
+    .find((part) => /^([A-Za-z]{2}|\d{3})$/.test(part))
+    ?.toUpperCase();
+}
+
+/**
+ * The English fallback banner for a non-program language, with the language's
+ * English name filled in. Returns null when the code resolves to no real language
+ * name (so we never render "translate Jiki to xyz").
+ */
+function englishCopy(lang: string): TranslatathonCopy | null {
+  const name = languageName(lang);
+  if (!name) {
+    return null;
+  }
+  return {
+    pre: `Want to help us translate Jiki to ${name}? `,
+    link: "Join the Translatathon",
+    post: "",
+    close: "Close this notice"
+  };
+}
+
+/** The English display name for a base language code, or undefined if it isn't a real language. */
+function languageName(lang: string): string | undefined {
+  try {
+    const name = new Intl.DisplayNames(["en"], { type: "language" }).of(lang);
+    // DisplayNames echoes the input back for unknown codes; treat that as "no name".
+    return name && name.toLowerCase() !== lang.toLowerCase() ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isDismissed(id: string): boolean {
+  try {
+    return window.localStorage.getItem(`${DISMISS_KEY_PREFIX}${id}`) === "1";
+  } catch {
+    // Storage disabled (private mode etc.) — just show the banner.
+    return false;
+  }
+}
+
+function dismiss(id: string): void {
+  try {
+    window.localStorage.setItem(`${DISMISS_KEY_PREFIX}${id}`, "1");
+  } catch {
+    // Ignore storage failures; the banner still closes for this view.
+  }
+}

--- a/app/lib/auth/authStore.ts
+++ b/app/lib/auth/authStore.ts
@@ -10,7 +10,7 @@ import type { LoginCredentials, LoginResponse, PasswordReset, SignupData, User }
 import { ApiError, AuthenticationError, NetworkError, RateLimitError } from "@/lib/api/client";
 import { setCriticalError, clearCriticalError } from "@/lib/api/errorHandlerStore";
 import { setLocaleCookie } from "@/lib/i18n/localeCookie";
-import { isSupportedLocale } from "@/lib/i18n/config";
+import { resolveUserLocale } from "@/lib/i18n/userLocale";
 import { create } from "zustand";
 import type { StoreApi } from "zustand";
 
@@ -209,10 +209,13 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
       error: null
     });
     // Mirror the authoritative locale into the NEXT_LOCALE cookie so the next
-    // SSR seed is correct. The cookie is an optimistic hint; user.locale is the
-    // source of truth. Ignore unsupported/absent values.
-    if (isSupportedLocale(user.locale)) {
-      setLocaleCookie(user.locale);
+    // SSR seed is correct. The cookie is an optimistic hint; /internal/me is the
+    // source of truth. Resolved via the same helper ClientLocaleProvider uses, so
+    // the cookie can't disagree with the locale actually rendered. Ignore
+    // unsupported/absent values.
+    const locale = resolveUserLocale(user);
+    if (locale) {
+      setLocaleCookie(locale);
     }
   },
   setNoUser: (error?: string | null) => {

--- a/app/lib/i18n/catalogLoader.ts
+++ b/app/lib/i18n/catalogLoader.ts
@@ -10,6 +10,11 @@ import { messageHashes } from "@/lib/generated/messages-hashes";
 /** Resolves a cache-tree path to a fetchable URL (sync on the client, async on the server). */
 type ResolveUrl = (path: string) => string | Promise<string>;
 
+// Catalog served for any locale that has no authored catalog of its own. Kept as a
+// literal rather than imported from lib/locales to avoid a cycle, and because this
+// is about which catalog FILE exists, not which locale is served.
+const FALLBACK_CATALOG_LOCALE = "en";
+
 /**
  * Build a catalog loader with its own promise cache keyed `${locale}:${hash}`.
  * The hash is immutable per build, so a resolved entry is always valid and is
@@ -23,7 +28,21 @@ type ResolveUrl = (path: string) => string | Promise<string>;
 export function createCatalogLoader(resolveUrl: ResolveUrl): (locale: string) => Promise<Record<string, unknown>> {
   const cache = new Map<string, Promise<Record<string, unknown>>>();
 
-  return function loadCatalog(locale: string): Promise<Record<string, unknown>> {
+  return function loadCatalog(requested: string): Promise<Record<string, unknown>> {
+    // STAGING-ONLY BRANCH — DO NOT MERGE TO MAIN.
+    //
+    // SUPPORTED_LOCALES now serves every locale the curriculum translates, but the
+    // app only authors UI catalogs for a couple of them (messages/*.json). Without
+    // this fallback a locale with no catalog of its own rejects, and since there is
+    // no bundled fallback that fails the whole request — /fr/blog would 500 rather
+    // than render. Falling back to English lets the locale routing, hreflang and
+    // /internal/me `locales` wiring be tested ahead of the catalogs existing.
+    //
+    // The consequence is that an untranslated locale renders English UI strings
+    // under its own locale route, which is exactly why this must not reach
+    // production: there it would silently serve English instead of failing loudly.
+    const locale = messageHashes[requested] ? requested : FALLBACK_CATALOG_LOCALE;
+
     const hash = messageHashes[locale];
     if (!hash) {
       return Promise.reject(new Error(`No UI message catalog hash for locale "${locale}"`));

--- a/app/lib/i18n/languageNames.ts
+++ b/app/lib/i18n/languageNames.ts
@@ -1,0 +1,21 @@
+import type { Locale } from "./config";
+
+/**
+ * The display name of `locale`, written in `inLocale`.
+ *
+ * Uses `Intl.DisplayNames` rather than an authored `common.languageNames` catalog
+ * entry, because that catalog would need an entry for every locale in every other
+ * locale (a 30x30 matrix) and would silently go stale each time a locale is added.
+ * ICU already ships this data, including for region-suffixed ids like `es-419`
+ * ("Latin American Spanish") and `pt-BR`.
+ *
+ * Falls back to the locale code itself if ICU has no name for it (or is built
+ * without the data), so the caller always has something renderable.
+ */
+export function languageName(locale: Locale | string, inLocale: Locale | string): string {
+  try {
+    return new Intl.DisplayNames([inLocale], { type: "language" }).of(locale) ?? locale;
+  } catch {
+    return locale;
+  }
+}

--- a/app/lib/i18n/userLocale.ts
+++ b/app/lib/i18n/userLocale.ts
@@ -2,21 +2,28 @@ import type { User } from "@/types/auth";
 import { isSupportedLocale } from "./config";
 import type { Locale } from "./config";
 
+type LocaleFields = Pick<User, "locale" | "locales" | "explicit_locale">;
+
 /**
- * The UI locale to use for a logged-in user.
+ * The UI locale to use for a logged-in user, in precedence order:
  *
- * /internal/me returns two locale fields: `locale` (the persisted account
- * preference) and `locales` (every locale the API parsed out of the browser's
- * Accept-Language string, in the browser's preference order). We take the FIRST
- * entry of `locales`, falling back to `locale` when the list is absent, empty, or
- * leads with something this build doesn't serve.
+ * 1. `explicit_locale` — a locale the user deliberately chose. It wins outright:
+ *    a deliberate choice must never be overridden by what the browser is asking
+ *    for, otherwise switching language would silently revert on the next load.
+ * 2. `locales` — every locale the API parsed out of the browser's Accept-Language
+ *    string, in the browser's preference order. We take the first served entry.
+ * 3. `locale` — the persisted account preference.
  *
- * Returns undefined when neither field yields a served locale, so callers can keep
+ * Returns undefined when none of them yields a served locale, so callers can keep
  * whatever locale they already resolved rather than being forced back to English.
  */
-export function resolveUserLocale(user: Pick<User, "locale" | "locales"> | null | undefined): Locale | undefined {
+export function resolveUserLocale(user: LocaleFields | null | undefined): Locale | undefined {
   if (!user) {
     return undefined;
+  }
+
+  if (isSupportedLocale(user.explicit_locale)) {
+    return user.explicit_locale;
   }
 
   // Guarded rather than trusting the type: `locales` is new on /internal/me, so an

--- a/app/lib/i18n/userLocale.ts
+++ b/app/lib/i18n/userLocale.ts
@@ -1,0 +1,30 @@
+import type { User } from "@/types/auth";
+import { isSupportedLocale } from "./config";
+import type { Locale } from "./config";
+
+/**
+ * The UI locale to use for a logged-in user.
+ *
+ * /internal/me returns two locale fields: `locale` (the persisted account
+ * preference) and `locales` (every locale the API parsed out of the browser's
+ * Accept-Language string, in the browser's preference order). We take the FIRST
+ * entry of `locales`, falling back to `locale` when the list is absent, empty, or
+ * leads with something this build doesn't serve.
+ *
+ * Returns undefined when neither field yields a served locale, so callers can keep
+ * whatever locale they already resolved rather than being forced back to English.
+ */
+export function resolveUserLocale(user: Pick<User, "locale" | "locales"> | null | undefined): Locale | undefined {
+  if (!user) {
+    return undefined;
+  }
+
+  // Guarded rather than trusting the type: `locales` is new on /internal/me, so an
+  // API that hasn't shipped it yet must degrade to `locale`, not throw.
+  const preferred = Array.isArray(user.locales) ? user.locales.find(isSupportedLocale) : undefined;
+  if (preferred) {
+    return preferred;
+  }
+
+  return isSupportedLocale(user.locale) ? user.locale : undefined;
+}

--- a/app/lib/locales.ts
+++ b/app/lib/locales.ts
@@ -25,8 +25,7 @@ export const ALL_LOCALES = [
   "nl",
   "pl",
   "pt-BR",
-  // Lowercase to match the authored catalog (messages/pt-pt.json) and content dirs.
-  "pt-pt",
+  "pt-PT",
   "ro",
   "ru",
   "sr",

--- a/app/lib/locales.ts
+++ b/app/lib/locales.ts
@@ -1,44 +1,69 @@
 // Every locale the codebase knows about: types, message catalogs (messages/*.json)
 // and localized content are all authored against this full set, regardless of
 // which locales a given environment actually serves. `Locale` is derived from
-// this, so hu types/content stay valid even when hu isn't served.
+// this, so a locale's types/content stay valid even when it isn't served.
 //
-// Every locale here has a real catalog at messages/<locale>.json. `en` first
-// (it is the source and the default), the rest alphabetical.
+// This mirrors the locale set the curriculum package ships translations for
+// (curriculum/src/**/locales/*), in canonical BCP-47 casing.
 export const ALL_LOCALES = [
   "en",
+  "ar",
+  "bn",
+  "ca",
+  "de",
   "el",
+  "es-419",
+  "es-ES",
   "fa",
   "fr",
+  "hi",
   "hu",
+  "id",
   "it",
+  "ja",
+  "ko",
   "nl",
+  "pl",
   "pt-BR",
-  "pt-PT",
+  // Lowercase to match the authored catalog (messages/pt-pt.json) and content dirs.
+  "pt-pt",
+  "ro",
   "ru",
   "sr",
+  "sv",
+  "sw",
+  "tr",
   "uk",
+  "ur",
+  "vi",
+  "zh-CN",
   "zh-TW"
 ] as const;
 export type Locale = (typeof ALL_LOCALES)[number];
 
 export const DEFAULT_LOCALE: Locale = "en";
 
-// Locales actually served in this environment. Production ships English only for
-// now; local development serves the full set so the localization work stays
-// testable. `NODE_ENV` is statically inlined by Next in both the server and
-// client bundles, so this resolves identically on the edge and in the browser.
+// STAGING-ONLY BRANCH — DO NOT MERGE TO MAIN.
 //
-// Note: any built/deployed environment (including staging/preview) reports
-// `NODE_ENV === "production"`, so those are en-only too; only `next dev` gets the
-// non-en locales.
-export const SUPPORTED_LOCALES: readonly Locale[] = process.env.NODE_ENV === "production" ? ["en"] : ALL_LOCALES;
+// Every known locale is served unconditionally so the full locale surface
+// (routing, hreflang, Accept-Language negotiation, the `locales` preference list
+// from /internal/me) can be exercised end-to-end on staging.jiki.io.
+//
+// This deliberately has no environment gate. `ENVIRONMENT=staging` cannot be used
+// here: it is a Cloudflare Worker runtime var, so it exists only server-side and is
+// NOT inlined into the client bundle. Gating on it would make the server serve every
+// locale while the browser still believed in `en` alone, desyncing locale routing and
+// link-building from SSR. `NODE_ENV` is inlined in both bundles but cannot separate
+// staging from production, since staging is a production build.
+//
+// So the safety property here is branch discipline, not code: this branch ships to
+// staging only and must never be deployed to production.
+export const SUPPORTED_LOCALES: readonly Locale[] = ALL_LOCALES;
 
-// Locales that read right-to-left. Deliberately empty today: every locale in
-// ALL_LOCALES is LTR except Persian ("fa"), which is knowingly left out until it
-// has real routed content rather than just a message catalog. Adding a locale
-// here is all it takes for `<html dir>` to flip to "rtl" for it.
-export const RTL_LOCALES: ReadonlySet<Locale> = new Set([]);
+// Locales that read right-to-left, driving `dir="rtl"` on `<html>` via
+// getLocaleDirection() (server-rendered in app/layout.tsx, synced client-side on
+// locale swap in ClientLocaleProvider).
+export const RTL_LOCALES: ReadonlySet<Locale> = new Set(["ar", "fa", "ur"]);
 
 // Text direction for a locale: "rtl" for locales in RTL_LOCALES, "ltr" otherwise
 // (including any unknown/unsupported string). Drives `dir` on `<html>` (server via

--- a/app/scripts/verify-locale.js
+++ b/app/scripts/verify-locale.js
@@ -4,10 +4,10 @@
 /**
  * Locale completeness check.
  *
- * Production serves only the LIVE languages (lib/locales.ts SUPPORTED_LOCALES —
- * currently just `en`), and en is the canonical source, so a live deploy can't
- * ship missing files. Before promoting another language to live (e.g. hu), run
- * this to confirm it's complete:
+ * `SUPPORTED_LOCALES` (lib/locales.ts) now serves every known language, but most
+ * of them are incomplete — they fall back to the `en` catalog rather than failing.
+ * en is the canonical source, so run this to see how complete a given language
+ * actually is before relying on it:
  *
  *   pnpm verify:locale hu            # strict: exit 1 if hu is missing anything
  *   pnpm verify:locale hu es-ES      # check several

--- a/app/tests/mocks/user.ts
+++ b/app/tests/mocks/user.ts
@@ -18,6 +18,7 @@ export function createMockUser(overrides?: Partial<User>): User {
     provider: "email",
     email_confirmed: true,
     locale: "en",
+    locales: ["en"],
     ...overrides
   };
 }

--- a/app/tests/mocks/user.ts
+++ b/app/tests/mocks/user.ts
@@ -19,6 +19,7 @@ export function createMockUser(overrides?: Partial<User>): User {
     email_confirmed: true,
     locale: "en",
     locales: ["en"],
+    explicit_locale: null,
     ...overrides
   };
 }

--- a/app/tests/unit/app/global-error.test.tsx
+++ b/app/tests/unit/app/global-error.test.tsx
@@ -40,13 +40,13 @@ describe("resolveGlobalErrorLocale", () => {
   });
 
   it("ignores an unsupported URL locale segment and falls through to the default", () => {
-    setPathname("/de/blog");
+    setPathname("/xx/blog");
     expect(resolveGlobalErrorLocale()).toBe("en");
   });
 
   it("ignores an unsupported NEXT_LOCALE cookie value", () => {
     setPathname("/dashboard");
-    document.cookie = `${LOCALE_COOKIE_NAME}=de`;
+    document.cookie = `${LOCALE_COOKIE_NAME}=xx`;
     expect(resolveGlobalErrorLocale()).toBe("en");
   });
 });
@@ -68,6 +68,6 @@ describe("getGlobalErrorCopy", () => {
   });
 
   it("falls back to the English copy for an unknown locale", () => {
-    expect(getGlobalErrorCopy("de")).toEqual(getGlobalErrorCopy("en"));
+    expect(getGlobalErrorCopy("xx")).toEqual(getGlobalErrorCopy("en"));
   });
 });

--- a/app/tests/unit/components/i18n/LocaleSwitcher.test.tsx
+++ b/app/tests/unit/components/i18n/LocaleSwitcher.test.tsx
@@ -1,0 +1,71 @@
+import { LocaleSwitcher } from "@/components/i18n/LocaleSwitcher/LocaleSwitcher";
+import { settingsApi } from "@/lib/api/settings";
+import { useAuthStore } from "@/lib/auth/authStore";
+import { createMockUser } from "@/tests/mocks/user";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("@/lib/api/settings", () => ({
+  settingsApi: { updateLocale: jest.fn() }
+}));
+
+const mockUpdateLocale = settingsApi.updateLocale as jest.MockedFunction<typeof settingsApi.updateLocale>;
+
+function setUser(user: ReturnType<typeof createMockUser> | null) {
+  useAuthStore.setState({ user, isAuthenticated: user !== null });
+}
+
+describe("LocaleSwitcher", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateLocale.mockResolvedValue({} as Awaited<ReturnType<typeof settingsApi.updateLocale>>);
+  });
+
+  // Unmount before resetting the store, so the reset can't re-render a live
+  // component outside act().
+  afterEach(() => {
+    cleanup();
+    act(() => setUser(null));
+  });
+
+  it("renders nothing for a logged-out user", () => {
+    setUser(null);
+    const { container } = render(<LocaleSwitcher />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the explicit locale as the current selection", () => {
+    setUser(createMockUser({ explicit_locale: "hu", locales: ["fr"] }));
+    render(<LocaleSwitcher />);
+    expect(screen.getByRole("combobox")).toHaveValue("hu");
+  });
+
+  it("falls back to the auto option and names the browser locale when no explicit choice exists", () => {
+    setUser(createMockUser({ explicit_locale: null, locales: ["fr"] }));
+    render(<LocaleSwitcher />);
+    expect(screen.getByRole("combobox")).toHaveValue("");
+    expect(screen.getByRole("option", { name: /Auto \(fr\)/ })).toBeInTheDocument();
+  });
+
+  it("PATCHes the chosen locale and updates the store so the UI swaps", async () => {
+    setUser(createMockUser({ explicit_locale: null, locales: ["fr"], locale: "en" }));
+    render(<LocaleSwitcher />);
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "hu" } });
+
+    await waitFor(() => expect(mockUpdateLocale).toHaveBeenCalledWith("hu"));
+    await waitFor(() => {
+      expect(useAuthStore.getState().user?.explicit_locale).toBe("hu");
+    });
+  });
+
+  it("surfaces a failed change without altering the stored locale", async () => {
+    setUser(createMockUser({ explicit_locale: null, locale: "en" }));
+    mockUpdateLocale.mockRejectedValue(new Error("Locale is not supported"));
+    render(<LocaleSwitcher />);
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "hu" } });
+
+    expect(await screen.findByText("Locale is not supported")).toBeInTheDocument();
+    expect(useAuthStore.getState().user?.explicit_locale).toBeNull();
+  });
+});

--- a/app/tests/unit/components/settings/subscription/SubscriptionSection.test.tsx
+++ b/app/tests/unit/components/settings/subscription/SubscriptionSection.test.tsx
@@ -34,6 +34,7 @@ function createMockUser(overrides?: Partial<User>): User {
     provider: "email",
     email_confirmed: true,
     locale: "en",
+    locales: ["en"],
     ...overrides
   };
 }

--- a/app/tests/unit/components/settings/subscription/SubscriptionSection.test.tsx
+++ b/app/tests/unit/components/settings/subscription/SubscriptionSection.test.tsx
@@ -35,6 +35,7 @@ function createMockUser(overrides?: Partial<User>): User {
     email_confirmed: true,
     locale: "en",
     locales: ["en"],
+    explicit_locale: null,
     ...overrides
   };
 }

--- a/app/tests/unit/lib/cache/cache-key-generator.test.ts
+++ b/app/tests/unit/lib/cache/cache-key-generator.test.ts
@@ -134,8 +134,8 @@ describe("cache-key-generator", () => {
     });
 
     it("buckets unsupported languages into the default locale", () => {
-      const de = new Request("https://jiki.io/blog", { headers: { "accept-language": "de-DE,de;q=0.9" } });
-      expect(generateCacheKey(de, deployId)).toBe("/blog#abc1234@en");
+      const unsupported = new Request("https://jiki.io/blog", { headers: { "accept-language": "xx-XX,xx;q=0.9" } });
+      expect(generateCacheKey(unsupported, deployId)).toBe("/blog#abc1234@en");
     });
 
     it("generates same key regardless of disallowed param order", () => {

--- a/app/tests/unit/lib/cache/cacheable-routes.test.ts
+++ b/app/tests/unit/lib/cache/cacheable-routes.test.ts
@@ -46,18 +46,18 @@ describe("cacheable-routes", () => {
 
     describe("locale-prefix handling is config-driven (not a loose regex)", () => {
       it("does not cache an unsupported locale prefix", () => {
-        // "de" isn't in SUPPORTED_LOCALES, so /de/blog is a 404 route, not a
+        // "zz" isn't in SUPPORTED_LOCALES, so /zz/blog is a 404 route, not a
         // cacheable page. The old /[a-z]{2}/ regex wrongly cached these.
-        expect(isCacheableRoute("/de/blog")).toBe(false);
+        expect(isCacheableRoute("/zz/blog")).toBe(false);
         expect(isCacheableRoute("/xx/concepts")).toBe(false);
-        expect(isCacheableRoute("/de")).toBe(false);
+        expect(isCacheableRoute("/zz")).toBe(false);
       });
 
-      it("caches region-subtag locales that are supported", () => {
-        // Caching keys off SUPPORTED_LOCALES, so a hyphenated locale is cacheable
-        // with no regex change, while an unsupported one still isn't.
+      it("caches region-subtag locales, which a two-letter regex would have missed", () => {
+        // Caching keys off SUPPORTED_LOCALES, so hyphenated locales are cacheable
+        // with no regex change. An unsupported region subtag still is not.
         expect(isCacheableRoute("/pt-BR/blog")).toBe(true);
-        expect(isCacheableRoute("/es-MX/blog")).toBe(false);
+        expect(isCacheableRoute("/de-AT/blog")).toBe(false);
       });
     });
 

--- a/app/tests/unit/lib/i18n/catalogLoader.test.ts
+++ b/app/tests/unit/lib/i18n/catalogLoader.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { createCatalogLoader } from "@/lib/i18n/catalogLoader";
+import { messageHashes } from "@/lib/generated/messages-hashes";
 
 jest.mock("@/lib/generated/messages-hashes", () => ({
   messageHashes: { en: "aaaaaaaaaaaa", hu: "bbbbbbbbbbbb" }
@@ -110,10 +111,25 @@ describe("createCatalogLoader", () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
-  it("rejects without fetching for a locale with no manifest hash", async () => {
+  it("falls back to the en catalog for a locale with no manifest hash", async () => {
     const load = createCatalogLoader((path) => path);
+    mockFetch.mockResolvedValueOnce(okResponse());
 
-    await expect(load("xx")).rejects.toThrow('No UI message catalog hash for locale "xx"');
-    expect(mockFetch).not.toHaveBeenCalled();
+    await expect(load("xx")).resolves.toEqual(CATALOG);
+    expect(mockFetch).toHaveBeenCalledWith("/static/i18n/app/en/messages-aaaaaaaaaaaa.json");
+  });
+
+  it("rejects without fetching when en itself has no manifest hash", async () => {
+    const hashes = messageHashes as Record<string, string | undefined>;
+    const enHash = hashes.en;
+    delete hashes.en;
+
+    try {
+      const load = createCatalogLoader((path) => path);
+      await expect(load("xx")).rejects.toThrow('No UI message catalog hash for locale "en"');
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      hashes.en = enHash;
+    }
   });
 });

--- a/app/tests/unit/lib/i18n/config.test.ts
+++ b/app/tests/unit/lib/i18n/config.test.ts
@@ -17,15 +17,13 @@ describe("stripLocalePrefix", () => {
   });
 
   it("does not strip an unsupported segment (it isn't a locale)", () => {
-    expect(stripLocalePrefix("/de/blog")).toBe("/de/blog");
+    expect(stripLocalePrefix("/zz/blog")).toBe("/zz/blog");
     expect(stripLocalePrefix("/xx")).toBe("/xx");
-    // Region subtags only strip once supported; es-MX isn't, so it's left as-is.
-    expect(stripLocalePrefix("/es-MX/blog")).toBe("/es-MX/blog");
+    // A region subtag on an unsupported region is not a locale either.
+    expect(stripLocalePrefix("/de-AT/blog")).toBe("/de-AT/blog");
   });
 
   it("strips a supported region-subtag locale prefix", () => {
-    // Hyphenated ids are handled by the same config-driven lookup, no special case.
     expect(stripLocalePrefix("/pt-BR/blog")).toBe("/blog");
-    expect(stripLocalePrefix("/pt-BR")).toBe("/");
   });
 });

--- a/app/tests/unit/lib/i18n/detectSeedLocale.test.ts
+++ b/app/tests/unit/lib/i18n/detectSeedLocale.test.ts
@@ -10,7 +10,7 @@ describe("detectSeedLocale", () => {
   });
 
   it("returns undefined for an unsupported locale (normalizes to default -> omit)", () => {
-    expect(detectSeedLocale("de")).toBeUndefined();
+    expect(detectSeedLocale("xx")).toBeUndefined();
     expect(detectSeedLocale("")).toBeUndefined();
     expect(detectSeedLocale("not-a-locale")).toBeUndefined();
   });

--- a/app/tests/unit/lib/i18n/futureLocales.test.ts
+++ b/app/tests/unit/lib/i18n/futureLocales.test.ts
@@ -1,9 +1,9 @@
 /**
- * The locale machinery (routing, hreflang, Accept-Language negotiation) must be
- * correct for the es/pt content variants (es-ES, es-419, pt-PT, pt-BR) whether or
- * not they are currently served, so going live is just adding the locale + its
- * catalog. These tests mock the locale config to run that machinery against the
- * full variant set, independently of what lib/locales.ts ships today.
+ * The es/pt content locales (es-ES, es-419, pt-PT, pt-BR) aren't served yet —
+ * lib/locales.ts still ships en/hu — but the locale machinery (routing, hreflang,
+ * Accept-Language negotiation) must already be correct for them so going live is
+ * just adding the locale + its catalog. These tests run that machinery against
+ * the future set by mocking the locale config.
  *
  * The negotiation cases mirror the API's User::DetermineLocale acceptance oracle
  * (jiki-education/api test/commands/user/determine_locale_test.rb) — keep them in
@@ -43,11 +43,11 @@ describe("routing for region-suffixed locales", () => {
 
 describe("hreflang emission", () => {
   it("collapses es-419 to generic es (Google rejects UN M.49 region codes)", () => {
-    expect(hreflangLocale("es-419" as never)).toBe("es");
+    expect(hreflangLocale("es-419")).toBe("es");
   });
 
   it("passes ISO-valid ids through untouched", () => {
-    expect(hreflangLocale("es-ES" as never)).toBe("es-ES");
+    expect(hreflangLocale("es-ES")).toBe("es-ES");
     expect(hreflangLocale("pt-PT")).toBe("pt-PT");
     expect(hreflangLocale("pt-BR")).toBe("pt-BR");
     expect(hreflangLocale("en")).toBe("en");

--- a/app/tests/unit/lib/i18n/localeBanner.test.ts
+++ b/app/tests/unit/lib/i18n/localeBanner.test.ts
@@ -26,7 +26,7 @@ describe("resolveBannerOffer", () => {
     });
 
     it("falls back to English on a non-English page when none of their languages are supported", () => {
-      expect(resolveBannerOffer({ ...anon, pathname: "/hu/blog/x", acceptLanguage: "de,ja;q=0.9" })).toEqual({
+      expect(resolveBannerOffer({ ...anon, pathname: "/hu/blog/x", acceptLanguage: "xx,zz;q=0.9" })).toEqual({
         offered: "en",
         current: "hu",
         href: "/blog/x"
@@ -34,7 +34,7 @@ describe("resolveBannerOffer", () => {
     });
 
     it("shows nothing on an English page when their languages are unsupported", () => {
-      expect(resolveBannerOffer({ ...anon, pathname: "/blog/x", acceptLanguage: "de" })).toBeNull();
+      expect(resolveBannerOffer({ ...anon, pathname: "/blog/x", acceptLanguage: "xx" })).toBeNull();
     });
   });
 
@@ -61,11 +61,15 @@ describe("resolveBannerOffer", () => {
 
 describe("firstSupportedLanguage", () => {
   it("honours q-value ordering and skips unsupported tags", () => {
-    expect(firstSupportedLanguage("de;q=0.9,hu;q=0.8")).toBe("hu");
+    expect(firstSupportedLanguage("xx;q=0.9,hu;q=0.8")).toBe("hu");
   });
 
   it("matches a base language (hu-HU -> hu)", () => {
     expect(firstSupportedLanguage("hu-HU,en;q=0.9")).toBe("hu");
+  });
+
+  it("collapses a region tag to its content variant (es-CL -> es-419)", () => {
+    expect(firstSupportedLanguage("es-CL")).toBe("es-419");
   });
 
   it("normalizes tag casing (Accept-Language isn't case-stable)", () => {
@@ -74,7 +78,7 @@ describe("firstSupportedLanguage", () => {
   });
 
   it("returns undefined when nothing is supported", () => {
-    expect(firstSupportedLanguage("de,ja,ko")).toBeUndefined();
+    expect(firstSupportedLanguage("xx,zz,qq-QQ")).toBeUndefined();
   });
 });
 
@@ -89,7 +93,7 @@ describe("localeCacheBucket", () => {
   });
 
   it("falls back to the default locale when nothing is supported", () => {
-    expect(localeCacheBucket("de-DE,de;q=0.9")).toBe("en");
+    expect(localeCacheBucket("xx-XX,xx;q=0.9")).toBe("en");
   });
 });
 

--- a/app/tests/unit/lib/i18n/localeDirection.test.ts
+++ b/app/tests/unit/lib/i18n/localeDirection.test.ts
@@ -1,17 +1,24 @@
 /**
  * `getLocaleDirection` drives the `dir` attribute on `<html>` (server via layout,
- * client via ClientLocaleProvider on a locale swap). The app is LTR-only today
- * (en/hu), so this is forward-looking infrastructure: adding an RTL locale to
- * RTL_LOCALES is all it takes for the page to flip to "rtl".
+ * client via ClientLocaleProvider on a locale swap). Membership of RTL_LOCALES is
+ * the only thing that flips a locale's direction.
  */
 import { ALL_LOCALES, getLocaleDirection, RTL_LOCALES } from "@/lib/locales";
 
+const EXPECTED_RTL = ["ar", "fa", "ur"];
+
 describe("getLocaleDirection", () => {
-  // RTL_LOCALES is deliberately empty while fa has no routed content, so every
-  // known locale still resolves to ltr. This asserts that state, not that every
-  // locale in ALL_LOCALES is an LTR language.
-  it("returns ltr for every currently-known locale", () => {
+  it("returns rtl for every RTL locale", () => {
+    for (const locale of EXPECTED_RTL) {
+      expect(getLocaleDirection(locale)).toBe("rtl");
+    }
+  });
+
+  it("returns ltr for every other known locale", () => {
     for (const locale of ALL_LOCALES) {
+      if (EXPECTED_RTL.includes(locale)) {
+        continue;
+      }
       expect(getLocaleDirection(locale)).toBe("ltr");
     }
   });
@@ -24,15 +31,7 @@ describe("getLocaleDirection", () => {
     expect(getLocaleDirection("xx-YY")).toBe("ltr");
   });
 
-  it("has no RTL locales today (fa's entry is deferred until it has routed content)", () => {
-    expect(RTL_LOCALES.size).toBe(0);
-  });
-
-  it("returns rtl for a locale added to RTL_LOCALES", () => {
-    // RTL_LOCALES is empty today; simulate the logic a real RTL locale would hit.
-    const rtl: ReadonlySet<string> = new Set(["ar"]);
-    const direction = (locale: string) => (rtl.has(locale) ? "rtl" : "ltr");
-    expect(direction("ar")).toBe("rtl");
-    expect(direction("en")).toBe("ltr");
+  it("RTL_LOCALES holds exactly the right-to-left locales", () => {
+    expect([...RTL_LOCALES].sort()).toEqual([...EXPECTED_RTL].sort());
   });
 });

--- a/app/tests/unit/lib/i18n/resolveLocale.test.ts
+++ b/app/tests/unit/lib/i18n/resolveLocale.test.ts
@@ -56,7 +56,7 @@ describe("resolveLocale", () => {
   });
 
   it("ignores an unsupported URL locale header and falls through", async () => {
-    setup({ urlLocale: "de", hasAuthCookie: false, localeCookie: "hu" });
+    setup({ urlLocale: "xx", hasAuthCookie: false, localeCookie: "hu" });
     await expect(resolveLocale()).resolves.toBe("en");
   });
 });

--- a/app/tests/unit/lib/i18n/routes.test.ts
+++ b/app/tests/unit/lib/i18n/routes.test.ts
@@ -9,7 +9,7 @@ describe("localePath", () => {
     });
 
     it("normalizes an unsupported locale to the default", () => {
-      expect(localePath("/blog", "de")).toBe("/blog");
+      expect(localePath("/blog", "xx")).toBe("/blog");
     });
   });
 

--- a/app/tests/unit/lib/i18n/userLocale.test.ts
+++ b/app/tests/unit/lib/i18n/userLocale.test.ts
@@ -1,11 +1,25 @@
 import { resolveUserLocale } from "@/lib/i18n/userLocale";
 import type { User } from "@/types/auth";
 
-function user(locale: string, locales: string[]): Pick<User, "locale" | "locales"> {
-  return { locale, locales };
+type LocaleFields = Pick<User, "locale" | "locales" | "explicit_locale">;
+
+function user(locale: string, locales: string[], explicit: string | null = null): LocaleFields {
+  return { locale, locales, explicit_locale: explicit };
 }
 
 describe("resolveUserLocale", () => {
+  it("lets an explicit choice beat both the browser list and the account preference", () => {
+    expect(resolveUserLocale(user("en", ["fr", "de"], "hu"))).toBe("hu");
+  });
+
+  it("ignores an explicit choice this build doesn't serve", () => {
+    expect(resolveUserLocale(user("en", ["fr"], "xx"))).toBe("fr");
+  });
+
+  it("falls through to the browser list when no explicit choice was made", () => {
+    expect(resolveUserLocale(user("en", ["ja"], null))).toBe("ja");
+  });
+
   it("prefers the first browser locale over the persisted account preference", () => {
     expect(resolveUserLocale(user("en", ["fr", "de"]))).toBe("fr");
   });
@@ -34,7 +48,7 @@ describe("resolveUserLocale", () => {
   });
 
   it("degrades to the account preference when the API hasn't shipped `locales` yet", () => {
-    const legacy = { locale: "ro" } as Pick<User, "locale" | "locales">;
+    const legacy = { locale: "ro" } as LocaleFields;
     expect(resolveUserLocale(legacy)).toBe("ro");
   });
 });

--- a/app/tests/unit/lib/i18n/userLocale.test.ts
+++ b/app/tests/unit/lib/i18n/userLocale.test.ts
@@ -1,0 +1,40 @@
+import { resolveUserLocale } from "@/lib/i18n/userLocale";
+import type { User } from "@/types/auth";
+
+function user(locale: string, locales: string[]): Pick<User, "locale" | "locales"> {
+  return { locale, locales };
+}
+
+describe("resolveUserLocale", () => {
+  it("prefers the first browser locale over the persisted account preference", () => {
+    expect(resolveUserLocale(user("en", ["fr", "de"]))).toBe("fr");
+  });
+
+  it("falls back to the account preference when the browser list is empty", () => {
+    expect(resolveUserLocale(user("hu", []))).toBe("hu");
+  });
+
+  it("skips leading browser locales this build doesn't serve", () => {
+    expect(resolveUserLocale(user("en", ["xx", "zz", "ja"]))).toBe("ja");
+  });
+
+  it("falls back to the account preference when no browser locale is served", () => {
+    expect(resolveUserLocale(user("hu", ["xx", "zz"]))).toBe("hu");
+  });
+
+  it("returns undefined when neither field yields a served locale", () => {
+    // Callers keep whatever locale they already resolved rather than being
+    // forced back to English.
+    expect(resolveUserLocale(user("xx", ["zz"]))).toBeUndefined();
+  });
+
+  it("returns undefined for an anonymous user", () => {
+    expect(resolveUserLocale(null)).toBeUndefined();
+    expect(resolveUserLocale(undefined)).toBeUndefined();
+  });
+
+  it("degrades to the account preference when the API hasn't shipped `locales` yet", () => {
+    const legacy = { locale: "ro" } as Pick<User, "locale" | "locales">;
+    expect(resolveUserLocale(legacy)).toBe("ro");
+  });
+});

--- a/app/tests/unit/stores/authStore.checkAuth.test.ts
+++ b/app/tests/unit/stores/authStore.checkAuth.test.ts
@@ -41,7 +41,8 @@ describe("authStore.checkAuth", () => {
     provider: "email",
     email_confirmed: true,
     locale: "en",
-    locales: ["en"]
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.checkAuth.test.ts
+++ b/app/tests/unit/stores/authStore.checkAuth.test.ts
@@ -40,7 +40,8 @@ describe("authStore.checkAuth", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"]
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.exercismLogin.test.ts
+++ b/app/tests/unit/stores/authStore.exercismLogin.test.ts
@@ -32,7 +32,8 @@ describe("AuthStore - Exercism Authentication", () => {
     provider: "exercism",
     email_confirmed: true,
     locale: "en",
-    locales: ["en"]
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.exercismLogin.test.ts
+++ b/app/tests/unit/stores/authStore.exercismLogin.test.ts
@@ -31,7 +31,8 @@ describe("AuthStore - Exercism Authentication", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "exercism",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"]
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.login.test.ts
+++ b/app/tests/unit/stores/authStore.login.test.ts
@@ -34,7 +34,8 @@ describe("AuthStore - Login", () => {
     provider: "email",
     email_confirmed: true,
     locale: "en",
-    locales: ["en"]
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.login.test.ts
+++ b/app/tests/unit/stores/authStore.login.test.ts
@@ -33,7 +33,8 @@ describe("AuthStore - Login", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"]
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.logout.test.ts
+++ b/app/tests/unit/stores/authStore.logout.test.ts
@@ -33,7 +33,8 @@ describe("AuthStore - Logout", () => {
     provider: "email",
     email_confirmed: true,
     locale: "en",
-    locales: ["en"]
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.logout.test.ts
+++ b/app/tests/unit/stores/authStore.logout.test.ts
@@ -32,7 +32,8 @@ describe("AuthStore - Logout", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"]
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.test.ts
+++ b/app/tests/unit/stores/authStore.test.ts
@@ -31,7 +31,8 @@ describe("AuthStore - Google Authentication", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"]
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.test.ts
+++ b/app/tests/unit/stores/authStore.test.ts
@@ -32,7 +32,8 @@ describe("AuthStore - Google Authentication", () => {
     provider: "email",
     email_confirmed: true,
     locale: "en",
-    locales: ["en"]
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -18,6 +18,10 @@ export interface User {
   provider: string;
   email_confirmed: boolean;
   locale: string;
+  // The locale the user picked deliberately, or null if they never have. Beats
+  // both `locales` and `locale` when choosing the UI locale: an explicit choice
+  // must not be overridden by what the browser happens to be asking for.
+  explicit_locale: string | null;
   // Every locale parsed out of the user's browser Accept-Language string that the
   // API recognised as valid, in the browser's own preference order. Sits alongside
   // `locale` (the persisted account preference) on /internal/me; the first entry is

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -18,6 +18,11 @@ export interface User {
   provider: string;
   email_confirmed: boolean;
   locale: string;
+  // Every locale parsed out of the user's browser Accept-Language string that the
+  // API recognised as valid, in the browser's own preference order. Sits alongside
+  // `locale` (the persisted account preference) on /internal/me; the first entry is
+  // preferred over `locale` when picking the UI locale. See lib/i18n/userLocale.ts.
+  locales: string[];
 }
 
 export interface LoginCredentials {


### PR DESCRIPTION
## ⛔️ Do not merge, do not deploy to production

This branch exists solely to exercise the full locale surface on `staging.jiki.io`. It is safe on staging and **not** safe on production, for the reasons below.

## Serve every locale

- `ALL_LOCALES` goes from `en`/`hu` to the 30 locales the curriculum ships translations for, in canonical BCP-47 casing.
- `SUPPORTED_LOCALES` becomes `ALL_LOCALES` unconditionally.
- `RTL_LOCALES` gains `ar`/`fa`/`ur`, which are now served and would otherwise render left-to-right.

### Why there is no `ENVIRONMENT=staging` gate

This was the intended approach and it can't work. `ENVIRONMENT` is a Cloudflare Worker runtime var (`lib/env.ts`), so it only exists server-side and is never inlined into the client bundle. Gating on it would have the edge serving 30 locales while the browser still believed in `en` alone, desyncing locale routing and link-building from SSR. `NODE_ENV` *is* inlined into both bundles but can't separate staging from production, because staging is a production build.

So the safety property here is branch discipline, not code. Hence the shouting in the title, the commit, and `lib/locales.ts`.

## Surviving the missing UI catalogs

The app authors `messages/*.json` for `en` and `hu` only. Serving a locale with no catalog would fail its request outright — there is deliberately no bundled fallback, so `/fr/blog` would 500 rather than render.

`createCatalogLoader` therefore falls back to the `en` catalog for any locale absent from the `messageHashes` manifest, still rejecting when `en` itself is missing.

**This is the single biggest reason this must not reach production.** It inverts a deliberate fail-loudly design: on prod it would silently serve English under 28 locale routes instead of erroring. On staging that's exactly what we want, so the routing, hreflang and Accept-Language machinery can be driven without waiting on translations.

Two smaller knock-ons from the widened `Locale` union:
- `global-error`'s inline `COPY` map becomes partial with `en` required, so adding a locale falls back to English rather than breaking the build.
- `LocaleBanner` takes language names from `Intl.DisplayNames` rather than a `common.languageNames` catalog entry, which would have needed a 30x30 locale matrix and gone stale on every addition.

## Reading the browser's locales from the API

`/internal/me` returns `locales: string[]` alongside `locale` — every locale the API parsed out of the browser's `Accept-Language` string that it recognised as valid, in the browser's own preference order — plus `explicit_locale: string | null`, the locale the user deliberately chose.

`resolveUserLocale()` (`lib/i18n/userLocale.ts`) is the single resolver, in precedence order:

1. `explicit_locale` — wins outright. A deliberate choice must not be overridden by what the browser is asking for, or switching language would silently revert on the next load.
2. first served entry of `locales`
3. `locale`

It returns `undefined` when none yields a served locale, so callers keep whatever they'd already resolved rather than being forced back to English. Both `ClientLocaleProvider` (which picks the rendered locale) and `authStore.setUser` (which mirrors it into `NEXT_LOCALE`) go through it, so the cookie can't disagree with what's on screen. It's guarded against an API that hasn't shipped the fields yet.

## Dashboard language switcher

`components/i18n/LocaleSwitcher/` — a fixed-position picker in the bottom-left of the dashboard, for hand-testing the locale set. It reads `explicit_locale` and writes via `settingsApi.updateLocale()` (`PATCH /internal/settings/locale`, body `{ "value": "hu" }`).

The change is applied by writing the result into the auth store, not by refetching: the PATCH returns settings rather than a `User`, and `checkAuth()` early-returns once auth has been checked. That store write is what `ClientLocaleProvider` watches to swap the catalog.

The "Auto" option is disabled — it represents having made no explicit choice, and the API has no endpoint to clear the field once set.

## Verified on staging

Deployed and checked against `staging.jiki.io`:

- ✅ All 30 locales serve their root page with the correct `<html lang>` — spot-checked `fr`, `ja`, `sv`, `zh-CN`.
- ✅ RTL works: `/ar`, `/fa`, `/ur` all render `dir="rtl"`.
- ✅ A locale outside the set still 404s correctly (`/he`).
- ✅ English (`/blog`) and Hungarian (`/hu/blog`) are unaffected.
- ⚠️ **Content-backed sections 404 for locales with no authored content** — `/fr/blog`, `/ja/help` return 404, because the content markdown only exists for `en`/`hu` and those pages `notFound()` when their locale's content index is missing. The UI-catalog fallback doesn't cover this; it's a separate content-availability limit, not a locale-plumbing bug. Locale roots and the app shell work everywhere, so the switcher is still fully testable.

## Tests

Locale samples that stood in for "an unsupported locale" (`fr`, `de`, `es`) are now real locales, so they become `xx`/`zz`/`de-AT`. hreflang expectations derive from `SUPPORTED_LOCALES` rather than hand-listing, so they can't rot again. The direction and catalog-loader suites assert the new RTL and fallback behaviour; `resolveUserLocale` and `LocaleSwitcher` are covered directly.

180 suites / 2152 tests pass; lint clean.

⚠️ Note: `pnpm typecheck` at the monorepo root runs `pnpm -r typecheck`, and the `app` package has **no `typecheck` script** — so app code is never type-checked by it. Verified separately with `npx tsc --noEmit` inside `app/`, which is how the three type errors above were found. Worth fixing on main independently.

## Known-failing check

`audit-keys` fails, and is expected to. It derives its locale list from `SUPPORTED_LOCALES`, so all 28 locales without an authored `messages/*.json` report "catalog NOT FOUND". That's the intentional state of this branch — the runtime `en` fallback covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvZExzHSfzTfukePMto2PU
