### PR TITLE
Accessibility page: point feedback link at the forum

### DIFF
--- a/content/src/posts/articles/accessibility/source.md
+++ b/content/src/posts/articles/accessibility/source.md
@@ -23,4 +23,4 @@ Our website is compliant with the Web Content Accessibility Guidelines version 2
 ## Improving accessibility
 
 We are always keen to know if parts of our website are not accessible.
-If you find something that's not good enough, please open an issue on our [GitHub repository](https://github.com/jikidotdev/jiki/issues) explaining what we need to improve.
+If you find something that's not good enough, please let us know on our [forum](https://forum.jiki.io) explaining what we need to improve.


### PR DESCRIPTION
The GitHub issues link on /help/accessibility 404s, [reported on the forum](https://forum.jiki.io/t/accessibility-page-has-a-broken-link/1190).

Points it at https://forum.jiki.io instead, matching the support and beta-phase articles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCfws3MiBqDmAmux2qmRAM