### PR TITLE
i18n: translate level titles for all 32 non-English locales

### DIFF
--- a/curriculum/src/concepts/arrays/sr.md
+++ b/curriculum/src/concepts/arrays/sr.md
@@ -1,7 +1,7 @@
 ---
 title: "Nizovi"
 description: "Uređeni lanac elemenata (stringova, brojeva, Boolean vrednosti ili bilo čega drugog) koji se drži na okupu kao jedna vrednost koju Jiki može da prosleđuje."
-en_md5: 012da550948ba2ebcfaf953cd0906f3f
+en_md5: d26ccb9e04fbc77129f3199d63a95017
 ---
 
 Već neko vreme koristiš brojeve, stringove i Boolean vrednosti, a Boolean je otmena reč za tačno i netačno. Sve njih zovemo različitim tipovima podataka (engl. _data types_). Sada dodajemo naš prvi složeni tip podataka (engl. _compound data type_).
@@ -22,7 +22,7 @@ Može da ga ubaci u ulazni otvor mašine. Može da ga izvuče iz izlaznog otvora
 
 E sada, u kodu niz i izgleda pomalo kao lanac. Ima uglastu zagradu na svakom kraju, a između njih mnogo stavki povezanih u lanac, razdvojenih zapetama.
 
-Na primer, ako želimo da napravimo niz sa imenima nekih članova našeg bootkampa, možemo da napravimo kutiju po imenu `mentors` (mentori) i da stavimo taj lanac u nju.
+Na primer, ako želimo da napravimo niz sa imenima nekih naših mentora, možemo da napravimo kutiju po imenu `mentors` (mentori) i da stavimo taj lanac u nju.
 
 Napišemo `let mentors =`, potpuno isto kao i za bilo koju drugu kutiju, a zatim otvorenu uglastu zagradu, mnogo elemenata, njihova imena razdvojena zapetama, i na kraju zatvorenu uglastu zagradu. Kada Jiki ovo vidi, ode po četiri papirića, po jedan za svako ime, zatim uzme nov lanac i sve ih poveže u njega, pa taj lanac stavi u kutiju `mentors`.
 

--- a/curriculum/src/levels/locales/ar/translation.json
+++ b/curriculum/src/levels/locales/ar/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "استخدام الدوال"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "النصوص والألوان"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "حلقة التكرار"
   },
   "variables": {
-    "title": "�"
+    "title": "المتغيّرات"
   },
   "basic-state": {
-    "title": "�"
+    "title": "الحالة الأساسية"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "دوال تُرجع قيمًا"
   },
   "conditionals": {
-    "title": "�"
+    "title": "الشروط"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "الشروط المركّبة"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "الشروط والحالة"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "اصنع دوالك الخاصة"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "معالجة النصوص"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "المرور على النصوص"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "استخدام عدة دوال معًا"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "الأساليب والخصائص"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "حلقات متقدّمة"
   },
   "lists": {
-    "title": "�"
+    "title": "القوائم"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "القواميس"
   },
   "everything": {
-    "title": "�"
+    "title": "كل شيء"
   }
 }

--- a/curriculum/src/levels/locales/bn/translation.json
+++ b/curriculum/src/levels/locales/bn/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "ফাংশন ব্যবহার"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "স্ট্রিং ও রঙ"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "রিপিট লুপ"
   },
   "variables": {
-    "title": "�"
+    "title": "ভেরিয়েবল"
   },
   "basic-state": {
-    "title": "�"
+    "title": "বেসিক স্টেট"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "রিটার্ন করা ফাংশন"
   },
   "conditionals": {
-    "title": "�"
+    "title": "কন্ডিশনাল"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "জটিল কন্ডিশনাল"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "কন্ডিশনাল ও স্টেট"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "নিজের ফাংশন বানানো"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "স্ট্রিং ম্যানিপুলেশন"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "স্ট্রিং ইটারেশন"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "একাধিক ফাংশন একসাথে"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "মেথড ও প্রপার্টি"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "অ্যাডভান্সড লুপ"
   },
   "lists": {
-    "title": "�"
+    "title": "লিস্ট"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "ডিকশনারি"
   },
   "everything": {
-    "title": "�"
+    "title": "সবকিছু"
   }
 }

