### PR TITLE
RTL: stop inline code tokens reordering in right-to-left prose

### DIFF
--- a/app/app/styles/base.css
+++ b/app/app/styles/base.css
@@ -145,6 +145,16 @@
     pre {
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         font-size: 1em;
+
+        /* Code is a directional island. Inside RTL prose (fa, ar, he, ur) the
+           Unicode Bidi Algorithm would otherwise resolve the trailing neutral
+           characters of a token like `move()` against the RTL paragraph
+           direction and render it as `()move`. `plaintext` derives each line's
+           base direction from its own first strong character, so LTR code reads
+           correctly in RTL prose without hard-coding `direction: ltr` (which
+           would break genuinely RTL content). Direction-agnostic, so it needs
+           no [dir="rtl"] conditional. */
+        unicode-bidi: plaintext;
     }
 
     small {

--- a/app/components/coding-exercise/CodingExercise.module.css
+++ b/app/components/coding-exercise/CodingExercise.module.css
@@ -490,6 +490,10 @@
     padding: 5px;
     border-radius: 8px;
     font-size: 12px;
+
+    /* Not a <kbd> element, so it misses the global bidi isolation in
+       app/styles/base.css; keep LTR shortcut tokens intact in RTL prose. */
+    unicode-bidi: plaintext;
 }
 
 /* Visual Player */

--- a/app/components/coding-exercise/ui/FunctionsView.module.css
+++ b/app/components/coding-exercise/ui/FunctionsView.module.css
@@ -33,6 +33,10 @@
     font-family: var(--font-mono);
     font-weight: 600;
     color: var(--color-gray-900);
+
+    /* Not a <code> element, so it misses the global bidi isolation in
+       app/styles/base.css. Without this, `move()` renders as `()move` in RTL. */
+    unicode-bidi: plaintext;
 }
 
 .category {

--- a/app/components/coding-exercise/ui/instructions-panel/instructions-panel.module.css
+++ b/app/components/coding-exercise/ui/instructions-panel/instructions-panel.module.css
@@ -373,6 +373,10 @@
     padding: 4px 8px;
     border-radius: 4px;
     display: inline-block;
+
+    /* Not a <code> element, so it misses the global bidi isolation in
+       app/styles/base.css. Without this, `move()` renders as `()move` in RTL. */
+    unicode-bidi: plaintext;
 }
 
 .functionDescription {
@@ -407,6 +411,10 @@
     background-color: var(--color-gray-100);
     padding: 8px;
     border-radius: 4px;
+
+    /* Not a <code> element, so it misses the global bidi isolation in
+       app/styles/base.css. Without this, `move()` renders as `()move` in RTL. */
+    unicode-bidi: plaintext;
 }
 
 /* ConceptLibrary styles */

--- a/app/components/coding-exercise/ui/log-panel.module.css
+++ b/app/components/coding-exercise/ui/log-panel.module.css
@@ -88,6 +88,10 @@
     line-height: 1.6;
     flex: 1;
     word-break: break-word;
+
+    /* Not a <code> element, so it misses the global bidi isolation in
+       app/styles/base.css. Without this, `move()` renders as `()move` in RTL. */
+    unicode-bidi: plaintext;
 }
 
 .consoleLogString {

--- a/app/components/coding-exercise/ui/test-results-view/io/IOScenarioTable.module.css
+++ b/app/components/coding-exercise/ui/test-results-view/io/IOScenarioTable.module.css
@@ -44,6 +44,11 @@
     overflow-x: auto;
     max-width: 100%;
     padding: 8px;
+
+    /* Stringified code values, not <code> elements, so they miss the global
+       bidi isolation in app/styles/base.css. Without this, `move()` renders as
+       `()move` in RTL. */
+    unicode-bidi: plaintext;
 }
 
 .addedPart,

--- a/app/components/quiz-card/CodeInput.module.css
+++ b/app/components/quiz-card/CodeInput.module.css
@@ -11,6 +11,9 @@
     padding-block: 12px;
     font-family: var(--font-mono);
     font-size: 14px;
+    /* Code entry field: derive each line's direction from its own content so
+       typed LTR code isn't reordered under an RTL locale. */
+    unicode-bidi: plaintext;
     border-radius: 8px;
     border: 2px solid var(--color-gray-300);
     background: var(--color-gray-50);

--- a/app/components/quiz-card/CodeWithBlanks.module.css
+++ b/app/components/quiz-card/CodeWithBlanks.module.css
@@ -5,6 +5,11 @@
     font-family: var(--font-mono);
     font-size: 14px;
     overflow-x: auto;
