### PR TITLE
Fix prices rendering 100x too high for RSD, ISK and friends

### DIFF
--- a/app/.context/stripe.md
+++ b/app/.context/stripe.md
@@ -251,3 +251,14 @@ await refreshUser(); // Refreshes user object from /internal/me endpoint
 ```
 
 The user's `membership_type` reflects their current tier, while `subscription_status` indicates the state of their Stripe subscription.
+
+## Formatting Prices
+
+All amounts from the API (`premium_prices`, payment history) are Stripe minor units. `lib/formatCurrency.ts` owns the conversion to display units, and everything that renders a price goes through it (`formatCurrency`, or `formatMonthlyPrice` in `lib/pricing.ts` which wraps it).
+
+Two separate questions, two separate functions, and they deliberately disagree for some currencies:
+
+- **How many minor units per major unit** (the divisor) comes from Stripe's own tables, never from `Intl`. Intl/CLDR calls RSD, ISK, ALL, LBP and ~10 others zero-decimal because their sub-units are obsolete, but Stripe still bills them in 1/100ths. Trusting Intl here rendered Serbian prices 100x too high.
+- **How many decimal places to show** (`currencyFractionDigits`) is Intl-driven, with HUF/TWD/UGX forced to 0.
+
+Never derive a divisor from `Intl.NumberFormat(...).resolvedOptions().minimumFractionDigits`.

--- a/app/lib/formatCurrency.ts
+++ b/app/lib/formatCurrency.ts
@@ -15,6 +15,29 @@ const DOLLAR_PREFIX: Record<string, string> = {
 // field is still multiplied by 100. See https://docs.stripe.com/currencies#special-cases
 const STRIPE_HUNDREDFOLD_ZERO_DECIMAL = new Set(["HUF", "TWD", "UGX"]);
 
+// Currencies Stripe bills in whole units - `amount: 500` means 500 yen, not 5.00.
+// See https://docs.stripe.com/currencies#zero-decimal
+const STRIPE_ZERO_DECIMAL = new Set([
+  "BIF",
+  "CLP",
+  "DJF",
+  "GNF",
+  "JPY",
+  "KMF",
+  "KRW",
+  "MGA",
+  "PYG",
+  "RWF",
+  "VND",
+  "VUV",
+  "XAF",
+  "XOF",
+  "XPF"
+]);
+
+// Currencies Stripe bills in thousandths - `amount: 1500` means KD 1.500.
+const STRIPE_THREE_DECIMAL = new Set(["BHD", "JOD", "KWD", "OMR", "TND"]);
+
 // Decimal places used when *displaying* an amount (e.g. "Ft 1,499" → 0 for HUF).
 // Do NOT use this to convert Stripe minor units → display units; use minorUnitExponent.
 export function currencyFractionDigits(currency: string): number {
@@ -25,10 +48,16 @@ export function currencyFractionDigits(currency: string): number {
 }
 
 // Power of 10 to convert Stripe's `amount` field into the displayed value.
-// Diverges from currencyFractionDigits for HUF/TWD/UGX.
+//
+// Driven by Stripe's own table rather than by Intl, because the two disagree:
+// Intl/CLDR reports RSD, ISK, ALL and a dozen others as zero-decimal (their
+// sub-units are long obsolete for display) while Stripe still bills them in
+// 1/100ths. Deriving the divisor from Intl rendered those prices 100x too
+// high, e.g. 39900 RSD showing as "RSD 39,900" rather than "RSD 399".
 function minorUnitExponent(currency: string): number {
-  if (STRIPE_HUNDREDFOLD_ZERO_DECIMAL.has(currency)) return 2;
-  return currencyFractionDigits(currency);
+  if (STRIPE_ZERO_DECIMAL.has(currency)) return 0;
+  if (STRIPE_THREE_DECIMAL.has(currency)) return 3;
+  return 2;
 }
 
 // Intl.NumberFormat in currency style with "narrowSymbol", falling back to

--- a/app/lib/pricing.ts
+++ b/app/lib/pricing.ts
@@ -8,7 +8,7 @@
  * `useExternalPremiumPrices` / `PremiumPrice`), not from any hardcoded literal.
  */
 
-import { currencyNumberFormat } from "./formatCurrency";
+import { formatCurrency } from "./formatCurrency";
 
 export type MembershipTier = "standard" | "premium";
 
@@ -21,25 +21,18 @@ export interface PremiumPrices {
   country_code: string | null;
 }
 
-// Prices arrive as minor units (e.g. cents/pence), so scale by the currency's
-// fraction digits before formatting.
-function currencyFractionDigits(currency: string): number {
-  return new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions().minimumFractionDigits ?? 2;
-}
-
 /**
  * Formats the monthly Premium price in the visitor's locale, e.g. "£6" or
  * "$9.99", using the currency's narrow symbol and no trailing zeroes.
+ *
+ * Prices arrive as Stripe minor units (e.g. cents/pence); formatCurrency owns
+ * the conversion to display units.
  */
 export function formatMonthlyPrice(prices: PremiumPrices): string {
-  const currency = prices.currency.toUpperCase();
-  const amount = prices.monthly / Math.pow(10, currencyFractionDigits(currency));
-
-  return currencyNumberFormat({
-    currency,
+  return formatCurrency(prices.monthly, prices.currency, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 2
-  }).format(amount);
+  });
 }
 
 // Helper to check if a tier includes another tier's features

--- a/app/tests/unit/components/common/PremiumPrice.test.tsx
+++ b/app/tests/unit/components/common/PremiumPrice.test.tsx
@@ -47,6 +47,13 @@ describe("PremiumPrice", () => {
     expect(container.textContent).not.toMatch(/149,900/);
   });
 
+  it("divides by 100 for a currency Intl reports as zero-decimal (RSD)", () => {
+    mockUser = { premium_prices: { currency: "rsd", monthly: 39900, annual: 399000, country_code: "RS" } };
+    const { container } = render(<PremiumPrice interval="monthly" />);
+    expect(container.textContent).toMatch(/399/);
+    expect(container.textContent).not.toMatch(/39,900/);
+  });
+
   it("handles uppercase currency from API", () => {
     mockUser = { premium_prices: { currency: "gbp", monthly: 799, annual: 7900, country_code: null } };
     const { container } = render(<PremiumPrice interval="monthly" />);

--- a/app/tests/unit/lib/formatCurrency.test.ts
+++ b/app/tests/unit/lib/formatCurrency.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for currency formatting of Stripe minor-unit amounts.
+ */
+
+import { currencyFractionDigits, formatCurrency } from "@/lib/formatCurrency";
+
+// formatCurrency formats in the runtime's default locale (Intl locale
+// `undefined`). Pin it to en-US so the assertions below don't depend on the
+// machine's system locale.
+const OriginalNumberFormat = Intl.NumberFormat;
+beforeAll(() => {
+  jest
+    .spyOn(Intl, "NumberFormat")
+    .mockImplementation((locales, options) => new OriginalNumberFormat(locales ?? "en-US", options));
+});
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+const PRICE_OPTIONS = { minimumFractionDigits: 0, maximumFractionDigits: 2 };
+
+describe("formatCurrency", () => {
+  it("scales a two-decimal currency by 100", () => {
+    expect(formatCurrency(799, "gbp", PRICE_OPTIONS)).toContain("7.99");
+  });
+
+  it("does not scale a Stripe zero-decimal currency", () => {
+    const result = formatCurrency(500, "jpy", PRICE_OPTIONS);
+    expect(result).toContain("500");
+    expect(result).not.toContain("5.00");
+  });
+
+  it("scales a Stripe three-decimal currency by 1000", () => {
+    expect(formatCurrency(1500, "kwd", { minimumFractionDigits: 3, maximumFractionDigits: 3 })).toContain("1.500");
+  });
+
+  it("scales a Stripe hundredfold zero-decimal currency by 100 (HUF)", () => {
+    const result = formatCurrency(149900, "huf", PRICE_OPTIONS);
+    expect(result).toContain("1,499");
+    expect(result).not.toContain("149,900");
+  });
+
+  // Intl/CLDR reports these as zero-decimal, but Stripe still bills them in
+  // 1/100ths. Trusting Intl for the divisor rendered them 100x too high.
+  it.each([
+    ["rsd", 39900, "399"],
+    ["isk", 39900, "399"],
+    ["all", 39900, "399"]
+  ])("scales %s by 100 despite Intl reporting it as zero-decimal", (currency, amount, expected) => {
+    const result = formatCurrency(amount, currency, PRICE_OPTIONS);
+    expect(result).toContain(expected);
+    expect(result).not.toContain("39,900");
+  });
+
+  it("accepts a lowercase currency code", () => {
+    expect(formatCurrency(1050, "eur", PRICE_OPTIONS)).toContain("10.5");
+  });
+
+  it("disambiguates dollar-family currencies", () => {
+    expect(formatCurrency(599, "sgd", PRICE_OPTIONS)).toMatch(/S\$/);
+    expect(formatCurrency(599, "usd", PRICE_OPTIONS)).not.toMatch(/US\$/);
+  });
+});
+
+describe("currencyFractionDigits", () => {
+  it("reports display digits for a two-decimal currency", () => {
+    expect(currencyFractionDigits("GBP")).toBe(2);
+  });
+
+  it("reports zero display digits for HUF despite Intl reporting two", () => {
+    expect(currencyFractionDigits("HUF")).toBe(0);
+  });
+
+  // RSD is billed in 1/100ths but displayed whole, so display digits and the
+  // minor-unit exponent deliberately diverge.
+  it("reports zero display digits for RSD", () => {
+    expect(currencyFractionDigits("RSD")).toBe(0);
+  });
+});

--- a/app/tests/unit/lib/formatCurrency.test.ts
+++ b/app/tests/unit/lib/formatCurrency.test.ts
@@ -71,9 +71,8 @@ describe("currencyFractionDigits", () => {
     expect(currencyFractionDigits("HUF")).toBe(0);
   });
 
-  // RSD is billed in 1/100ths but displayed whole, so display digits and the
-  // minor-unit exponent deliberately diverge.
-  it("reports zero display digits for RSD", () => {
-    expect(currencyFractionDigits("RSD")).toBe(0);
-  });
+  // Not asserted here: currencies like RSD, whose Intl answer depends on the
+  // engine's CLDR version (recent ICU says 0, older ICU says 2). That variance
+  // is exactly why minorUnitExponent must not be derived from Intl - see the
+  // formatCurrency cases above, which stay correct on either.
 });

--- a/app/tests/unit/lib/pricing.test.ts
+++ b/app/tests/unit/lib/pricing.test.ts
@@ -74,6 +74,13 @@ describe("formatMonthlyPrice", () => {
     expect(result).not.toContain(".00");
   });
 
+  it("scales a currency Intl reports as zero-decimal but Stripe bills in 1/100ths", () => {
+    // 39900 para -> RSD 399, not RSD 39,900
+    const result = formatMonthlyPrice(prices({ currency: "rsd", monthly: 39900, country_code: "RS" }));
+    expect(result).toContain("399");
+    expect(result).not.toContain("39,900");
+  });
+
   it("accepts a lowercase currency code", () => {
     // 1050 cents -> €10.50
     const result = formatMonthlyPrice(prices({ currency: "eur", monthly: 1050 }));

--- a/curriculum/src/concepts/using-functions/it.md
+++ b/curriculum/src/concepts/using-functions/it.md
@@ -4,7 +4,7 @@ description: "Dire a Jiki di avviare una delle sue piccole macchine scrivendo il
 en_md5: 007a425ced42fd3550bfdf9fe6f7b391
 ---
 
-Quando scrivi codice, quello che stai facendo in realtà è comunicare ciò che vuoi che accada, in un linguaggio che il computer capisce. Esistono tantissimi linguaggi di programmazione diversi, e tantissimi interpreti diversi che prendono quello che scrivi e lo trasformano nel codice binario che il computer riesce a capire. In questo corso ti accompagna Jiki. L'intero corso prende il suo nome: Jiki sarà il tuo amico in questo viaggio nella programmazione. Il suo compito è interpretare il codice che scrivi e convertirlo nelle sequenze di 0 e 1 su cui il computer può davvero agire.
+Quando scrivi codice, quello che stai facendo in realtà è comunicare ciò che vuoi che accada, in un linguaggio che il computer capisce. Esistono tantissimi linguaggi di programmazione diversi, e tantissimi interpreti diversi che prendono quello che scrivi e lo trasformano negli uni e zeri che il computer riesce a capire. In questo corso il tuo interprete è Jiki. Tutto il corso prende il nome da lui. Lui è Jiki. Jiki sarà il tuo amico in questo viaggio nella programmazione. Il suo compito è interpretare il codice che scrivi e trasformarlo negli uni e zeri su cui il computer può davvero agire.
 
 <img
   class="concept-image"
@@ -16,7 +16,7 @@ Quando scrivi codice, quello che stai facendo in realtà è comunicare ciò che 
 
 Il senso della programmazione è dare all'interprete, in questo caso Jiki, le istruzioni giuste. E le istruzioni che puoi dare a Jiki sono tantissime, ne capisce moltissime. Sa attaccare le cose tra loro, sa fare una cosa molte volte, sa dire: "Se succede questo, allora devo fare quest'altro". Sa ricordare le cose e riutilizzarle più tardi. E se qualcosa non va, sa segnalarti un errore. Nel corso vedremo tutte queste cose. Ma la cosa fondamentale da capire è che tutto quello che farai consiste nello scrivere istruzioni su una lavagna, che Jiki poi arriva a leggere e segue.
 
-Quando ho imparato a programmare, 34 anni fa, il modello mentale che mi sono costruito è questo, ed è lo stesso che ho ancora oggi. Capisco come funziona un computer fino al livello degli 0 e 1, ma sinceramente non ci penso mai. Nella mia testa, dentro il computer vive un ometto, e io gli dico cosa fare. Quindi seguimi su questa strada. È un modello mentale potente, che puoi costruirti anche tu, e se inizi a pensare in modo così visivo a quello che sta facendo la persona dentro il computer, ti sarà davvero molto utile mentre impari a programmare.
+Quando ho imparato a programmare, 34 anni fa, il modello mentale che mi sono costruito è questo, ed è lo stesso che ho ancora oggi. Capisco come funziona un computer fino agli uni e agli zeri, ma sinceramente non ci penso mai. Nella mia testa, dentro il computer vive un ometto, e io gli dico cosa fare. Quindi seguimi su questa strada. È un modello mentale potente, che puoi costruirti anche tu, e se inizi a pensare in modo così visivo a quello che sta facendo la persona dentro il computer, ti sarà davvero molto utile mentre impari a programmare.
 
 Allora iniziamo da uno dei concetti fondamentali della programmazione: le funzioni. Le funzioni sono come piccole macchine che puoi chiedere a Jiki di usare. E se diamo un'occhiata al magazzino di Jiki, il posto dove passa il suo tempo, vedrai che ha uno scaffale con tre macchine diverse sopra: `move` (muoviti), `turnLeft` (gira a sinistra) e `turnRight` (gira a destra).
 

--- a/curriculum/src/concepts/using-functions/it.md
+++ b/curriculum/src/concepts/using-functions/it.md
@@ -4,7 +4,7 @@ description: "Dire a Jiki di avviare una delle sue piccole macchine scrivendo il
 en_md5: 007a425ced42fd3550bfdf9fe6f7b391
 ---
 
-Quando scrivi codice, quello che stai facendo in realtà è comunicare ciò che vuoi che accada, in un linguaggio che il computer capisce. Esistono tantissimi linguaggi di programmazione diversi, e tantissimi interpreti diversi che prendono quello che scrivi e lo trasformano negli uni e zeri che il computer riesce a capire. In questo corso il tuo interprete è Jiki. Tutto il corso prende il nome da lui. Lui è Jiki. Jiki sarà il tuo amico in questo viaggio nella programmazione. Il suo compito è interpretare il codice che scrivi e trasformarlo negli uni e zeri su cui il computer può davvero agire.
+Quando scrivi codice, quello che stai facendo in realtà è comunicare ciò che vuoi che accada, in un linguaggio che il computer capisce. Esistono tantissimi linguaggi di programmazione diversi, e tantissimi interpreti diversi che prendono quello che scrivi e lo trasformano nel codice binario che il computer riesce a capire. In questo corso ti accompagna Jiki. L'intero corso prende il suo nome: Jiki sarà il tuo amico in questo viaggio nella programmazione. Il suo compito è interpretare il codice che scrivi e convertirlo nelle sequenze di 0 e 1 su cui il computer può davvero agire.
 
 <img
   class="concept-image"
@@ -16,7 +16,7 @@ Quando scrivi codice, quello che stai facendo in realtà è comunicare ciò che 
 
 Il senso della programmazione è dare all'interprete, in questo caso Jiki, le istruzioni giuste. E le istruzioni che puoi dare a Jiki sono tantissime, ne capisce moltissime. Sa attaccare le cose tra loro, sa fare una cosa molte volte, sa dire: "Se succede questo, allora devo fare quest'altro". Sa ricordare le cose e riutilizzarle più tardi. E se qualcosa non va, sa segnalarti un errore. Nel corso vedremo tutte queste cose. Ma la cosa fondamentale da capire è che tutto quello che farai consiste nello scrivere istruzioni su una lavagna, che Jiki poi arriva a leggere e segue.
 
-Quando ho imparato a programmare, 34 anni fa, il modello mentale che mi sono costruito è questo, ed è lo stesso che ho ancora oggi. Capisco come funziona un computer fino agli uni e agli zeri, ma sinceramente non ci penso mai. Nella mia testa, dentro il computer vive un ometto, e io gli dico cosa fare. Quindi seguimi su questa strada. È un modello mentale potente, che puoi costruirti anche tu, e se inizi a pensare in modo così visivo a quello che sta facendo la persona dentro il computer, ti sarà davvero molto utile mentre impari a programmare.
+Quando ho imparato a programmare, 34 anni fa, il modello mentale che mi sono costruito è questo, ed è lo stesso che ho ancora oggi. Capisco come funziona un computer fino al livello degli 0 e 1, ma sinceramente non ci penso mai. Nella mia testa, dentro il computer vive un ometto, e io gli dico cosa fare. Quindi seguimi su questa strada. È un modello mentale potente, che puoi costruirti anche tu, e se inizi a pensare in modo così visivo a quello che sta facendo la persona dentro il computer, ti sarà davvero molto utile mentre impari a programmare.
 
 Allora iniziamo da uno dei concetti fondamentali della programmazione: le funzioni. Le funzioni sono come piccole macchine che puoi chiedere a Jiki di usare. E se diamo un'occhiata al magazzino di Jiki, il posto dove passa il suo tempo, vedrai che ha uno scaffale con tre macchine diverse sopra: `move` (muoviti), `turnLeft` (gira a sinistra) e `turnRight` (gira a destra).
 


### PR DESCRIPTION
## Problem

Reported by aleksaelezovic: `/premium` showed Serbian users **RSD 39,900** instead of **RSD 399**. The charge itself was correct (399,00 RSD) — this was display only.

Stripe minor units were converted to display units using `Intl`/CLDR's fraction digits, but the two tables disagree. CLDR calls RSD zero-decimal (para are obsolete for display), so the divide-by-100 was skipped and the raw `39900` was rendered.

RSD isn't alone. Every currency where CLDR says 0 decimals but Stripe still bills in 1/100ths was affected:

`AFN, ALL, IQD, IRR, ISK, KPW, LAK, LBP, MMK, RSD, SLL, SOS, SYP, YER`

## Fix

`minorUnitExponent` in `lib/formatCurrency.ts` now uses Stripe's own zero-decimal and three-decimal tables instead of asking `Intl`. Display digits (`currencyFractionDigits`) stay Intl-driven — RSD is correctly *shown* whole even though it's *billed* in para, so the two deliberately diverge.

Also drops the duplicate, un-special-cased copy of this logic in `lib/pricing.ts`. `formatMonthlyPrice` now delegates to `formatCurrency`, which as a side effect gives the landing page and logged-out `/premium` the `S$`/`CA$` disambiguation the signed-in price already had.

## Test plan

- [x] New `tests/unit/lib/formatCurrency.test.ts` covering all four Stripe currency classes, with regression cases for RSD/ISK/ALL
- [x] Regression cases added to `pricing.test.ts` and `PremiumPrice.test.tsx`
- [x] Full unit suite passes (2148 tests)
- [x] `tsc --noEmit` clean, lint clean

Before/after for RSD: `RSD 39,900` → `RSD 399` monthly, `RSD 399,000` → `RSD 3,990` annual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5zdg2yTP5yaanzvGyw88y