--- a/curriculum/src/levels/locales/ca/translation.json
+++ b/curriculum/src/levels/locales/ca/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Usar funcions"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Cadenes i colors"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Bucle repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variables"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Estat bàsic"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funcions que retornen coses"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Condicionals"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Condicionals complexos"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Condicionals i estat"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Crea les teves funcions"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipulació de cadenes"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iteració de cadenes"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Combinar funcions"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Mètodes i propietats"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Bucles avançats"
   },
   "lists": {
-    "title": "�"
+    "title": "Llistes"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Diccionaris"
   },
   "everything": {
-    "title": "�"
+    "title": "Tot"
   }
 }

--- a/curriculum/src/levels/locales/de/translation.json
+++ b/curriculum/src/levels/locales/de/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Funktionen verwenden"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Strings und Farben"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Repeat-Schleife"
   },
   "variables": {
-    "title": "�"
+    "title": "Variablen"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Einfacher Zustand"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funktionen mit Rückgabe"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Bedingungen"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Komplexe Bedingungen"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Bedingungen und Zustand"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Eigene Funktionen schreiben"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Strings bearbeiten"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Strings durchlaufen"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Funktionen kombinieren"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Methoden und Eigenschaften"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Fortgeschrittene Schleifen"
   },
   "lists": {
-    "title": "�"
+    "title": "Listen"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dictionaries"
   },
   "everything": {
-    "title": "�"
+    "title": "Alles"
   }
 }

--- a/curriculum/src/levels/locales/el/translation.json
+++ b/curriculum/src/levels/locales/el/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Χρήση Συναρτήσεων"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Συμβολοσειρές και Χρώματα"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Βρόχος Επανάληψης"
   },
   "variables": {
-    "title": "�"
+    "title": "Μεταβλητές"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Βασική Κατάσταση"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Συναρτήσεις που Επιστρέφουν Τιμές"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Συνθήκες"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Σύνθετες Συνθήκες"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Συνθήκες και Κατάσταση"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Φτιάξε τις Δικές σου Συναρτήσεις"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Επεξεργασία Συμβολοσειρών"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Διάσχιση Συμβολοσειρών"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Συνδυασμός Συναρτήσεων"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Μέθοδοι και Ιδιότητες"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Προχωρημένοι Βρόχοι"
   },
   "lists": {
-    "title": "�"
+    "title": "Λίστες"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Λεξικά"
   },
   "everything": {
-    "title": "�"
+    "title": "Τα Πάντα"
   }
 }

--- a/curriculum/src/levels/locales/es-419/translation.json
+++ b/curriculum/src/levels/locales/es-419/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Usar funciones"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Cadenas y colores"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Bucle repetir"
   },
   "variables": {
-    "title": "�"
+    "title": "Variables"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Estado básico"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funciones que devuelven cosas"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Condicionales"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Condicionales complejos"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Condicionales y estado"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Crea tus propias funciones"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipulación de cadenas"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iteración de cadenas"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Usar varias funciones juntas"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Métodos y propiedades"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Bucles avanzados"
   },
   "lists": {
-    "title": "�"
+    "title": "Listas"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Diccionarios"
   },
   "everything": {
-    "title": "�"
+    "title": "Todo"
   }
 }

--- a/curriculum/src/levels/locales/es-ES/translation.json
+++ b/curriculum/src/levels/locales/es-ES/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Usar funciones"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Cadenas y colores"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Bucle repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variables"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Estado básico"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funciones que devuelven cosas"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Condicionales"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Condicionales complejos"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Condicionales y estado"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Crea tus propias funciones"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipular cadenas"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Recorrer cadenas"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Combinar varias funciones"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Métodos y propiedades"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Bucles avanzados"
   },
   "lists": {
-    "title": "�"
+    "title": "Listas"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Diccionarios"
   },
   "everything": {
-    "title": "�"
+    "title": "Todo"
   }
 }

