### PR TITLE
i18n: translate the code editor's error tooltip and breakpoint gutter chrome

### DIFF
--- a/app/components/coding-exercise/lib/Orchestrator.ts
+++ b/app/components/coding-exercise/lib/Orchestrator.ts
@@ -39,6 +39,10 @@ class Orchestrator {
   // useExerciseLoader (fetched in the blocking load); tests default to an empty
   // dict, which resolves keys as-is.
   private readonly exerciseLocaleMessages: CurriculumMessages;
+  // Translator for the `codingExercise` namespace. Held so it can be handed to the
+  // EditorManager (and from there to the CodeMirror extensions), which are built
+  // outside the React tree and so cannot call `useTranslations()` themselves.
+  private readonly t: CodingExerciseTranslator;
 
   constructor(
     exercise: ExerciseDefinition,
@@ -56,6 +60,7 @@ class Orchestrator {
     this.contentHash = contentHash;
     this.interpreterLocaleMessages = interpreterLocaleMessages;
     this.exerciseLocaleMessages = exerciseLocaleMessages;
+    this.t = t;
 
     // Create instance-specific store with exercise, language, and context
     this.store = createOrchestratorStore(exercise, language, context, onGoToDashboard);
@@ -106,6 +111,7 @@ class Orchestrator {
             this.exercise.slug,
             this.store.getState().code,
             this.getStoredOrDefaultReadonlyRanges(),
+            this.t,
             this.runCode.bind(this),
             (code: string) => this.lintCodeDebounced(code)
           );

--- a/app/components/coding-exercise/lib/orchestrator/EditorManager.ts
+++ b/app/components/coding-exercise/lib/orchestrator/EditorManager.ts
@@ -36,6 +36,7 @@ import { updateUnfoldableFunctions } from "../../ui/codemirror/utils/unfoldableF
 import type { ReadonlyRange } from "@jiki/curriculum";
 import { saveCodeMirrorContent } from "../localStorage";
 import type { InformationWidgetData, OrchestratorStore, UnderlineRange } from "../types";
+import type { CodingExerciseTranslator } from "../test-results-types";
 
 export class EditorManager {
   readonly editorView: EditorView;
@@ -48,6 +49,10 @@ export class EditorManager {
     private readonly exerciseSlug: string,
     code: string,
     readonlyRanges: ReadonlyRange[],
+    // Translator for the `codingExercise` namespace, threaded down from the
+    // Orchestrator so the CodeMirror extensions (built outside React) can resolve
+    // their own copy.
+    private readonly t: CodingExerciseTranslator,
     private readonly runCode: (code: string) => void,
     private readonly lintCode?: (code: string) => void
   ) {
@@ -75,7 +80,8 @@ export class EditorManager {
       onBreakpointChange,
       onFoldChange,
       onEditorChange,
-      onCloseInfoWidget
+      onCloseInfoWidget,
+      t: this.t
     });
 
     // Create editor view directly with the element

--- a/app/components/coding-exercise/ui/codemirror/extensions/breakpoint.ts
+++ b/app/components/coding-exercise/ui/codemirror/extensions/breakpoint.ts
@@ -1,6 +1,7 @@
 import { RangeSet, StateEffect, StateField } from "@codemirror/state";
 import type { Range } from "@codemirror/state";
 import { EditorView, gutter, GutterMarker, lineNumbers } from "@codemirror/view";
+import type { CodingExerciseTranslator } from "../../../lib/test-results-types";
 
 export const breakpointEffect = StateEffect.define<{
   pos: number;
@@ -43,103 +44,124 @@ function toggleBreakpoint(view: EditorView, pos: number) {
   });
 }
 
-const breakpointMarker = new (class extends GutterMarker {
+// The `title` is the marker's hover tooltip, so it is user-facing copy and has to be
+// translated. Gutter markers are built outside the React tree, so the translator is
+// injected when the extension is created rather than read from a hook.
+class BreakpointMarker extends GutterMarker {
+  constructor(private readonly title?: string) {
+    super();
+  }
   toDOM() {
     const dot = document.createElement("div");
     dot.classList.add("cm-breakpoint-marker");
-    dot.title = "Remove breakpoint";
-    return dot;
-  }
-})();
-
-class IdleMarker extends GutterMarker {
-  toDOM() {
-    const dot = document.createElement("div");
-    dot.classList.add("cm-idle-marker");
-    dot.title = "Add breakpoint";
+    if (this.title !== undefined) {
+      dot.title = this.title;
+    }
     return dot;
   }
 }
 
-const idleMarker = new IdleMarker();
+class IdleMarker extends GutterMarker {
+  constructor(private readonly title?: string) {
+    super();
+  }
+  toDOM() {
+    const dot = document.createElement("div");
+    dot.classList.add("cm-idle-marker");
+    if (this.title !== undefined) {
+      dot.title = this.title;
+    }
+    return dot;
+  }
+}
 
-export const breakpointGutter = [
-  breakpointState,
-  gutter({
-    class: "cm-breakpoint-gutter",
-    markers: (view) => {
-      const breakpoints = view.state.field(breakpointState);
-      const markers: Range<GutterMarker>[] = [];
+// The marker stored in `breakpointState` is never the one the gutter renders (the
+// gutter rebuilds its own markers from the range set on every redraw), so this
+// untitled instance exists purely to occupy the range and needs no translator.
+const breakpointMarker = new BreakpointMarker();
 
-      for (let i = 1; i <= view.state.doc.lines; i++) {
-        const pos = view.state.doc.line(i).from;
-        let hasBreakpoint = false;
+export function breakpointGutter(t: CodingExerciseTranslator) {
+  const activeMarker = new BreakpointMarker(t("breakpointGutter.removeBreakpoint"));
+  const idleMarker = new IdleMarker(t("breakpointGutter.addBreakpoint"));
 
-        breakpoints.between(pos, pos, (from) => {
-          if (from === pos) {
-            hasBreakpoint = true;
+  return [
+    breakpointState,
+    gutter({
+      class: "cm-breakpoint-gutter",
+      markers: (view) => {
+        const breakpoints = view.state.field(breakpointState);
+        const markers: Range<GutterMarker>[] = [];
+
+        for (let i = 1; i <= view.state.doc.lines; i++) {
+          const pos = view.state.doc.line(i).from;
+          let hasBreakpoint = false;
+
+          breakpoints.between(pos, pos, (from) => {
+            if (from === pos) {
+              hasBreakpoint = true;
+            }
+          });
+
+          // TODO: Review why this is always falsy
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          markers.push((hasBreakpoint ? activeMarker : idleMarker).range(pos));
+        }
+
+        return RangeSet.of(markers);
+      },
+      initialSpacer: () => activeMarker,
+      domEventHandlers: {
+        mousedown(view, line) {
+          toggleBreakpoint(view, line.from);
+          return true;
+        }
+      }
+    }),
+    lineNumbers({
+      domEventHandlers: {
+        mousedown(view, line) {
+          toggleBreakpoint(view, line.from);
+          return true;
+        },
+        mousemove(view, line) {
+          const lineNumber = view.state.doc.lineAt(line.from).number;
+          document.querySelectorAll(".hovered-idle-marker").forEach((el) => {
+            el.classList.remove("hovered-idle-marker");
+          });
+
+          const breakpointMarkerElement = view.dom.querySelector(
+            `.cm-breakpoint-gutter .cm-gutterElement:nth-child(${lineNumber + 1}) .cm-idle-marker`
+          );
+
+          if (breakpointMarkerElement) {
+            breakpointMarkerElement.classList.add("hovered-idle-marker");
+            return true;
           }
-        });
+          return false;
+        },
+        mouseleave(view) {
+          const breakpointMarkerElement = view.dom.querySelectorAll(
+            `.cm-breakpoint-gutter .cm-gutterElement .cm-idle-marker`
+          );
 
-        // TODO: Review why this is always falsy
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        markers.push((hasBreakpoint ? breakpointMarker : idleMarker).range(pos));
-      }
-
-      return RangeSet.of(markers);
-    },
-    initialSpacer: () => breakpointMarker,
-    domEventHandlers: {
-      mousedown(view, line) {
-        toggleBreakpoint(view, line.from);
-        return true;
-      }
-    }
-  }),
-  lineNumbers({
-    domEventHandlers: {
-      mousedown(view, line) {
-        toggleBreakpoint(view, line.from);
-        return true;
-      },
-      mousemove(view, line) {
-        const lineNumber = view.state.doc.lineAt(line.from).number;
-        document.querySelectorAll(".hovered-idle-marker").forEach((el) => {
-          el.classList.remove("hovered-idle-marker");
-        });
-
-        const breakpointMarkerElement = view.dom.querySelector(
-          `.cm-breakpoint-gutter .cm-gutterElement:nth-child(${lineNumber + 1}) .cm-idle-marker`
-        );
-
-        if (breakpointMarkerElement) {
-          breakpointMarkerElement.classList.add("hovered-idle-marker");
-          return true;
+          // Check if it's valid that it's always truthy
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (breakpointMarkerElement) {
+            breakpointMarkerElement.forEach((el) => el.classList.remove("hovered-idle-marker"));
+            return true;
+          }
+          return false;
         }
-        return false;
-      },
-      mouseleave(view) {
-        const breakpointMarkerElement = view.dom.querySelectorAll(
-          `.cm-breakpoint-gutter .cm-gutterElement .cm-idle-marker`
-        );
-
-        // Check if it's valid that it's always truthy
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (breakpointMarkerElement) {
-          breakpointMarkerElement.forEach((el) => el.classList.remove("hovered-idle-marker"));
-          return true;
-        }
-        return false;
       }
-    }
-  }),
-  EditorView.baseTheme({
-    ".cm-breakpoint-gutter .cm-gutterElement": {
-      display: "grid",
-      placeContent: "center"
-    },
-    ".cm-lineNumbers .cm-gutterElement": {
-      cursor: "pointer"
-    }
-  })
-];
+    }),
+    EditorView.baseTheme({
+      ".cm-breakpoint-gutter .cm-gutterElement": {
+        display: "grid",
+        placeContent: "center"
+      },
+      ".cm-lineNumbers .cm-gutterElement": {
+        cursor: "pointer"
+      }
+    })
+  ];
+}

--- a/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/information-widget.ts
+++ b/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/information-widget.ts
@@ -11,6 +11,7 @@ import { addHighlight, removeAllHighlightEffect } from "../edit-editor/highlight
 import { cleanupAllInformationTooltips } from "./cleanup";
 import closeButtonStyles from "@/components/ui-kit/CloseButton/CloseButton.module.css";
 import tooltipStyles from "./informationTooltip.module.css";
+import type { CodingExerciseTranslator } from "../../../../lib/test-results-types";
 
 export class InformationWidget extends WidgetType {
   private tooltip: HTMLElement | null = null;
@@ -24,7 +25,11 @@ export class InformationWidget extends WidgetType {
     private readonly tooltipHtml: string,
     private readonly status: "ERROR" | "SUCCESS",
     private readonly view: EditorView,
-    private readonly onClose: (view: EditorView) => void
+    private readonly onClose: (view: EditorView) => void,
+    // CodeMirror widgets are built outside the React tree, so `useTranslations()`
+    // is unreachable here. The translator is threaded down from the component that
+    // creates the orchestrator, the same rail the test runner already uses.
+    private readonly t: CodingExerciseTranslator
   ) {
     super();
   }
@@ -78,7 +83,7 @@ export class InformationWidget extends WidgetType {
             <path d="M12 7V13" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
             <circle cx="12" cy="16.5" r="1" fill="currentColor" />
           </svg>
-          Oops, something went wrong!
+          ${this.t("informationTooltip.errorHeading")}
         </div>
         ${this.tooltipHtml}
       `.trim();
@@ -97,7 +102,7 @@ export class InformationWidget extends WidgetType {
     closeButton.classList.add(closeButtonStyles.small);
     // Add light variant for all tooltips (both have white/light backgrounds)
     closeButton.classList.add(closeButtonStyles.light);
-    closeButton.setAttribute("aria-label", "Close tooltip");
+    closeButton.setAttribute("aria-label", this.t("informationTooltip.closeAriaLabel"));
     closeButton.onclick = () => {
       this.onClose(this.view);
     };

--- a/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/line-information.ts
+++ b/app/components/coding-exercise/ui/codemirror/extensions/end-line-information/line-information.ts
@@ -6,6 +6,7 @@ import { highlightedLineField } from "../lineHighlighter";
 import { placeholderTheme } from "../placeholder-widget";
 import { cleanupAllInformationTooltips } from "./cleanup";
 import { InformationWidget } from "./information-widget";
+import type { CodingExerciseTranslator } from "../../../../lib/test-results-types";
 
 export const showInfoWidgetEffect = StateEffect.define<boolean>();
 
@@ -47,7 +48,11 @@ export const informationWidgetDataField = StateField.define<InformationWidgetDat
   }
 });
 
-function lineInformationWidget(view: EditorView, onClose: (view: EditorView) => void): DecorationSet {
+function lineInformationWidget(
+  view: EditorView,
+  onClose: (view: EditorView) => void,
+  t: CodingExerciseTranslator
+): DecorationSet {
   const widgets: Range<Decoration>[] = [];
 
   const shouldShowWidget = view.state.field(showInfoWidgetField);
@@ -65,7 +70,7 @@ function lineInformationWidget(view: EditorView, onClose: (view: EditorView) => 
   const { html, status } = widgetData;
 
   const deco = Decoration.widget({
-    widget: new InformationWidget(html, status, view, onClose),
+    widget: new InformationWidget(html, status, view, onClose, t),
     side: 1
   });
 
@@ -79,9 +84,11 @@ function lineInformationWidget(view: EditorView, onClose: (view: EditorView) => 
 class EndlineDecoration {
   placeholders: DecorationSet;
   onClose: (view: EditorView) => void;
-  constructor(view: EditorView, onClose: (view: EditorView) => void) {
+  t: CodingExerciseTranslator;
+  constructor(view: EditorView, onClose: (view: EditorView) => void, t: CodingExerciseTranslator) {
     this.onClose = onClose;
-    this.placeholders = lineInformationWidget(view, this.onClose);
+    this.t = t;
+    this.placeholders = lineInformationWidget(view, this.onClose, this.t);
   }
   update(update: ViewUpdate) {
     if (
@@ -91,15 +98,15 @@ class EndlineDecoration {
       update.startState.field(showInfoWidgetField) !== update.state.field(showInfoWidgetField) ||
       update.startState.field(informationWidgetDataField) !== update.state.field(informationWidgetDataField)
     ) {
-      this.placeholders = lineInformationWidget(update.view, this.onClose);
+      this.placeholders = lineInformationWidget(update.view, this.onClose, this.t);
     }
   }
 }
 
-function endlineDecoration(onClose: (view: EditorView) => void) {
+function endlineDecoration(onClose: (view: EditorView) => void, t: CodingExerciseTranslator) {
   return ViewPlugin.define(
     (view) => {
-      return new EndlineDecoration(view, onClose);
+      return new EndlineDecoration(view, onClose, t);
     },
     {
       decorations: (instance) => instance.placeholders,
@@ -112,6 +119,12 @@ function endlineDecoration(onClose: (view: EditorView) => void) {
   );
 }
 
-export function lineInformationExtension({ onClose }: { onClose: (view: EditorView) => void }) {
-  return [placeholderTheme, endlineDecoration(onClose)];
+export function lineInformationExtension({
+  onClose,
+  t
+}: {
+  onClose: (view: EditorView) => void;
+  t: CodingExerciseTranslator;
+}) {
+  return [placeholderTheme, endlineDecoration(onClose, t)];
 }

--- a/app/components/coding-exercise/ui/codemirror/setup/editorExtensions.ts
+++ b/app/components/coding-exercise/ui/codemirror/setup/editorExtensions.ts
@@ -23,6 +23,7 @@ import { readonlyCompartment, languageCompartment } from "./editorCompartments";
 
 import type { Extension } from "@codemirror/state";
 import type { Language } from "@jiki/curriculum";
+import type { CodingExerciseTranslator } from "../../../lib/test-results-types";
 
 // Get language extension based on language string
 export function getLanguageExtension(language: Language): Extension {
@@ -46,6 +47,9 @@ export interface EditorExtensionsConfig {
   onFoldChange: Extension;
   onEditorChange: Extension;
   onCloseInfoWidget: () => void;
+  // Translator for the `codingExercise` namespace. CodeMirror extensions are built
+  // outside the React tree, so it is injected here rather than read from a hook.
+  t: CodingExerciseTranslator;
   isDarkTheme?: boolean;
 }
 
@@ -57,6 +61,7 @@ export function createEditorExtensions({
   onFoldChange,
   onEditorChange,
   onCloseInfoWidget,
+  t,
   isDarkTheme = false
 }: EditorExtensionsConfig) {
   return [
@@ -77,7 +82,7 @@ export function createEditorExtensions({
     crosshairCursor(),
 
     // Custom extensions
-    Ext.breakpointGutter,
+    Ext.breakpointGutter(t),
     Ext.foldGutter,
     Ext.underlineExtension(),
     Ext.readOnlyRangeDecoration(),
@@ -89,7 +94,8 @@ export function createEditorExtensions({
     Ext.showInfoWidgetField,
     Ext.informationWidgetDataField,
     Ext.lineInformationExtension({
-      onClose: onCloseInfoWidget
+      onClose: onCloseInfoWidget,
+      t
     }),
     Ext.multiHighlightLine([]),
     Ext.cursorTooltip(),

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1596,6 +1596,14 @@
       "congratsCongratulations": "Congratulations!",
       "congratsCongrats": "Congrats!"
     },
+    "informationTooltip": {
+      "errorHeading": "Oops, something went wrong!",
+      "closeAriaLabel": "Close tooltip"
+    },
+    "breakpointGutter": {
+      "addBreakpoint": "Add breakpoint",
+      "removeBreakpoint": "Remove breakpoint"
+    },
     "syntaxError": {
       "heading": "Jiki couldn't understand your code.",
       "message": "No need to panic. Read and fix the error in the message above, and then run the code again."

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -1596,6 +1596,14 @@
       "congratsCongratulations": "Gratulálunk!",
       "congratsCongrats": "Gratula!"
     },
+    "informationTooltip": {
+      "errorHeading": "�",
+      "closeAriaLabel": "�"
+    },
+    "breakpointGutter": {
+      "addBreakpoint": "�",
+      "removeBreakpoint": "�"
+    },
     "syntaxError": {
       "heading": "Jiki nem értette a kódodat.",
       "message": "Semmi pánik! Olvasd el és javítsd ki a fenti üzenetben jelzett hibát, majd futtasd újra a kódot."

--- a/app/tests/unit/components/coding-exercise/orchestrator/EditorManager.test.ts
+++ b/app/tests/unit/components/coding-exercise/orchestrator/EditorManager.test.ts
@@ -115,6 +115,7 @@ import { createOrchestratorStore } from "@/components/coding-exercise/lib/orches
 import { EditorManager, clampRangesToDoc } from "@/components/coding-exercise/lib/orchestrator/EditorManager";
 import type { ReadonlyRange } from "@jiki/curriculum";
 import { createMockExercise } from "@/tests/mocks/exercise";
+import { makeTestTranslator } from "@/tests/test-utils/makeTestTranslator";
 import type { EditorView } from "@codemirror/view";
 
 describe("EditorManager", () => {
@@ -133,7 +134,15 @@ describe("EditorManager", () => {
 
     // Set the values in the store that EditorManager will read
 
-    editorManager = new EditorManager(mockElement, store, "test-uuid", "const x = 1;", [], mockRunCode);
+    editorManager = new EditorManager(
+      mockElement,
+      store,
+      "test-uuid",
+      "const x = 1;",
+      [],
+      makeTestTranslator(),
+      mockRunCode
+    );
   });
 
   describe("constructor", () => {

--- a/app/tests/unit/components/coding-exercise/ui/codemirror/extensions/breakpoint.test.ts
+++ b/app/tests/unit/components/coding-exercise/ui/codemirror/extensions/breakpoint.test.ts
@@ -4,6 +4,11 @@ import {
   breakpointState,
   breakpointGutter
 } from "@/components/coding-exercise/ui/codemirror/extensions/breakpoint";
+import { makeTestTranslator } from "@/tests/test-utils/makeTestTranslator";
+
+// `breakpointGutter` is now a factory that takes the injected translator (the gutter
+// markers' hover titles are user-facing copy), so build it once for these tests.
+const breakpointGutterExtension = breakpointGutter(makeTestTranslator());
 
 // Mock DOM methods
 const mockCreateElement = jest.fn(() => ({
@@ -225,18 +230,18 @@ describe("breakpoint extension", () => {
 
   describe("breakpointGutter", () => {
     it("should be an array of extensions", () => {
-      expect(Array.isArray(breakpointGutter)).toBe(true);
-      expect(breakpointGutter.length).toBeGreaterThan(0);
+      expect(Array.isArray(breakpointGutterExtension)).toBe(true);
+      expect(breakpointGutterExtension.length).toBeGreaterThan(0);
     });
 
     it("should include breakpointState", () => {
-      expect(breakpointGutter).toContain(breakpointState);
+      expect(breakpointGutterExtension).toContain(breakpointState);
     });
 
     it("should work with CodeMirror state", () => {
       const state = EditorState.create({
         doc: "line1\nline2\nline3",
-        extensions: breakpointGutter
+        extensions: breakpointGutterExtension
       });
 
       expect(state).toBeDefined();
@@ -250,7 +255,7 @@ describe("breakpoint extension", () => {
     it("should handle breakpoint operations when used as full extension", () => {
       const state = EditorState.create({
         doc: "line1\nline2\nline3\nline4",
-        extensions: breakpointGutter
+        extensions: breakpointGutterExtension
       });
 
       // Add multiple breakpoints
@@ -276,7 +281,7 @@ describe("breakpoint extension", () => {
     it("should toggle breakpoints correctly", () => {
       const state = EditorState.create({
         doc: "line1\nline2\nline3",
-        extensions: breakpointGutter
+        extensions: breakpointGutterExtension
       });
 
       const pos = 0;
@@ -316,7 +321,7 @@ describe("breakpoint extension", () => {
     it("should handle edge cases", () => {
       const state = EditorState.create({
         doc: "short",
-        extensions: breakpointGutter
+        extensions: breakpointGutterExtension
       });
 
       // Try to add breakpoint beyond document length
@@ -413,7 +418,7 @@ describe("breakpoint extension", () => {
         createBreakpointEditor: (content: string) => {
           return EditorState.create({
             doc: content,
-            extensions: breakpointGutter
+            extensions: breakpointGutterExtension
           });
         },
 
@@ -499,7 +504,7 @@ describe("breakpoint extension", () => {
             const content = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`).join("\n");
             let state = EditorState.create({
               doc: content,
-              extensions: breakpointGutter
+              extensions: breakpointGutterExtension
             });
 
             // Add breakpoints on every 5th line

--- a/app/tests/unit/components/coding-exercise/ui/codemirror/extensions/end-line-information/information-widget.test.ts
+++ b/app/tests/unit/components/coding-exercise/ui/codemirror/extensions/end-line-information/information-widget.test.ts
@@ -1,0 +1,68 @@
+import { EditorState } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import { InformationWidget } from "@/components/coding-exercise/ui/codemirror/extensions/end-line-information/information-widget";
+import type { CodingExerciseTranslator } from "@/components/coding-exercise/lib/test-results-types";
+import { makeTestTranslator } from "@/tests/test-utils/makeTestTranslator";
+
+// CodeMirror widgets live outside the React tree, so their copy comes from a
+// translator injected at construction rather than from `useTranslations()`. These
+// tests pin that: the chrome must come from the translator, never from a literal.
+function createMockView(): EditorView {
+  const dom = document.createElement("div");
+  document.body.appendChild(dom);
+  return {
+    dom,
+    state: EditorState.create({ doc: "test content" }),
+    dispatch: jest.fn()
+  } as unknown as EditorView;
+}
+
+function renderWidget(status: "ERROR" | "SUCCESS", t: CodingExerciseTranslator) {
+  const widget = new InformationWidget("<p>body</p>", status, createMockView(), jest.fn(), t);
+  widget.toDOM();
+  const tooltip = document.body.querySelector<HTMLElement>("[class*='informationTooltip']");
+  return { widget, tooltip };
+}
+
+describe("InformationWidget", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the error heading from the injected translator", () => {
+    const { tooltip } = renderWidget("ERROR", makeTestTranslator());
+
+    expect(tooltip?.textContent).toContain("Oops, something went wrong!");
+  });
+
+  it("labels the close button from the injected translator", () => {
+    const { tooltip } = renderWidget("ERROR", makeTestTranslator());
+
+    expect(tooltip?.querySelector("button")?.getAttribute("aria-label")).toBe("Close tooltip");
+  });
+
+  it("uses the translator's copy rather than hardcoded English", () => {
+    const t = ((key: string) => `translated:${key}`) as unknown as CodingExerciseTranslator;
+
+    const { tooltip } = renderWidget("ERROR", t);
+
+    expect(tooltip?.textContent).toContain("translated:informationTooltip.errorHeading");
+    expect(tooltip?.textContent).not.toContain("Oops, something went wrong!");
+    expect(tooltip?.querySelector("button")?.getAttribute("aria-label")).toBe(
+      "translated:informationTooltip.closeAriaLabel"
+    );
+  });
+
+  it("still renders the interpreter-supplied body html untouched", () => {
+    const { tooltip } = renderWidget("ERROR", makeTestTranslator());
+
+    expect(tooltip?.innerHTML).toContain("<p>body</p>");
+  });
+
+  it("renders no heading for a SUCCESS tooltip", () => {
+    const { tooltip } = renderWidget("SUCCESS", makeTestTranslator());
+
+    expect(tooltip?.textContent).not.toContain("Oops, something went wrong!");
+    expect(tooltip?.innerHTML).toContain("<p>body</p>");
+  });
+});


### PR DESCRIPTION
## The bug

With a non-English UI language, the error tooltip over a broken line of code rendered an **English header** above a correctly-translated body:

> **Oops, something went wrong!**
> Здається, під час виклику функції move пропущено закривну дужку `)`.

The body is right because it comes from the interpreter's translated catalog. The header was a literal inside the widget's `innerHTML` template, as was the close button's `aria-label="Close tooltip"`.

## Why it isn't a one-line `t()` call

CodeMirror extensions are constructed outside the React tree, so `useTranslations()` is unreachable at that point.

The codebase already solves this, and this PR follows that convention rather than inventing a new mechanism. `CodingExerciseTranslator` (`components/coding-exercise/lib/test-results-types.ts`) is a next-intl translator over the `codingExercise` namespace, produced once by `useExerciseLoader` and threaded down a constructor rail into plain, hook-less modules — that is how `TestSuiteManager` and the test runner already resolve their own copy. (It is the same shape as the interpreters' inject-the-dict model in `interpreters/src/shared/i18n.ts`: no global, the dict/translator is handed in explicitly.)

The rail already reached `Orchestrator`; it just stopped there. This PR extends it one hop further:

```
useExerciseLoader → Orchestrator → EditorManager → createEditorExtensions → the extensions
```

`Orchestrator` now keeps `t` as a field (it previously only forwarded it to `TestSuiteManager`), `EditorManager` takes it, and `EditorExtensionsConfig` grows a `t`. `lineInformationExtension({ onClose, t })` passes it to `InformationWidget`, which resolves its two strings.

## Also fixed: the breakpoint gutter

Sweeping the sibling extensions for user-visible English turned up the breakpoint gutter's marker hover titles ("Add breakpoint" / "Remove breakpoint"), so those are translated on the same rail. `breakpointGutter` becomes a factory taking the translator.

One subtlety worth noting: the marker instance stored in the module-level `breakpointState` `StateField` stays untitled and needs no translator. The gutter rebuilds its own markers from the range set on every redraw, so that instance is only ever a range placeholder and is never rendered.

## Catalog

New English keys under `codingExercise`:

```json
"informationTooltip": { "errorHeading": "…", "closeAriaLabel": "…" },
"breakpointGutter":   { "addBreakpoint": "…", "removeBreakpoint": "…" }
```

**English only — no translations were invented.** Other locales are the normal translation pipeline's job. `hu.json` is at full key parity (required by the `app/tests/unit/messages.test.ts` guard) with the `U+FFFD` sentinel at the new keys, written by the translator repo's `scripts/catalog-stub`, which is what owns that file. The sentinel is the established "not translated yet" marker in that catalog, and is deliberately impossible to mistake for real copy.

## Not changed

- The interpreter-supplied tooltip body still renders exactly as before (there is a test pinning this).
- Tooltip markup, styling and positioning are untouched beyond the string substitution.
- `describeError.ts` also contains hardcoded English headings, but it is **dead code**: the only importer is its own unit test. Left alone rather than adding catalog keys for copy nobody sees.

## Verification

- `npx tsc --noEmit` clean.
- `pnpm lint` clean (one pre-existing unrelated warning in `postcss-plugins/`).
- `jest`: 180 suites / 2152 tests pass. `TestSuiteManager.test.ts:205` (which asserts the header string is *absent* from the widget `html`) still passes unchanged — it always was asserting about the interpreter body, and the header still lives in the widget, not the html.
- `scripts/audit-i18n-keys.mjs`: PASS.
- New `information-widget.test.ts` covers the heading, the aria-label, that a custom translator's output is used rather than English, that the body html is untouched, and that SUCCESS tooltips render no heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFiR2rx2oapRPuikQHE26B
