### PR TITLE
BetaTag: localize the label and mirror the ribbon in RTL

### DIFF
--- a/app/components/common/BetaTag.module.css
+++ b/app/components/common/BetaTag.module.css
@@ -3,6 +3,8 @@
     inset-inline-end: -50px;
     position: fixed;
     z-index: var(--z-index-beta-tag);
+    /* The ribbon hangs off the inline-end corner, so the diagonal has to run
+       the other way in RTL for the text to read along the corner. */
     transform: rotate(45deg);
 
     background: var(--color-blue-600);
@@ -16,4 +18,8 @@
     font-weight: 700;
 
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+:global([dir="rtl"]) .tag {
+    transform: rotate(-45deg);
 }

--- a/app/components/common/BetaTag.tsx
+++ b/app/components/common/BetaTag.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import styles from "./BetaTag.module.css";
 
 export default function BetaTag() {
+  const t = useTranslations("common");
   const routes = useLocaleRoutes();
   return (
     <Link href={routes.article("beta-phase")} className={styles.tag}>
-      Beta Version
+      {t("betaTag")}
     </Link>
   );
 }

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -147,7 +147,8 @@
     },
     "saving": "Saving...",
     "retry": "Retry",
-    "tryAgain": "Try Again"
+    "tryAgain": "Try Again",
+    "betaTag": "Beta Version"
   },
   "build": {
     "upcomingStreams": {

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -147,7 +147,8 @@
     },
     "saving": "Mentés...",
     "retry": "Újra",
-    "tryAgain": "Próbáld újra"
+    "tryAgain": "Próbáld újra",
+    "betaTag": "Beta Version"
   },
   "build": {
     "upcomingStreams": {


### PR DESCRIPTION
The "Beta Version" corner ribbon had two problems: the text was hardcoded English, and its diagonal did not flip in RTL locales.

## Changes

**1. i18n**
- Added `common.betaTag` to `messages/en.json` and `messages/hu.json` (`common.*` because `BetaTag` is a shared component with one meaning everywhere it renders, like `common.badgeNewLabel`).
- `components/common/BetaTag.tsx` now reads it via `useTranslations("common")` instead of the literal string.
- The `hu` value is stubbed with the English string for the translation pipeline to fill in.

**2. RTL**
- The ribbon already positions with `inset-inline-end`, so it lands in the mirrored corner automatically in RTL. The only remaining physical value was `transform: rotate(45deg)`, which left the diagonal running the LTR direction.
- Added a `:global([dir="rtl"]) .tag` rule with `rotate(-45deg)`, matching the existing `[dir="rtl"]` convention used elsewhere in the repo (e.g. `components/blog/CTABlock.module.css`). No JS-level direction check needed.

## Test plan

- [x] `pnpm typecheck` from the monorepo root — clean
- [x] `pnpm run lint` in `app/` — no new issues (one pre-existing warning in `postcss-plugins/`)
- [x] Full unit suite via pre-commit — 2149 tests passing, including `tests/unit/messages.test.ts` (ICU validity + `en`/`hu` key-tree parity)
- [ ] **Human visual check (not verifiable here — no browser):** load `/dashboard` in an LTR locale and confirm the ribbon looks unchanged (same corner, same diagonal, translated label rendering).
- [ ] **Human visual check:** load the same page in an RTL locale (`ar`, `he`, `fa`, `ur`) and confirm the ribbon sits in the mirrored corner with the diagonal running the other way, and the text reads correctly along it (not upside-down or mirrored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9tYRNY8BHVT5zSFEWSsfX