--- a/curriculum/src/levels/locales/fa/translation.json
+++ b/curriculum/src/levels/locales/fa/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "استفاده از توابع"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "رشته‌ها و رنگ‌ها"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "حلقه تکرار"
   },
   "variables": {
-    "title": "�"
+    "title": "متغیرها"
   },
   "basic-state": {
-    "title": "�"
+    "title": "وضعیت ساده"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "توابعی که چیزی برمی‌گردانند"
   },
   "conditionals": {
-    "title": "�"
+    "title": "شرط‌ها"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "شرط‌های پیچیده"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "شرط‌ها و وضعیت"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "ساختن تابع خودتان"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "کار با رشته‌ها"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "پیمایش رشته‌ها"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "استفاده از چند تابع با هم"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "متدها و ویژگی‌ها"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "حلقه‌های پیشرفته"
   },
   "lists": {
-    "title": "�"
+    "title": "فهرست‌ها"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "دیکشنری‌ها"
   },
   "everything": {
-    "title": "�"
+    "title": "همه‌چیز"
   }
 }

--- a/curriculum/src/levels/locales/fi/translation.json
+++ b/curriculum/src/levels/locales/fi/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Funktioiden käyttö"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Merkkijonot ja värit"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Toistosilmukka"
   },
   "variables": {
-    "title": "�"
+    "title": "Muuttujat"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Tilan perusteet"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Arvoa palauttavat funktiot"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Ehtolauseet"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Monimutkaiset ehtolauseet"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Ehtolauseet ja tila"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Omat funktiot"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Merkkijonojen käsittely"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Merkkijonojen läpikäynti"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Useita funktioita yhdessä"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metodit ja ominaisuudet"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Edistyneet silmukat"
   },
   "lists": {
-    "title": "�"
+    "title": "Listat"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Sanakirjat"
   },
   "everything": {
-    "title": "�"
+    "title": "Kaikki yhdessä"
   }
 }

--- a/curriculum/src/levels/locales/fr/translation.json
+++ b/curriculum/src/levels/locales/fr/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Utiliser les fonctions"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Chaînes et couleurs"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Boucle repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variables"
   },
   "basic-state": {
-    "title": "�"
+    "title": "L'état, les bases"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Fonctions qui renvoient des valeurs"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Conditions"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Conditions complexes"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Conditions et état"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Créer ses propres fonctions"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipuler les chaînes"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Parcourir les chaînes"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Combiner plusieurs fonctions"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Méthodes et propriétés"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Boucles avancées"
   },
   "lists": {
-    "title": "�"
+    "title": "Listes"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dictionnaires"
   },
   "everything": {
-    "title": "�"
+    "title": "Tout"
   }
 }

--- a/curriculum/src/levels/locales/he/translation.json
+++ b/curriculum/src/levels/locales/he/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "שימוש בפונקציות"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "מחרוזות וצבעים"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "לולאת חזרה"
   },
   "variables": {
-    "title": "�"
+    "title": "משתנים"
   },
   "basic-state": {
-    "title": "�"
+    "title": "מצב בסיסי"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "פונקציות שמחזירות ערכים"
   },
   "conditionals": {
-    "title": "�"
+    "title": "תנאים"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "תנאים מורכבים"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "תנאים ומצב"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "כתיבת פונקציות משלכם"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "עיבוד מחרוזות"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "מעבר על מחרוזות"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "שילוב כמה פונקציות"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "מתודות ותכונות"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "לולאות מתקדמות"
   },
   "lists": {
-    "title": "�"
+    "title": "רשימות"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "מילונים"
   },
   "everything": {
-    "title": "�"
+    "title": "הכול"
   }
 }

--- a/curriculum/src/levels/locales/hi/translation.json
+++ b/curriculum/src/levels/locales/hi/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "फ़ंक्शन का उपयोग"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "स्ट्रिंग और रंग"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "रिपीट लूप"
   },
   "variables": {
-    "title": "�"
+    "title": "वेरिएबल"
   },
   "basic-state": {
-    "title": "�"
+    "title": "बेसिक स्टेट"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "रिटर्न करने वाले फ़ंक्शन"
   },
   "conditionals": {
-    "title": "�"
+    "title": "कंडिशनल"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "जटिल कंडिशनल"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "कंडिशनल और स्टेट"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "अपने फ़ंक्शन बनाएँ"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "स्ट्रिंग मैनिपुलेशन"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "स्ट्रिंग इटरेशन"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "कई फ़ंक्शन एक साथ"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "मेथड और प्रॉपर्टी"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "एडवांस्ड लूप"
   },
   "lists": {
-    "title": "�"
+    "title": "लिस्ट"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "डिक्शनरी"
   },
   "everything": {
-    "title": "�"
+    "title": "सब कुछ"
   }
 }

