### PR TITLE
Restore orange palette lost when Tailwind was removed

### DIFF
--- a/app/app/(app)/achievements/BadgeCard/ColorThemes.module.css
+++ b/app/app/(app)/achievements/BadgeCard/ColorThemes.module.css
@@ -8,7 +8,7 @@
 }
 
 .card.earned.gold:not(.new) {
-    border-color: var(--color-gold-700);
+    border-color: var(--color-amber-700);
 }
 
 /* Amber theme for recently revealed badges */

--- a/app/app/styles/theme/colors.css
+++ b/app/app/styles/theme/colors.css
@@ -76,8 +76,19 @@
     --color-red-900: #7f1d1d;
     --color-red-950: #450a0a;
 
-    /* Orange Scale extension */
+    /* Orange Scale */
     --color-orange-30: #fffaf3;
+    --color-orange-50: #fff7ed;
+    --color-orange-100: #ffedd5;
+    --color-orange-200: #fed7aa;
+    --color-orange-300: #fdba74;
+    --color-orange-400: #fb923c;
+    --color-orange-500: #f97316;
+    --color-orange-600: #ea580c;
+    --color-orange-700: #c2410c;
+    --color-orange-800: #9a3412;
+    --color-orange-900: #7c2d12;
+    --color-orange-950: #431407;
 
     /* Amber/Yellow Scale */
     --color-amber-50: #fffbeb;
@@ -176,7 +187,9 @@
     --color-button-primary-bg: #8b5cf6;
     --color-button-primary-text: white;
     --color-button-secondary-bg: var(--color-gray-100);
+    --color-button-secondary-bg-hover: var(--color-gray-200);
     --color-button-secondary-text: var(--color-gray-700);
+    --color-button-secondary-border: var(--color-gray-300);
     --color-link-primary: var(--color-blue-600);
     --color-link-hover: var(--color-blue-700);
 
@@ -219,7 +232,9 @@
     --color-button-primary-bg: #8b5cf6;
     --color-button-primary-text: white;
     --color-button-secondary-bg: #374151;
+    --color-button-secondary-bg-hover: #4b5563;
     --color-button-secondary-text: var(--color-gray-300);
+    --color-button-secondary-border: var(--color-gray-600);
     --color-link-primary: var(--color-blue-400);
     --color-link-hover: var(--color-blue-300);
 

--- a/app/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css
+++ b/app/lib/modal/modals/PremiumUpgradeModal/PremiumUpgradeModal.module.css
@@ -47,11 +47,7 @@
 }
 
 .mainHeading .highlight {
-    background: linear-gradient(
-        135deg,
-        var(--color-purple-500, #8b5cf6) 0%,
-        var(--color-primary-500, var(--color-blue-500)) 100%
-    );
+    background: linear-gradient(135deg, var(--color-purple-500, #8b5cf6) 0%, var(--color-blue-500) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;


### PR DESCRIPTION
Fixes the missing lint-warning colours reported at https://forum.jiki.io/t/no-colors-in-niche-named-party-milestone-12/954 ("scenarios don't turn green, they turn white" + missing squiggly underlines).

## Root cause

`e1ba4db8` ("Migrate remaining tw to css modules", #972) removed the last `@import "tailwindcss"`. Tailwind v4 had been implicitly supplying its default theme variables, and `colors.css` **never defined an orange scale of its own** — only a stray `--color-orange-30`. Confirmed with `git log -S"--color-orange-500:" --all`, which returns no commits.

Every `var(--color-orange-*)` reference therefore became unresolved. An unresolved custom property makes the entire declaration invalid-at-computed-value-time, so the property falls back to its inherited/initial value.

## Why that produced exactly the two reported symptoms

Both are the `lint_warning` status, the only orange-coded state:

- `CodingExercise.module.css:303` — `.Dot.lint_warning { background: var(--color-orange-500) }` → no background → the scenario dot renders **white**. The reporter's scenario was passing *with a lint warning*, not plain-passing. Same for `.StatusLine.lint_warning` (:239) and `.scenarioButton.lint_warning` (:459).
- `lintDecorations.ts:107` — `textDecoration: "wavy underline var(--color-orange-500)"` → the whole shorthand is invalid → **no underline drawn at all**, plus dead tooltip styling on :112-143.

The red syntax-error underline survived only because `.cm-underline` hardcodes `underline 2px red` rather than using a var — which is why *only* the orange affordances vanished.

## Changes

CSS only, 3 files:

- **`colors.css`** — adds the orange 50-950 scale using the values Tailwind had been providing, so this restores the exact pre-#972 appearance. Keeps `--color-orange-30`.
- **`colors.css`** — adds `--color-button-secondary-bg-hover` / `--color-button-secondary-border` to both the light and dark blocks, built from existing gray tokens.
- **`ColorThemes.module.css`** — `--color-gold-700` → `--color-amber-700`.
- **`PremiumUpgradeModal.module.css`** — drops the phantom `--color-primary-500`, using `--color-blue-500` directly (already its inline fallback, so no visual change).

`gold-700` and `primary-500` were pre-existing dead tokens unrelated to this regression — no gold or primary palette has ever existed. Pointed at canonical palette entries rather than inventing new ones.

## Verification

An audit of every `var(--color-*)` used across `app/`, `components/` and `lib/` against every definition now returns **zero** undefined tokens (was 12). Full unit suite passes (2147 tests).

Worth eyeballing a lint-warning scenario in the dev server before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xg4aFqFqCH3XoM8io7Q6zL