### PR TITLE
Fix challenge completed modal showing fallback icon

### DIFF
--- a/app/lib/modal/modals/steps/CompletedStep.tsx
+++ b/app/lib/modal/modals/steps/CompletedStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChallengeIcon } from "@/components/icons/ChallengeIcon";
 import { LessonIcon } from "@/components/icons/LessonIcon";
 import { useTranslations } from "next-intl";
 import styles from "@/app/styles/components/modals.module.css";
@@ -28,7 +29,7 @@ export function CompletedStep({
   const hasOutstandingBonuses = outstandingBonusCount > 0;
   return (
     <>
-      <CompletionTimeline exerciseSlug={exerciseSlug} />
+      <CompletionTimeline exerciseSlug={exerciseSlug} isChallenge={isChallenge} />
       <h2 className={styles.modalTitle}>{isChallenge ? t("titleChallenge") : t("titleExercise")}</h2>
       <CompletionMessage
         isChallenge={isChallenge}
@@ -51,14 +52,14 @@ export function CompletedStep({
   );
 }
 
-function CompletionTimeline({ exerciseSlug }: { exerciseSlug: string }) {
+function CompletionTimeline({ exerciseSlug, isChallenge }: { exerciseSlug: string; isChallenge: boolean }) {
   return (
     <div className={timelineStyles.exerciseTimeline}>
       <div className={`${timelineStyles.timelineLine} ${timelineStyles.timelineLineGreen}`}></div>
       <div className={`${timelineStyles.timelineBox} ${timelineStyles.timelineBoxGreen}`}></div>
       <div className={`${timelineStyles.timelineLine} ${timelineStyles.timelineLineAnimate}`}></div>
       <div className={timelineStyles.exerciseIconBox}>
-        <LessonIcon slug={exerciseSlug} />
+        {isChallenge ? <ChallengeIcon slug={exerciseSlug} /> : <LessonIcon slug={exerciseSlug} />}
         <div className={timelineStyles.exerciseIconGreenOverlay}></div>
       </div>
       <div


### PR DESCRIPTION
The completion modal always rendered `LessonIcon`, which looks up `icons/lessons/{slug}.svg`. Challenge icons live in `icons/challenges/`, so every challenge fell through to the placeholder ("LOST" cat poster) even though the challenge page itself rendered the right icon via `ChallengeIcon`.

`isChallenge` was already plumbed into `CompletedStep`, so this just threads it down to the timeline and picks the matching icon component.

## Test plan

- Complete a challenge (e.g. Checkerboard) and confirm the completion modal shows the challenge icon, not the placeholder.
- Complete a regular exercise and confirm its lesson icon is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPJW97kAGYYSz6FJzpU4mx