--- a/curriculum/src/levels/locales/hu/translation.json
+++ b/curriculum/src/levels/locales/hu/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Függvények használata"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Szövegek és színek"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Ismétlő ciklus"
   },
   "variables": {
-    "title": "�"
+    "title": "Változók"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Egyszerű állapot"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Értéket visszaadó függvények"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Elágazások"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Összetett elágazások"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Elágazások és állapot"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Saját függvények"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Szövegkezelés"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Szövegek bejárása"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Több függvény együtt"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metódusok és tulajdonságok"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Haladó ciklusok"
   },
   "lists": {
-    "title": "�"
+    "title": "Listák"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Szótárak"
   },
   "everything": {
-    "title": "�"
+    "title": "Minden"
   }
 }

--- a/curriculum/src/levels/locales/id/translation.json
+++ b/curriculum/src/levels/locales/id/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Menggunakan Fungsi"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "String dan Warna"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Perulangan Repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variabel"
   },
   "basic-state": {
-    "title": "�"
+    "title": "State Dasar"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Fungsi yang Mengembalikan Nilai"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Kondisional"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Kondisional Kompleks"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Kondisional dan State"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Membuat Fungsi Sendiri"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipulasi String"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iterasi String"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Menggabungkan Beberapa Fungsi"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metode dan Properti"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Perulangan Lanjutan"
   },
   "lists": {
-    "title": "�"
+    "title": "List"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dictionary"
   },
   "everything": {
-    "title": "�"
+    "title": "Semuanya"
   }
 }

--- a/curriculum/src/levels/locales/it/translation.json
+++ b/curriculum/src/levels/locales/it/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Usare le funzioni"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Stringhe e colori"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Ciclo repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variabili"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Stato di base"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funzioni che restituiscono valori"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Condizionali"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Condizionali complessi"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Condizionali e stato"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Crea le tue funzioni"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipolare le stringhe"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iterare sulle stringhe"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Usare più funzioni insieme"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metodi e proprietà"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Cicli avanzati"
   },
   "lists": {
-    "title": "�"
+    "title": "Liste"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dizionari"
   },
   "everything": {
-    "title": "�"
+    "title": "Tutto quanto"
   }
 }

--- a/curriculum/src/levels/locales/ja/translation.json
+++ b/curriculum/src/levels/locales/ja/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "関数を使う"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "文字列と色"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "繰り返しループ"
   },
   "variables": {
-    "title": "�"
+    "title": "変数"
   },
   "basic-state": {
-    "title": "�"
+    "title": "状態の基本"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "値を返す関数"
   },
   "conditionals": {
-    "title": "�"
+    "title": "条件分岐"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "複雑な条件分岐"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "条件分岐と状態"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "自分で関数を作る"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "文字列の操作"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "文字列の反復処理"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "複数の関数を組み合わせる"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "メソッドとプロパティ"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "発展的なループ"
   },
   "lists": {
-    "title": "�"
+    "title": "リスト"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "辞書"
   },
   "everything": {
-    "title": "�"
+    "title": "総まとめ"
   }
 }

--- a/curriculum/src/levels/locales/ko/translation.json
+++ b/curriculum/src/levels/locales/ko/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "함수 사용하기"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "문자열과 색"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "반복문"
   },
   "variables": {
-    "title": "�"
+    "title": "변수"
   },
   "basic-state": {
-    "title": "�"
+    "title": "기본 상태"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "값을 돌려주는 함수"
   },
   "conditionals": {
-    "title": "�"
+    "title": "조건문"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "복잡한 조건문"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "조건문과 상태"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "나만의 함수 만들기"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "문자열 다루기"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "문자열 반복하기"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "여러 함수 함께 쓰기"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "메서드와 속성"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "고급 반복문"
   },
   "lists": {
-    "title": "�"
+    "title": "리스트"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "딕셔너리"
   },
   "everything": {
-    "title": "�"
+    "title": "모든 것"
   }
 }

--- a/curriculum/src/levels/locales/nl/translation.json
+++ b/curriculum/src/levels/locales/nl/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Functies gebruiken"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Strings en kleuren"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Repeat-lus"
   },
   "variables": {
-    "title": "�"
+    "title": "Variabelen"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Basistoestand"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Functies die iets teruggeven"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Voorwaarden"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Complexe voorwaarden"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Voorwaarden en toestand"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Eigen functies maken"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Strings bewerken"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Strings doorlopen"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Meerdere functies combineren"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Methodes en eigenschappen"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Gevorderde lussen"
   },
   "lists": {
-    "title": "�"
+    "title": "Lijsten"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dictionaries"
   },
   "everything": {
-    "title": "�"
+    "title": "Alles"
   }
 }

