### PR TITLE
pre-commit: fix index corruption in linked worktrees, and never write the index on failure

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Anchor on the repo root explicitly. Git runs hooks from the top of the work
+# tree, but it exports GIT_DIR without exporting GIT_WORK_TREE, so once we cd
+# into a package git would otherwise treat *that* directory as the repo root
+# (see scripts/pre-commit-lib.sh). Every package hook is entered in a subshell
+# so the current directory can never drift between steps.
+REPO_ROOT="$(pwd)"
+
+# Open one transaction for the whole run. Package hooks may reformat and
+# auto-fix files, but nothing reaches the index until every package has passed.
+# If any of them fails, the rewrites are undone on the way out and the index is
+# left exactly as it was found.
+. "$REPO_ROOT/scripts/pre-commit-lib.sh"
+pc_session_begin "$REPO_ROOT" || exit 1
+
 echo "🔍 Detecting changed packages..."
 
 # Get all staged files
@@ -13,17 +27,13 @@ CONTENT_CHANGED=false
 LLM_CHAT_PROXY_CHANGED=false
 
 for file in $STAGED_FILES; do
-  if echo "$file" | grep -q "^app/"; then
-    APP_CHANGED=true
-  elif echo "$file" | grep -q "^curriculum/"; then
-    CURRICULUM_CHANGED=true
-  elif echo "$file" | grep -q "^interpreters/"; then
-    INTERPRETERS_CHANGED=true
-  elif echo "$file" | grep -q "^content/"; then
-    CONTENT_CHANGED=true
-  elif echo "$file" | grep -q "^llm-chat-proxy/"; then
-    LLM_CHAT_PROXY_CHANGED=true
-  fi
+  case "$file" in
+    app/*) APP_CHANGED=true ;;
+    curriculum/*) CURRICULUM_CHANGED=true ;;
+    interpreters/*) INTERPRETERS_CHANGED=true ;;
+    content/*) CONTENT_CHANGED=true ;;
+    llm-chat-proxy/*) LLM_CHAT_PROXY_CHANGED=true ;;
+  esac
 done
 
 # Build all packages in dependency order (always runs to ensure everything is available)
@@ -31,20 +41,16 @@ echo "\n🔨 Building packages in dependency order..."
 FAILED=false
 
 echo "Building interpreters..."
-cd interpreters && pnpm run build
-if [ $? -ne 0 ]; then
+if ! (cd "$REPO_ROOT/interpreters" && pnpm run build); then
   echo "❌ Failed to build interpreters"
   FAILED=true
 fi
-cd ..
 
 echo "Building curriculum..."
-cd curriculum && pnpm run build
-if [ $? -ne 0 ]; then
+if ! (cd "$REPO_ROOT/curriculum" && pnpm run build); then
   echo "❌ Failed to build curriculum"
   FAILED=true
 fi
-cd ..
 
 if [ "$FAILED" = true ]; then
   echo "\n❌ Build failed in one or more packages"
@@ -57,53 +63,50 @@ echo "✅ All packages built successfully\n"
 
 if [ "$APP_CHANGED" = true ]; then
   echo "\n📦 Running app pre-commit checks..."
-  cd app && ./scripts/pre-commit
-  if [ $? -ne 0 ]; then
+  if ! (cd "$REPO_ROOT/app" && ./scripts/pre-commit); then
     FAILED=true
   fi
-  cd ..
 fi
 
 if [ "$CURRICULUM_CHANGED" = true ]; then
   echo "\n📦 Running curriculum pre-commit checks..."
-  cd curriculum && ./scripts/pre-commit
-  if [ $? -ne 0 ]; then
+  if ! (cd "$REPO_ROOT/curriculum" && ./scripts/pre-commit); then
     FAILED=true
   fi
-  cd ..
 fi
 
 if [ "$INTERPRETERS_CHANGED" = true ]; then
   echo "\n📦 Running interpreters pre-commit checks..."
-  cd interpreters && ./scripts/pre-commit
-  if [ $? -ne 0 ]; then
+  if ! (cd "$REPO_ROOT/interpreters" && ./scripts/pre-commit); then
     FAILED=true
   fi
-  cd ..
 fi
 
 if [ "$CONTENT_CHANGED" = true ]; then
   echo "\n📦 Running content pre-commit checks..."
-  cd content && ./scripts/pre-commit
-  if [ $? -ne 0 ]; then
+  if ! (cd "$REPO_ROOT/content" && ./scripts/pre-commit); then
     FAILED=true
   fi
-  cd ..
 fi
 
 if [ "$LLM_CHAT_PROXY_CHANGED" = true ]; then
   echo "\n📦 Running llm-chat-proxy pre-commit checks..."
-  cd llm-chat-proxy && ./scripts/pre-commit
-  if [ $? -ne 0 ]; then
+  if ! (cd "$REPO_ROOT/llm-chat-proxy" && ./scripts/pre-commit); then
     FAILED=true
   fi
-  cd ..
 fi
 
 if [ "$FAILED" = true ]; then
   echo "\n❌ Pre-commit checks failed in one or more packages"
   exit 1
 fi
+
+# Everything passed: commit the transaction, staging whatever the formatters
+# and --fix passes rewrote.
+pc_session_commit || {
+  echo "\n❌ Failed to stage formatted files"
+  exit 1
+}
 
 if [ "$APP_CHANGED" = false ] && [ "$CURRICULUM_CHANGED" = false ] && [ "$INTERPRETERS_CHANGED" = false ] && [ "$CONTENT_CHANGED" = false ] && [ "$LLM_CHAT_PROXY_CHANGED" = false ]; then
   echo "✅ No package files changed, skipping pre-commit checks"

--- a/app/scripts/pre-commit
+++ b/app/scripts/pre-commit
@@ -4,72 +4,66 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$APP_DIR" || exit 1
 
+. "$APP_DIR/../scripts/pre-commit-lib.sh"
+pc_init "$APP_DIR" || exit 1
+
 echo "Running pre-commit checks..."
 
 # Run TypeScript type checking
 echo "🔷 Running TypeScript type check..."
-pnpm exec tsc --noEmit
-if [ $? -ne 0 ]; then
-    echo "❌ TypeScript type check failed. Commit aborted."
-    exit 1
-fi
+pnpm exec tsc --noEmit || pc_fail "❌ TypeScript type check failed. Commit aborted."
+
+# Work out what is staged. Paths stay exactly as git reports them
+# (repo-relative, e.g. app/app/test/network/page.tsx) and are only ever made
+# absolute by prefixing the repo root, so no prefix can be mis-stripped.
+FORMAT_LIST="$PC_TMP/format"
+LINT_LIST="$PC_TMP/lint"
+CSS_LIST="$PC_TMP/css"
+pc_staged_files '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' > "$FORMAT_LIST"
+pc_staged_files '\.(ts|tsx|js|jsx|mjs)$' > "$LINT_LIST"
+pc_staged_files '\.css$' > "$CSS_LIST"
+
+# Snapshot everything we might rewrite, so a failure anywhere below leaves the
+# working tree and the index exactly as it found them.
+pc_snapshot "$FORMAT_LIST"
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^app/||' || true)
-if [ -n "$STAGED_FILES_RELATIVE" ]; then
-    echo "Formatting: $STAGED_FILES_RELATIVE"
-    # Convert relative paths to absolute paths for prettier
-    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$APP_DIR/|")
-    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
-    # Re-add formatted files (use paths relative to current directory, which is APP_DIR)
-    git add $STAGED_FILES_RELATIVE
+if [ -s "$FORMAT_LIST" ]; then
+    echo "Formatting:"
+    cat "$FORMAT_LIST"
+    pc_run_on "$FORMAT_LIST" pnpm exec prettier --write || pc_fail "❌ Formatting failed. Commit aborted."
 else
     echo "No files to format"
 fi
 
 # Run lint --fix on staged files only, then check for remaining errors/warnings
 echo "🔍 Running lint --fix on staged files..."
-STAGED_TS_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.(ts|tsx|js|jsx|mjs)$' | sed 's|^app/||' || true)
-if [ -n "$STAGED_TS_FILES_RELATIVE" ]; then
-    echo "Linting: $STAGED_TS_FILES_RELATIVE"
-    # Convert relative paths to absolute paths for eslint
-    STAGED_TS_FILES_ABSOLUTE=$(echo "$STAGED_TS_FILES_RELATIVE" | sed "s|^|$APP_DIR/|")
-    pnpm exec eslint --fix $STAGED_TS_FILES_ABSOLUTE
-    # Re-add any files that eslint auto-fixed
-    git add $STAGED_TS_FILES_RELATIVE
-    # Now check for remaining errors/warnings
-    pnpm exec eslint $STAGED_TS_FILES_ABSOLUTE --max-warnings=0
-    if [ $? -ne 0 ]; then
-        echo "❌ Lint check failed (errors or warnings found). Commit aborted."
-        exit 1
-    fi
+if [ -s "$LINT_LIST" ]; then
+    echo "Linting:"
+    cat "$LINT_LIST"
+    pc_run_on "$LINT_LIST" pnpm exec eslint --fix
+    pc_run_on "$LINT_LIST" pnpm exec eslint --max-warnings=0 ||
+        pc_fail "❌ Lint check failed (errors or warnings found). Commit aborted."
 else
     echo "No JavaScript/TypeScript files to lint"
 fi
 
 # Run stylelint on staged CSS files only
 echo "🎨 Running stylelint on staged CSS files..."
-STAGED_CSS_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^app/" | grep -E '\.css$' | sed 's|^app/||' || true)
-if [ -n "$STAGED_CSS_FILES_RELATIVE" ]; then
-    echo "Linting CSS: $STAGED_CSS_FILES_RELATIVE"
-    # Convert relative paths to absolute paths for stylelint
-    STAGED_CSS_FILES_ABSOLUTE=$(echo "$STAGED_CSS_FILES_RELATIVE" | sed "s|^|$APP_DIR/|")
-    pnpm exec stylelint $STAGED_CSS_FILES_ABSOLUTE
-    if [ $? -ne 0 ]; then
-        echo "❌ CSS lint check failed. Commit aborted."
-        exit 1
-    fi
+if [ -s "$CSS_LIST" ]; then
+    echo "Linting CSS:"
+    cat "$CSS_LIST"
+    pc_run_on "$CSS_LIST" pnpm exec stylelint || pc_fail "❌ CSS lint check failed. Commit aborted."
 else
     echo "No CSS files to lint"
 fi
 
 # Run tests
 echo "🧪 Running tests..."
-pnpm test
-if [ $? -ne 0 ]; then
-    echo "❌ Tests failed. Commit aborted."
-    exit 1
-fi
+pnpm test || pc_fail "❌ Tests failed. Commit aborted."
+
+# Everything passed: now, and only now, stage whatever the fixers rewrote.
+pc_finish || pc_fail "❌ Failed to stage formatted files. Commit aborted."
 
 echo "✅ All checks passed!"

--- a/curriculum/scripts/pre-commit
+++ b/curriculum/scripts/pre-commit
@@ -4,44 +4,43 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CURRICULUM_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$CURRICULUM_DIR" || exit 1
 
+. "$CURRICULUM_DIR/../scripts/pre-commit-lib.sh"
+pc_init "$CURRICULUM_DIR" || exit 1
+
 echo "Running pre-commit checks..."
 
 # Run TypeScript type checking
 echo "🔷 Running TypeScript type check..."
-pnpm exec tsc --noEmit
-if [ $? -ne 0 ]; then
-    echo "❌ TypeScript type check failed. Commit aborted."
-    exit 1
-fi
+pnpm exec tsc --noEmit || pc_fail "❌ TypeScript type check failed. Commit aborted."
+
+# Paths stay exactly as git reports them (repo-relative) and are only ever made
+# absolute by prefixing the repo root, so no prefix can be mis-stripped.
+FORMAT_LIST="$PC_TMP/format"
+pc_staged_files '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' > "$FORMAT_LIST"
+
+# Snapshot everything we might rewrite, so a failure anywhere below leaves the
+# working tree and the index exactly as it found them.
+pc_snapshot "$FORMAT_LIST"
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^curriculum/" | grep -E '\.(ts|tsx|js|jsx|mjs|css|json|md|yml|yaml)$' | sed 's|^curriculum/||' || true)
-if [ -n "$STAGED_FILES_RELATIVE" ]; then
-    echo "Formatting: $STAGED_FILES_RELATIVE"
-    # Convert relative paths to absolute paths for prettier
-    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$CURRICULUM_DIR/|")
-    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
-    # Re-add formatted files (use paths relative to current directory, which is CURRICULUM_DIR)
-    git add $STAGED_FILES_RELATIVE
+if [ -s "$FORMAT_LIST" ]; then
+    echo "Formatting:"
+    cat "$FORMAT_LIST"
+    pc_run_on "$FORMAT_LIST" pnpm exec prettier --write || pc_fail "❌ Formatting failed. Commit aborted."
 else
     echo "No files to format"
 fi
 
 # Run lint check (treating warnings as errors)
 echo "🔍 Running lint check..."
-pnpm run lint --max-warnings=0
-if [ $? -ne 0 ]; then
-    echo "❌ Lint check failed (errors or warnings found). Commit aborted."
-    exit 1
-fi
+pnpm run lint --max-warnings=0 || pc_fail "❌ Lint check failed (errors or warnings found). Commit aborted."
 
 # Run tests
 echo "🧪 Running tests..."
-pnpm test
-if [ $? -ne 0 ]; then
-    echo "❌ Tests failed. Commit aborted."
-    exit 1
-fi
+pnpm test || pc_fail "❌ Tests failed. Commit aborted."
+
+# Everything passed: now, and only now, stage whatever the formatter rewrote.
+pc_finish || pc_fail "❌ Failed to stage formatted files. Commit aborted."
 
 echo "✅ All checks passed!"

--- a/interpreters/scripts/pre-commit
+++ b/interpreters/scripts/pre-commit
@@ -4,52 +4,47 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INTERPRETERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$INTERPRETERS_DIR" || exit 1
 
+. "$INTERPRETERS_DIR/../scripts/pre-commit-lib.sh"
+pc_init "$INTERPRETERS_DIR" || exit 1
+
 echo "Running pre-commit checks..."
+
+# Paths stay exactly as git reports them (repo-relative) and are only ever made
+# absolute by prefixing the repo root, so no prefix can be mis-stripped.
+FORMAT_LIST="$PC_TMP/format"
+pc_staged_files '\.(ts|tsx|js|jsx|json|md|yml)$' > "$FORMAT_LIST"
+
+# Snapshot everything we might rewrite, so a failure anywhere below leaves the
+# working tree and the index exactly as it found them.
+pc_snapshot "$FORMAT_LIST"
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^interpreters/" | grep -E '\.(ts|tsx|js|jsx|json|md|yml)$' | sed 's|^interpreters/||' || true)
-if [ -n "$STAGED_FILES_RELATIVE" ]; then
-    echo "Formatting: $STAGED_FILES_RELATIVE"
-    # Convert relative paths to absolute paths for prettier
-    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$INTERPRETERS_DIR/|")
-    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
-    # Re-add formatted files (use paths relative to current directory, which is INTERPRETERS_DIR)
-    git add $STAGED_FILES_RELATIVE
+if [ -s "$FORMAT_LIST" ]; then
+    echo "Formatting:"
+    cat "$FORMAT_LIST"
+    pc_run_on "$FORMAT_LIST" pnpm exec prettier --write || pc_fail "❌ Formatting failed. Commit aborted."
 else
     echo "No files to format"
 fi
 
 # Run ESLint check (treating warnings as errors)
 echo "🔍 Running ESLint..."
-pnpm run lint --max-warnings=0
-if [ $? -ne 0 ]; then
-    echo "❌ ESLint check failed (errors or warnings found). Commit aborted."
-    exit 1
-fi
+pnpm run lint --max-warnings=0 || pc_fail "❌ ESLint check failed (errors or warnings found). Commit aborted."
 
 # Run type check
 echo "🔍 Type checking..."
-pnpm run typecheck
-if [ $? -ne 0 ]; then
-    echo "❌ Type check failed. Commit aborted."
-    exit 1
-fi
+pnpm run typecheck || pc_fail "❌ Type check failed. Commit aborted."
 
 # Run tests
 echo "🧪 Running tests..."
-pnpm test
-if [ $? -ne 0 ]; then
-    echo "❌ Tests failed. Commit aborted."
-    exit 1
-fi
+pnpm test || pc_fail "❌ Tests failed. Commit aborted."
 
 # Run benchmark tests
 echo "⚡ Running benchmark tests..."
-pnpm test:benchmark
-if [ $? -ne 0 ]; then
-    echo "❌ Benchmark tests failed. Commit aborted."
-    exit 1
-fi
+pnpm test:benchmark || pc_fail "❌ Benchmark tests failed. Commit aborted."
+
+# Everything passed: now, and only now, stage whatever the formatter rewrote.
+pc_finish || pc_fail "❌ Failed to stage formatted files. Commit aborted."
 
 echo "✅ All checks passed!"

--- a/llm-chat-proxy/scripts/pre-commit
+++ b/llm-chat-proxy/scripts/pre-commit
@@ -4,45 +4,43 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LLM_CHAT_PROXY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$LLM_CHAT_PROXY_DIR" || exit 1
 
+. "$LLM_CHAT_PROXY_DIR/../scripts/pre-commit-lib.sh"
+pc_init "$LLM_CHAT_PROXY_DIR" || exit 1
+
 echo "Running pre-commit checks..."
 
 # Run TypeScript type checking
 echo "🔷 Running TypeScript type check..."
-pnpm exec tsc --noEmit
-if [ $? -ne 0 ]; then
-    echo "❌ TypeScript type check failed. Commit aborted."
-    exit 1
-fi
+pnpm exec tsc --noEmit || pc_fail "❌ TypeScript type check failed. Commit aborted."
+
+# Paths stay exactly as git reports them (repo-relative) and are only ever made
+# absolute by prefixing the repo root, so no prefix can be mis-stripped.
+FORMAT_LIST="$PC_TMP/format"
+pc_staged_files '\.(ts|js|json|md|yml|yaml)$' > "$FORMAT_LIST"
+
+# Snapshot everything we might rewrite, so a failure anywhere below leaves the
+# working tree and the index exactly as it found them.
+pc_snapshot "$FORMAT_LIST"
 
 # Run formatter on changed files only
 echo "💅 Formatting changed files..."
-STAGED_FILES_RELATIVE=$(git diff --cached --name-only --diff-filter=ACMR | grep "^llm-chat-proxy/" | grep -E '\.(ts|js|json|md|yml|yaml)$' | sed 's|^llm-chat-proxy/||' || true)
-if [ -n "$STAGED_FILES_RELATIVE" ]; then
-    echo "Formatting: $STAGED_FILES_RELATIVE"
-    # Convert relative paths to absolute paths for prettier
-    STAGED_FILES_ABSOLUTE=$(echo "$STAGED_FILES_RELATIVE" | sed "s|^|$LLM_CHAT_PROXY_DIR/|")
-    pnpm exec prettier --write $STAGED_FILES_ABSOLUTE
-    # Git add needs paths relative to repo root (llm-chat-proxy/...)
-    STAGED_FILES_FOR_GIT=$(echo "$STAGED_FILES_RELATIVE" | sed 's|^|llm-chat-proxy/|')
-    git add $STAGED_FILES_FOR_GIT
+if [ -s "$FORMAT_LIST" ]; then
+    echo "Formatting:"
+    cat "$FORMAT_LIST"
+    pc_run_on "$FORMAT_LIST" pnpm exec prettier --write || pc_fail "❌ Formatting failed. Commit aborted."
 else
     echo "No files to format"
 fi
 
 # Run lint check (treating warnings as errors)
 echo "🔍 Running lint check..."
-pnpm run lint --max-warnings=0
-if [ $? -ne 0 ]; then
-    echo "❌ Lint check failed (errors or warnings found). Commit aborted."
-    exit 1
-fi
+pnpm run lint --max-warnings=0 || pc_fail "❌ Lint check failed (errors or warnings found). Commit aborted."
 
 # Run tests
 echo "🧪 Running tests..."
-pnpm test
-if [ $? -ne 0 ]; then
-    echo "❌ Tests failed. Commit aborted."
-    exit 1
-fi
+pnpm test || pc_fail "❌ Tests failed. Commit aborted."
+
+# Everything passed: now, and only now, stage whatever the formatter rewrote.
+pc_finish || pc_fail "❌ Failed to stage formatted files. Commit aborted."
 
 echo "✅ All checks passed!"

--- a/scripts/pre-commit-lib.sh
+++ b/scripts/pre-commit-lib.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+# Shared helpers for the pre-commit hooks.
+#
+# Why this exists
+# ---------------
+# Git exports GIT_DIR (and GIT_INDEX_FILE) when it runs a hook, but it does NOT
+# export GIT_WORK_TREE. In the main checkout GIT_DIR is left unset, so git
+# rediscovers the repo from the current directory and everything behaves as you
+# would expect. In a *linked worktree* GIT_DIR is set, and the moment a script
+# does `cd app` git treats the current directory as the top of the work tree:
+#
+#     $ cd app && git rev-parse --show-toplevel   # <worktree>/app   (!)
+#     $ cd app && git rev-parse --show-prefix     # <empty>          (!)
+#
+# That silently reinterprets every relative pathspec as repo-root-relative, so
+# `git add app/test/network/page.tsx` (meant as app-relative) wrote a bogus
+# root-relative entry into the index. The bogus entry was then picked up by the
+# next `git diff --cached`, which handed eslint a path that does not exist, and
+# the hook aborted leaving the polluted index behind.
+#
+# The rules these helpers enforce so that cannot happen again:
+#
+#   1. The repo root is derived structurally from the script's own location,
+#      never from git's idea of the current directory.
+#   2. Paths are kept repo-relative, exactly as `git diff --cached` emits them.
+#      Nothing is ever prefix-stripped, so nothing can be mis-stripped. Tools
+#      are handed absolute paths built as "$PC_REPO_ROOT/$path".
+#   3. Every git command runs as `git -C "$PC_REPO_ROOT"`, so pathspecs resolve
+#      against the real repo root in a main checkout and a linked worktree
+#      alike.
+#   4. The whole run is one transaction. Formatters and --fix passes rewrite
+#      the working tree, but nothing is staged until every check in every
+#      package has passed. If anything fails, the rewrites are undone and the
+#      index is never touched, so the commit aborts with the repository exactly
+#      as the hook found it.
+#
+# There are two entry points. `.husky/pre-commit` calls pc_session_begin /
+# pc_session_commit to wrap the whole multi-package run in one transaction.
+# A package script calls pc_init, and either joins the session already in
+# progress or (when run standalone) opens one of its own.
+
+# ---------------------------------------------------------------------------
+# Session: the unit of atomicity.
+# ---------------------------------------------------------------------------
+
+# pc_session_begin <repo-root>
+pc_session_begin() {
+  PC_REPO_ROOT="$1"
+  PC_SESSION="$(mktemp -d "${TMPDIR:-/tmp}/jiki-pre-commit.XXXXXX")" || return 1
+  export PC_SESSION
+  mkdir -p "$PC_SESSION/snapshot"
+  : > "$PC_SESSION/to-stage"
+  PC_OWNS_SESSION=1
+  PC_DONE=0
+  trap 'pc_session_cleanup' EXIT
+  trap 'exit 1' INT TERM
+}
+
+# pc_session_commit: every check passed, so stage the rewrites and disarm the
+# restore-on-exit trap.
+pc_session_commit() {
+  pc_stage_pending || return 1
+  PC_DONE=1
+  return 0
+}
+
+pc_session_cleanup() {
+  if [ "${PC_DONE:-0}" != "1" ]; then
+    pc_restore
+  fi
+  if [ -n "${PC_SESSION:-}" ]; then
+    rm -rf "$PC_SESSION"
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# pc_init <package-dir>
+#
+# <package-dir> is the absolute path to the package (e.g. /path/to/repo/app).
+# Sets PC_PKG_DIR, PC_REPO_ROOT, PC_PKG_PREFIX (e.g. "app/") and PC_TMP.
+# ---------------------------------------------------------------------------
+pc_init() {
+  PC_PKG_DIR="$1"
+  PC_REPO_ROOT="$(cd "$PC_PKG_DIR/.." && pwd)"
+  PC_PKG_PREFIX="$(basename "$PC_PKG_DIR")/"
+
+  PC_TMP="$(mktemp -d "${TMPDIR:-/tmp}/jiki-pre-commit-pkg.XXXXXX")" || return 1
+
+  if [ -n "${PC_SESSION:-}" ] && [ -d "$PC_SESSION" ]; then
+    # A parent hook owns the transaction; it will stage or restore for us.
+    PC_OWNS_SESSION=0
+    trap 'rm -rf "$PC_TMP"' EXIT
+  else
+    PC_SESSION="$PC_TMP/session"
+    mkdir -p "$PC_SESSION/snapshot"
+    : > "$PC_SESSION/to-stage"
+    PC_OWNS_SESSION=1
+    PC_DONE=0
+    trap 'pc_pkg_cleanup' EXIT
+    trap 'exit 1' INT TERM
+  fi
+  return 0
+}
+
+pc_pkg_cleanup() {
+  if [ "${PC_DONE:-0}" != "1" ]; then
+    pc_restore
+  fi
+  rm -rf "$PC_TMP"
+  return 0
+}
+
+# pc_finish: called by a package once its own checks pass. When the package
+# owns the transaction it stages now; otherwise the parent hook does it after
+# every package has passed.
+pc_finish() {
+  if [ "${PC_OWNS_SESSION:-0}" = "1" ]; then
+    pc_stage_pending || return 1
+    PC_DONE=1
+  fi
+  return 0
+}
+
+# pc_fail <message>: report and abort. The EXIT trap undoes any rewrites.
+pc_fail() {
+  echo "$1"
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Staged-file discovery
+# ---------------------------------------------------------------------------
+
+# pc_staged_files <extension-regex>
+#
+# Prints the repo-relative paths of staged files inside this package that match
+# the regex, one per line. Paths are exactly as git records them, so
+# app/app/foo.tsx stays app/app/foo.tsx.
+pc_staged_files() {
+  git -C "$PC_REPO_ROOT" diff --cached --name-only --diff-filter=ACMR -z -- "$PC_PKG_PREFIX" |
+    tr '\0' '\n' |
+    grep -E "$1" || true
+}
+
+# ---------------------------------------------------------------------------
+# The transaction
+# ---------------------------------------------------------------------------
+
+# pc_snapshot <file-of-repo-relative-paths>
+#
+# Records the current contents of every listed file, and registers it as
+# something to stage if (and only if) the whole run succeeds.
+pc_snapshot() {
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    src="$PC_REPO_ROOT/$rel"
+    [ -f "$src" ] || continue
+    dest="$PC_SESSION/snapshot/$rel"
+    # Never re-snapshot: the first copy is the only pristine one.
+    if [ -f "$dest" ]; then
+      continue
+    fi
+    mkdir -p "$(dirname "$dest")"
+    cp -p "$src" "$dest"
+    printf '%s\n' "$rel" >> "$PC_SESSION/to-stage"
+  done < "$1"
+}
+
+# pc_abs_list <file-of-repo-relative-paths> <output-file>
+#
+# Writes a NUL-delimited list of absolute paths for `xargs -0`, so paths
+# containing spaces survive.
+pc_abs_list() {
+  : > "$2"
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    printf '%s/%s\0' "$PC_REPO_ROOT" "$rel" >> "$2"
+  done < "$1"
+}
+
+# pc_run_on <file-of-repo-relative-paths> <command...>
+#
+# Runs the command over the absolute paths. Non-zero if any invocation was.
+pc_run_on() {
+  list="$1"
+  shift
+  pc_abs_list "$list" "$PC_TMP/args"
+  xargs -0 "$@" < "$PC_TMP/args"
+}
+
+# pc_restore: put every snapshotted file back exactly as it was found. Only
+# files a fixer actually rewrote are written, so mtimes are otherwise left be.
+pc_restore() {
+  if [ -z "${PC_SESSION:-}" ] || [ ! -f "$PC_SESSION/to-stage" ]; then
+    return 0
+  fi
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    snap="$PC_SESSION/snapshot/$rel"
+    live="$PC_REPO_ROOT/$rel"
+    [ -f "$snap" ] || continue
+    if [ ! -f "$live" ] || ! cmp -s "$snap" "$live"; then
+      cp -p "$snap" "$live"
+    fi
+  done < "$PC_SESSION/to-stage"
+  return 0
+}
+
+# pc_stage_pending: stage the files a fixer rewrote, using repo-relative paths
+# resolved against the repo root.
+pc_stage_pending() {
+  if [ -z "${PC_SESSION:-}" ] || [ ! -s "$PC_SESSION/to-stage" ]; then
+    return 0
+  fi
+  to_add="$PC_SESSION/to-add"
+  : > "$to_add"
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    snap="$PC_SESSION/snapshot/$rel"
+    live="$PC_REPO_ROOT/$rel"
+    if [ -f "$live" ] && { [ ! -f "$snap" ] || ! cmp -s "$snap" "$live"; }; then
+      printf '%s\0' "$rel" >> "$to_add"
+    fi
+  done < "$PC_SESSION/to-stage"
+  if [ -s "$to_add" ]; then
+    xargs -0 git -C "$PC_REPO_ROOT" add -- < "$to_add" || return 1
+  fi
+  return 0
+}


### PR DESCRIPTION
## The bug

Committing from a **linked git worktree** corrupted the index. An agent working in one hit it, had to `git reset` to recover, and ended up committing with `--no-verify`. Another independently landed a commit that had silently gained 27 duplicate files at `/src`, `/lib`, `/tests` and `/.context`, and had to amend them out and force-push.

### Root cause

Git exports `GIT_DIR` when it runs a hook, but it does **not** export `GIT_WORK_TREE`.

In the main checkout `GIT_DIR` is left unset, so git rediscovers the repo from the current directory and everything behaves as you would expect. In a linked worktree `GIT_DIR` is set, and the moment a package script does `cd app`, git treats *that directory* as the top of the work tree. Measured inside a real hook:

| | main checkout | linked worktree |
|---|---|---|
| `GIT_DIR` | unset | `.../.git/worktrees/<name>` |
| `GIT_WORK_TREE` | unset | unset |
| `cd app && git rev-parse --show-toplevel` | `<repo>` | `<worktree>/app` ❌ |
| `cd app && git rev-parse --show-prefix` | `app/` | *(empty)* ❌ |

Every package hook stripped its own prefix off the staged paths and re-added them with what it believed were package-relative pathspecs. With the prefix silently empty, git resolved those as **repo-root-relative** and wrote bogus entries into the index.

This is one defect, not two. The reported "eslint gets a nonexistent path" symptom is the *second-order* effect of the same `git add`: the bogus entry lands in the index, the next `git diff --cached` picks it up, and the hook feeds it back through the prefix strip to produce a path that does not exist.

## Before

Reproduced in a linked worktree with `app/app/test/network/page.tsx` staged (the real hook scripts, real git, stub for `pnpm` only):

```
📦 Running app pre-commit checks...
💅 Formatting changed files...
Formatting: app/test/network/page.tsx
🔍 Running lint --fix on staged files...
Linting: app/test/network/page.tsx
test/network/page.tsx                                    <- bogus entry, fed back in
eslint: No files matching the pattern ".../old-wt/app/test/network/page.tsx" were found.
fatal: pathspec 'test/network/page.tsx' did not match any files
eslint: No files matching the pattern ".../old-wt/app/test/network/page.tsx" were found.
❌ Lint check failed (errors or warnings found). Commit aborted.
### commit exit=1
### stray entries:
app/test/network/page.tsx                                <- left behind in the index
```

The commit fails on a file with nothing wrong with it, and the index is left polluted.

Staging one file per package at once, the pollution came from **every** package that had this code:

```
index entries NOT under a package directory:
  ❌ lib/foo.ts                      (from app/)
  ❌ src/bar.ts                      (from interpreters/)
  ❌ src/baz.ts                      (from curriculum/)
  ❌ app/test/network/page.tsx       (from app/, the app/app/** case)
```

`llm-chat-proxy/` had the mirror-image variant: it re-added the package prefix instead of stripping it, so its `git add` matched the real index entry against a missing file and recorded a **deletion**. The staged file silently vanished from the commit:

```
--- index before commit ---   llm-chat-proxy/src/p.ts
✅ All pre-commit checks passed!
--- index after commit ---    (none)
```

## After

Same scenarios, same worktree:

```
📦 Running app pre-commit checks...
💅 Formatting changed files...
Formatting:
app/app/_hooktest/page.tsx
app/lib/_hooktest.ts
🔍 Running lint --fix on staged files...
Linting:
app/app/_hooktest/page.tsx
app/lib/_hooktest.ts

/Users/.../app/app/_hooktest/page.tsx
  2:7  warning  'unusedOnPurpose' is assigned a value but never used
✖ 1 problem (0 errors, 1 warning)
```

Correct paths, and the commit now fails on the file's **real content** rather than on a path error. On a clean run the same files commit at the right paths with prettier's rewrite staged:

```
 app/app/_hooktest/page.tsx    | 1 +
 app/lib/_hooktest.ts          | 1 +
 interpreters/src/_hooktest.ts | 1 +
--- any stray root-relative index entries? ---
  none
```

## A failed hook no longer touches the index

Stated explicitly because it is the more serious of the two problems: **a failing pre-commit hook now leaves the index byte-identical to how it found it, and never partially staged.**

Previously the hooks ran `prettier --write` and `eslint --fix` and staged the results *before* running the checks that could fail, so an aborted commit left the index carrying changes the user never staged. That was true in a normal checkout too, not just in a worktree.

Now the whole run is a single transaction: files are snapshotted before any fixer touches them, and nothing is staged until every check in every package has passed. If anything fails, the rewrites are undone on the way out and the index is never written. Verified by capturing `git status --porcelain`, `git ls-files -s` and the working-tree file hashes before and after a failing commit and diffing them:

```
RESULT: git status / index / working tree byte-identical after failed hook ✅
```

That holds across packages too: if `interpreters` passes and reformats its files but `app` then fails, the interpreters rewrites are rolled back rather than left staged.

## The fix

New `scripts/pre-commit-lib.sh`, shared by all four package hooks, replacing the copy-pasted path handling:

1. The repo root is derived **structurally** from the script's own location, never from git's idea of the current directory.
2. Paths stay exactly as `git diff --cached` emits them. Nothing is ever prefix-stripped, so nothing can be mis-stripped. Tools get absolute paths built as `"$repo_root/$path"`, NUL-delimited through `xargs -0` so paths containing spaces survive.
3. Every git command runs as `git -C "$repo_root"`, so pathspecs resolve against the real root in a main checkout and a linked worktree alike.
4. Staging happens once, at the end, only if everything passed.

`.husky/pre-commit` owns the transaction across packages and now enters each one in a subshell, so the working directory cannot drift between steps (previously a failed `cd` would have left every later step running in the wrong directory).

This deliberately does not special-case `app/app/`. The prefix stripping was wrong for every path; the App Router directory just made it visible.

## Verification

Exercised for real rather than reasoned about, from **both** a main checkout and a linked worktree:

- Files staged under `app/app/**`, at other depths in `app/`, in `interpreters/`, in `llm-chat-proxy/`, and mixtures spanning two packages in one commit.
- A deliberate lint error fails the commit, on the file's real content.
- `git status`, the index and the working tree are byte-identical after such a failure.
- A clean run stages the reformat and commits at the correct paths, with no stray entries.
- Package scripts still work when invoked standalone (`cd app && ./scripts/pre-commit`), opening their own transaction.
- All scripts pass `sh -n` and `dash -n`, and were tested under husky's `sh -e` wrapper.

The real-repo runs used actual `tsc`, `prettier`, `eslint`, `stylelint`, `jest` and `vitest`. A stub `pnpm` was used only for the exhaustive matrix across all four packages.

## Not fixed here

Left alone deliberately, worth knowing about:

- **Partially staged files.** If a file has both staged and unstaged changes and a fixer rewrites it, the end-of-run `git add` stages the whole working-tree file, including the hunks the user deliberately left out. That is pre-existing behaviour and the previous scripts' evident intent; fixing it properly means stashing unstaged changes for the duration, which is a bigger change than this one.
- `content/scripts/pre-commit` has no path handling at all (it just runs `format:check`), so it needed nothing.
- The top-level hook always builds `interpreters` and `curriculum` even when nothing in them changed, which is most of the hook's runtime. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFiR2rx2oapRPuikQHE26B