+
+    /* A multi-line source-code widget with a line-number gutter: a complete
+       LTR island, regardless of the surrounding prose direction. */
+    direction: ltr;
+    unicode-bidi: isolate;
 }
 
 .line {


### PR DESCRIPTION
## The bug

Inline `<code>` inside right-to-left prose (e.g. Farsi instructions) rendered its content in the wrong visual order: `move()` displayed as `()move`.

**Root cause (one explanation, applies to every site below):** the markdown source is correct. The problem is the Unicode Bidi Algorithm. A `<code>` element in RTL prose inherits `direction: rtl` and has no bidi isolation, so the trailing neutral characters (`(`, `)`, `.`, `[`, `]`, `,`) of an LTR token resolve against the RTL paragraph direction and get placed to the *left* of the Latin run. Nothing in the repo set `direction`, `unicode-bidi` or `dir` on code, so this affected every markdown-rendered surface at once.

## The fix

One declaration, applied consistently: **`unicode-bidi: plaintext`**. It derives each line's base direction from that line's own first strong character, so an LTR token reads LTR and genuinely-RTL content still reads RTL. It is direction-agnostic, so unlike the `[dir="rtl"]` overrides used elsewhere in the repo (e.g. `components/blog/CTABlock.module.css`) it needs no conditional and cannot regress LTR locales.

The primary fix is a single rule in the global base reset, which covers *every* `marked.parse()` + `dangerouslySetInnerHTML` surface in the app in one place rather than patching each component's own `code` rule:

- `app/app/styles/base.css` — added `unicode-bidi: plaintext` to the existing `code, kbd, samp, pre` reset rule (`@layer base`, loaded via `globals.css` on every route). No CSS module sets `unicode-bidi`, so nothing overrides it.

That single rule covers all of these markdown/rich-text renderers without per-file changes: `instructions-panel/InstructionsContent.tsx`, `HintsPanel.tsx`, `FunctionsView.tsx`, `instructions-panel/FunctionsGrid.tsx` (description + examples), `test-results-view/ScenarioHeader.tsx`, `test-results-view/VisualTestResultView.tsx`, `test-results-view/IOTestResultView.tsx`, `test-results-view/HighlightedCode.tsx`, `ChatMessageItem.tsx`, `TypeItAssistantMessage.tsx`, `LogPanel.tsx` rich-text chunks, `projects/EpisodeSummary.tsx`, `concepts/ConceptHero.tsx`, `concepts/ConceptCard.tsx`, `quiz-card/QuizContent.tsx`, and the whole blog/article/guide pipeline via `content/MarkdownContent.tsx` + `app/styles/components/textual-content.css`, plus the CodeMirror end-line-information tooltip.

### Sites that are *not* `<code>` elements

These render code-like LTR tokens in `<div>`/`<span>`/`<textarea>`, so they miss the element-level reset and needed the same declaration locally:

- `app/components/coding-exercise/ui/FunctionsView.module.css` — `.signature` (function signatures)
- `app/components/coding-exercise/ui/instructions-panel/instructions-panel.module.css` — `.functionSignature` and `.functionExample`
- `app/components/coding-exercise/ui/log-panel.module.css` — `.consoleLogContent`
- `app/components/coding-exercise/ui/test-results-view/io/IOScenarioTable.module.css` — `.cellScroll` (stringified expected/actual values)
- `app/components/coding-exercise/CodingExercise.module.css` — `.keyboardShortcut`
- `app/components/quiz-card/CodeInput.module.css` — `.textarea` (code entry field)

### One LTR island

- `app/components/quiz-card/CodeWithBlanks.module.css` — `.container` gets `direction: ltr; unicode-bidi: isolate`. This is a multi-line source-code widget with a line-number gutter, so the whole block (including gutter placement) should be LTR regardless of locale, not merely per-line isolated.

## Checks run

- `pnpm typecheck` from the monorepo root: clean
- `pnpm run lint` in `app/`: clean (one pre-existing unrelated warning in `postcss-plugins/shorthand-physical-to-logical.cjs`)
- Full pre-commit suite: 180 suites / 2149 tests passing

## Test plan (needs a human in a browser — I can't verify visually)

Switch to the Farsi locale (`fa`) and confirm LTR tokens like `move()`, `turn_left()`, `my_var`, `[1, 2, 3]` read left-to-right with parens/brackets on the correct side. Then repeat a spot-check in an LTR locale (`en`) to confirm nothing shifted.

- [ ] Exercise **instructions** panel — inline code in the prose (the original `move()` → `()move` repro)
- [ ] Exercise **hints** panel — inline code in hint questions and in hint answers
- [ ] **Functions grid** (instructions panel) — function signature pills, descriptions, and the example snippets
- [ ] **Functions view** / functions list — the `.signature` heading
- [ ] **Scenario headers** in test results — inline code in scenario descriptions
- [ ] **Test result errors** — visual test error messages and IO expected/actual table cells (incl. the diff highlighting)
- [ ] **Log/console panel** output lines
- [ ] **Ask Jiki chat** messages — inline code and fenced code blocks in prompts and responses
- [ ] **Blog / article / guide** content pages — inline code in body prose (`ui-textual-content`)
- [ ] **Concept** pages — concept hero intro and concept card inline code
- [ ] **Quiz cards** — `CodeWithBlanks` (line numbers on the left, code LTR, blanks in the right slots) and `CodeInput`
- [ ] **Keyboard shortcut** pills in the exercise UI
- [ ] Fenced multi-line code blocks anywhere in RTL prose still render each line correctly
- [ ] Sanity check in `en`: none of the above changed appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9tYRNY8BHVT5zSFEWSsfX