--- a/curriculum/src/levels/locales/pl/translation.json
+++ b/curriculum/src/levels/locales/pl/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Używanie funkcji"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Napisy i kolory"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Pętla repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Zmienne"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Podstawy stanu"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funkcje zwracające wartości"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Instrukcje warunkowe"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Złożone warunki"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Warunki i stan"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Twórz własne funkcje"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Operacje na napisach"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iterowanie po napisach"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Łączenie wielu funkcji"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metody i właściwości"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Zaawansowane pętle"
   },
   "lists": {
-    "title": "�"
+    "title": "Listy"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Słowniki"
   },
   "everything": {
-    "title": "�"
+    "title": "Wszystko razem"
   }
 }

--- a/curriculum/src/levels/locales/pt-BR/translation.json
+++ b/curriculum/src/levels/locales/pt-BR/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Usando Funções"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Strings e Cores"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Laço Repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variáveis"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Estado Básico"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funções Que Retornam Coisas"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Condicionais"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Condicionais Complexas"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Condicionais e Estado"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Crie Suas Próprias Funções"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipulação de Strings"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iteração de Strings"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Usando Várias Funções Juntas"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Métodos e Propriedades"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Laços Avançados"
   },
   "lists": {
-    "title": "�"
+    "title": "Listas"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dicionários"
   },
   "everything": {
-    "title": "�"
+    "title": "Tudo"
   }
 }

--- a/curriculum/src/levels/locales/pt-PT/translation.json
+++ b/curriculum/src/levels/locales/pt-PT/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Usar Funções"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Strings e Cores"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Ciclo Repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variáveis"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Estado Básico"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funções Que Devolvem Valores"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Condicionais"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Condicionais Complexas"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Condicionais e Estado"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Criar as Tuas Funções"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipulação de Strings"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iteração de Strings"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Combinar Várias Funções"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Métodos e Propriedades"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Ciclos Avançados"
   },
   "lists": {
-    "title": "�"
+    "title": "Listas"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dicionários"
   },
   "everything": {
-    "title": "�"
+    "title": "Tudo"
   }
 }

--- a/curriculum/src/levels/locales/ro/translation.json
+++ b/curriculum/src/levels/locales/ro/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Folosirea funcțiilor"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Șiruri și culori"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Bucla repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Variabile"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Stare de bază"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funcții care returnează valori"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Condiționale"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Condiționale complexe"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Condiționale și stare"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Creează-ți propriile funcții"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Manipularea șirurilor"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Iterarea șirurilor"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Mai multe funcții împreună"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metode și proprietăți"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Bucle avansate"
   },
   "lists": {
-    "title": "�"
+    "title": "Liste"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Dicționare"
   },
   "everything": {
-    "title": "�"
+    "title": "Totul"
   }
 }

--- a/curriculum/src/levels/locales/ru/translation.json
+++ b/curriculum/src/levels/locales/ru/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Использование функций"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Строки и цвета"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Цикл повторения"
   },
   "variables": {
-    "title": "�"
+    "title": "Переменные"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Основы состояния"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Функции, возвращающие значения"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Условия"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Сложные условия"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Условия и состояние"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Свои функции"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Работа со строками"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Перебор строк"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Несколько функций вместе"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Методы и свойства"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Продвинутые циклы"
   },
   "lists": {
-    "title": "�"
+    "title": "Списки"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Словари"
   },
   "everything": {
-    "title": "�"
+    "title": "Всё вместе"
   }
 }

--- a/curriculum/src/levels/locales/sr/translation.json
+++ b/curriculum/src/levels/locales/sr/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Коришћење функција"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Стрингови и боје"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Петља понављања"
   },
   "variables": {
-    "title": "�"
+    "title": "Променљиве"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Основно стање"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Функције које враћају вредности"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Услови"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Сложени услови"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Услови и стање"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Направи своје функције"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Рад са стринговима"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Пролазак кроз стрингове"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Више функција заједно"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Методе и својства"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Напредне петље"
   },
   "lists": {
-    "title": "�"
+    "title": "Листе"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Речници"
   },
   "everything": {
-    "title": "�"
+    "title": "Све"
   }
 }

