### PR TITLE
Formal Dinner: clarify .slice() description

### DIFF
--- a/curriculum/src/exercises/formal-dinner/instructions/hu.md
+++ b/curriculum/src/exercises/formal-dinner/instructions/hu.md
@@ -34,7 +34,7 @@ In addition to the `.length` property you learned about in the last exercise, th
 // ["J", "r", "my"]
 ```
 
-`[...].slice(start)` slices off part of the `start` part of an array, and returns a NEW array with those items. For example:
+`[...].slice(start)` captures part of an array, starting at index `start` and continuing to the end of the array. The captured elements are copied into a NEW array, which is returned to you. In effect, this drops the first `start` elements. For example:
 
 ```js
 ["Jeremy", "Erik", "Aron", "DJ", "Glenn", "Isaac", "Bethany"].slice(2)

--- a/curriculum/src/exercises/formal-dinner/instructions/source.md
+++ b/curriculum/src/exercises/formal-dinner/instructions/source.md
@@ -34,7 +34,7 @@ In addition to the `.length` property you learned about in the last exercise, th
 // ["J", "r", "my"]
 ```
 
-`[...].slice(start)` slices off part of the `start` part of an array, and returns a NEW array with those items. For example:
+`[...].slice(start)` captures part of an array, starting at index `start` and continuing to the end of the array. The captured elements are copied into a NEW array, which is returned to you. In effect, this drops the first `start` elements. For example:
 
 ```js
 ["Jeremy", "Erik", "Aron", "DJ", "Glenn", "Isaac", "Bethany"].slice(2)


### PR DESCRIPTION
Actions [Glenn's suggestion on the forum](https://forum.jiki.io/t/formal-dinner-instructions-issue/1172/3).

The old line described `slice` using the word "slice", and turned `start` into "the `start` part", which read as nonsense:

> `[...].slice(start)` slices off part of the `start` part of an array, and returns a NEW array with those items.

Now:

> `[...].slice(start)` captures part of an array, starting at index `start` and continuing to the end of the array. The captured elements are copied into a NEW array, which is returned to you. In effect, this drops the first `start` elements.

Mirrored into `hu.md`, which is still an untranslated English stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1oaTuMY4D3V1LURdwrNry