### PR TITLE
maze-automated-solve: add missing comma in instructions

### DIFF
--- a/curriculum/src/exercises/maze-automated-solve/instructions/hu.md
+++ b/curriculum/src/exercises/maze-automated-solve/instructions/hu.md
@@ -13,7 +13,7 @@ To make that possible, you have three new functions:
 
 When we match those up with the `move()`, `turnLeft()` and `turnRight()` you had before, it's possible to write an algorithm to solve **any** maze. "Algorithm" is a posh word that just means "a way of doing something". It's like a formula or a recipe.
 
-Further down in the instructions, I'll tell you the algorithm ready for you to solve. But I want you to try and work it out yourself first as a little logic puzzle. If you know whether you can turn left right or move ahead, how can you solve any maze I give you?
+Further down in the instructions, I'll tell you the algorithm ready for you to solve. But I want you to try and work it out yourself first as a little logic puzzle. If you know whether you can turn left, right or move ahead, how can you solve any maze I give you?
 
 Once you've got it, or given up, scroll down to see the answer and what you need to write in code.
 

--- a/curriculum/src/exercises/maze-automated-solve/instructions/source.md
+++ b/curriculum/src/exercises/maze-automated-solve/instructions/source.md
@@ -13,7 +13,7 @@ To make that possible, you have three new functions:
 
 When we match those up with the <define>`move()`</define>, <define>`turnLeft()`</define> and <define>`turnRight()`</define> you had before, it's possible to write an algorithm to solve **any** maze. "Algorithm" is a posh word that just means "a way of doing something". It's like a formula or a recipe.
 
-Further down in the instructions, I'll tell you the algorithm ready for you to solve. But I want you to try and work it out yourself first as a little logic puzzle. If you know whether you can turn left right or move ahead, how can you solve any maze I give you?
+Further down in the instructions, I'll tell you the algorithm ready for you to solve. But I want you to try and work it out yourself first as a little logic puzzle. If you know whether you can turn left, right or move ahead, how can you solve any maze I give you?
 
 Once you've got it, or given up, scroll down to see the answer and what you need to write in code.
 


### PR DESCRIPTION
Fixes a forum-reported typo in the "Solve the Maze Programmatically" instructions.

Reported by petrem on the [forum](https://forum.jiki.io/t/solve-the-mase-programatically-trivial-missing-comma/1017):

> If you know whether you can turn left right or move ahead

Now reads "turn left, right or move ahead".

Applied to the English `source.md` and to `hu.md`, which is still an untranslated copy of the English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1R2cq5VgBn4d1p5AGUVcn