--- a/curriculum/src/levels/locales/sv/translation.json
+++ b/curriculum/src/levels/locales/sv/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Använda funktioner"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Strängar och färger"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Repeat-loopen"
   },
   "variables": {
-    "title": "�"
+    "title": "Variabler"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Grundläggande tillstånd"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Funktioner som returnerar saker"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Villkor"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Komplexa villkor"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Villkor och tillstånd"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Skapa egna funktioner"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Stränghantering"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Strängiteration"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Kombinera flera funktioner"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metoder och egenskaper"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Avancerade loopar"
   },
   "lists": {
-    "title": "�"
+    "title": "Listor"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Ordböcker"
   },
   "everything": {
-    "title": "�"
+    "title": "Allt"
   }
 }

--- a/curriculum/src/levels/locales/sw/translation.json
+++ b/curriculum/src/levels/locales/sw/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Kutumia Vitendakazi"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Mifuatano na Rangi"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Kitanzi cha Kurudia"
   },
   "variables": {
-    "title": "�"
+    "title": "Vigezo"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Hali za Msingi"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Vitendakazi Vinavyorudisha Vitu"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Masharti"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Masharti Changamano"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Masharti na Hali"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Tengeneza Vitendakazi Vyako"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Kushughulikia Mifuatano"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Kupitia Mifuatano"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Kutumia Vitendakazi Vingi Pamoja"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Mbinu na Sifa"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Vitanzi vya Hali ya Juu"
   },
   "lists": {
-    "title": "�"
+    "title": "Orodha"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Kamusi"
   },
   "everything": {
-    "title": "�"
+    "title": "Kila Kitu"
   }
 }

--- a/curriculum/src/levels/locales/tr/translation.json
+++ b/curriculum/src/levels/locales/tr/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Fonksiyonları Kullanmak"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Metinler ve Renkler"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Tekrar Döngüsü"
   },
   "variables": {
-    "title": "�"
+    "title": "Değişkenler"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Temel Durum"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Değer Döndüren Fonksiyonlar"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Koşullar"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Karmaşık Koşullar"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Koşullar ve Durum"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Kendi Fonksiyonlarını Yaz"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Metin İşleme"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Metinde Gezinme"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Fonksiyonları Birlikte Kullanmak"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Metotlar ve Özellikler"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "İleri Döngüler"
   },
   "lists": {
-    "title": "�"
+    "title": "Listeler"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Sözlükler"
   },
   "everything": {
-    "title": "�"
+    "title": "Her Şey"
   }
 }

--- a/curriculum/src/levels/locales/uk/translation.json
+++ b/curriculum/src/levels/locales/uk/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Використання функцій"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Рядки та кольори"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Цикл repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Змінні"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Базовий стан"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Функції, що повертають значення"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Умови"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Складні умови"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Умови та стан"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Власні функції"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Робота з рядками"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Перебір рядків"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Кілька функцій разом"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Методи та властивості"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Просунуті цикли"
   },
   "lists": {
-    "title": "�"
+    "title": "Списки"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Словники"
   },
   "everything": {
-    "title": "�"
+    "title": "Усе разом"
   }
 }

--- a/curriculum/src/levels/locales/ur/translation.json
+++ b/curriculum/src/levels/locales/ur/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "فنکشنز کا استعمال"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "سٹرنگز اور رنگ"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "ریپیٹ لوپ"
   },
   "variables": {
-    "title": "�"
+    "title": "ویری ایبلز"
   },
   "basic-state": {
-    "title": "�"
+    "title": "بنیادی سٹیٹ"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "قدر واپس کرنے والے فنکشنز"
   },
   "conditionals": {
-    "title": "�"
+    "title": "کنڈیشنلز"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "پیچیدہ کنڈیشنلز"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "کنڈیشنلز اور سٹیٹ"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "اپنے فنکشنز بنائیں"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "سٹرنگ میں ردوبدل"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "سٹرنگ اِٹریشن"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "کئی فنکشنز ایک ساتھ"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "میتھڈز اور پراپرٹیز"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "ایڈوانسڈ لوپس"
   },
   "lists": {
-    "title": "�"
+    "title": "لسٹس"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "ڈکشنریز"
   },
   "everything": {
-    "title": "�"
+    "title": "سب کچھ"
   }
 }

--- a/curriculum/src/levels/locales/vi/translation.json
+++ b/curriculum/src/levels/locales/vi/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "Sử dụng hàm"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "Chuỗi và màu sắc"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "Vòng lặp repeat"
   },
   "variables": {
-    "title": "�"
+    "title": "Biến"
   },
   "basic-state": {
-    "title": "�"
+    "title": "Trạng thái cơ bản"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "Hàm trả về giá trị"
   },
   "conditionals": {
-    "title": "�"
+    "title": "Câu lệnh điều kiện"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "Điều kiện phức tạp"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "Điều kiện và trạng thái"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "Tự viết hàm"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "Xử lý chuỗi"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "Duyệt chuỗi"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "Kết hợp nhiều hàm"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "Phương thức và thuộc tính"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "Vòng lặp nâng cao"
   },
   "lists": {
-    "title": "�"
+    "title": "Danh sách"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "Từ điển"
   },
   "everything": {
-    "title": "�"
+    "title": "Tất cả"
   }
 }

--- a/curriculum/src/levels/locales/zh-CN/translation.json
+++ b/curriculum/src/levels/locales/zh-CN/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "使用函数"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "字符串与颜色"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "重复循环"
   },
   "variables": {
-    "title": "�"
+    "title": "变量"
   },
   "basic-state": {
-    "title": "�"
+    "title": "基础状态"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "有返回值的函数"
   },
   "conditionals": {
-    "title": "�"
+    "title": "条件判断"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "复杂条件判断"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "条件判断与状态"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "自己写函数"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "字符串处理"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "字符串遍历"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "组合使用多个函数"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "方法与属性"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "进阶循环"
   },
   "lists": {
-    "title": "�"
+    "title": "列表"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "字典"
   },
   "everything": {
-    "title": "�"
+    "title": "综合运用"
   }
 }

--- a/curriculum/src/levels/locales/zh-TW/translation.json
+++ b/curriculum/src/levels/locales/zh-TW/translation.json
@@ -1,56 +1,56 @@
 {
   "using-functions": {
-    "title": "�"
+    "title": "使用函式"
   },
   "strings-and-colors": {
-    "title": "�"
+    "title": "字串與顏色"
   },
   "repeat-loop": {
-    "title": "�"
+    "title": "重複迴圈"
   },
   "variables": {
-    "title": "�"
+    "title": "變數"
   },
   "basic-state": {
-    "title": "�"
+    "title": "基本狀態"
   },
   "functions-that-return-things": {
-    "title": "�"
+    "title": "會回傳值的函式"
   },
   "conditionals": {
-    "title": "�"
+    "title": "條件判斷"
   },
   "complex-conditionals": {
-    "title": "�"
+    "title": "複雜的條件判斷"
   },
   "conditionals-and-state": {
-    "title": "�"
+    "title": "條件判斷與狀態"
   },
   "make-your-own-functions": {
-    "title": "�"
+    "title": "自己寫函式"
   },
   "string-manipulation": {
-    "title": "�"
+    "title": "字串操作"
   },
   "string-iteration": {
-    "title": "�"
+    "title": "走訪字串"
   },
   "multiple-functions": {
-    "title": "�"
+    "title": "一起使用多個函式"
   },
   "methods-and-properties": {
-    "title": "�"
+    "title": "方法與屬性"
   },
   "advanced-loops": {
-    "title": "�"
+    "title": "進階迴圈"
   },
   "lists": {
-    "title": "�"
+    "title": "串列"
   },
   "dictionaries": {
-    "title": "�"
+    "title": "字典"
   },
   "everything": {
-    "title": "�"
+    "title": "全部"
   }
 }


### PR DESCRIPTION
## Summary
- Machine-translated the level title catalog (`curriculum/src/levels/locales/<lang>/translation.json`) for all 32 non-English locales, replacing placeholder/corrupted content.
- Titles kept short, matching the English tone; a few glossary-worthy judgement calls were flagged per-language during translation and may need a native-speaker pass before final release.

## Test plan
- [x] All 32 files validate as JSON with the same key structure as `en/translation.json`
- [x] Curriculum pre-commit checks (typecheck, format, lint, tests) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRS25FD7WVMgr5nYTRkGHW