### PR TITLE
Front end owns every video

### DIFF
--- a/API_TODO.md
+++ b/API_TODO.md
@@ -1,0 +1,75 @@
+# API TODO — video data moves to the front end
+
+The front end now owns every video the platform plays. Videos are authored in
+`curriculum/src/videos/videos.json` (keyed by video slug, one entry per locale
+plus a required `fallback`), referenced from `curriculum/src/concepts/{slug}/config.json`
+(`"video": "<video-slug>"`) and from exercise `metadata.json` (`"walkthroughVideo": "<video-slug>"`),
+and resolved per locale at build time into the static catalogs the app fetches.
+
+The API no longer needs to store, validate or serve any of it. Everything below
+is API-side cleanup to do **after** the front-end change has shipped — until
+then the API can keep serving the fields, the front end simply ignores them.
+
+## 1. Stop serving video data
+
+- `SerializeConcept` — drop `video_data`.
+- `SerializeAdminConcept` / `SerializeAdminConcepts` — drop `video_data`.
+- `SerializeLesson` — drop `walkthrough_video_data`, and drop the `data[:sources]`
+  block from the payload.
+- `SerializeAdminLesson` — drop `walkthrough_video_data`.
+
+**Check first:** these are read paths. If anything in admin _writes_ video data,
+that workflow ends (video metadata becomes a curriculum edit + deploy). Confirm
+before deleting.
+
+## 2. Remove the video programming-language axis
+
+`SerializeLesson#data` filters `sources` to those matching `user_courses.language`
+(`javascript` / `python`). No seed ever set a `language` on a source, so this is
+dead code, and the front end has replaced the axis with human locale. Remove:
+
+- the `sources` filtering in `SerializeLesson#data`
+- the `language` lookup it does via `user.user_courses`
+
+`user_courses.language` itself stays — it is still the student's chosen
+programming language for everything else.
+
+## 3. Drop the storage and validation
+
+- `db/seeds/curriculum.json` — remove the `data.sources` block from every video
+  lesson. Keep `type: "video"` and the lesson's place in the syllabus.
+- `app/models/concerns/has_video_data.rb` — delete; the catalog generator now
+  enforces provider/id/durationSeconds/uploadDate.
+- `Lesson#validate_video_data!` and the `choose_language` sources validation —
+  delete. A video lesson with no video is now caught at build time in the front
+  end, not at save time here.
+- `lessons.walkthrough_video_data` column — drop once nothing reads it.
+
+Progress tracking is unaffected: `user_videos` and
+`user_lessons.walkthrough_video_watched_percentage` key on identity, not
+metadata, and stay exactly as they are.
+
+## 4. Concept unlocking is now only unlocking
+
+`concepts.unlocked_by_lesson` was doing double duty: gating the concept _and_
+supplying its recap video. It now only gates. That means a concept can be
+unlocked by an exercise lesson without losing its video, and
+`db/seeds/concepts.json` can point each concept at whatever lesson genuinely
+unlocks it.
+
+Related: PR #603 repoints `type-conversion` from `for-while-loops` to
+`isbn-verifier`. That was the interim fix for the wrong video showing on the
+Type Conversion concept page. With this change the video is gone regardless, so
+the repoint is now purely an unlocking decision — keep it or revert it on that
+basis alone.
+
+## 5. Confirm Mux playback policy (do this first)
+
+Lesson video sources were previously only reachable through `internal/`
+(authenticated). They now ship in a public static catalog. If those Mux assets
+use **public** playback policy, the catalog was effectively the paywall and
+publishing it gives the course away. If they use **signed** playback, the ids
+are inert and there is nothing to do.
+
+Concept videos and project episodes were already public, so they are unaffected
+either way.

--- a/app/app/(hybrid)/[locale]/concepts/[slug]/page.tsx
+++ b/app/app/(hybrid)/[locale]/concepts/[slug]/page.tsx
@@ -10,8 +10,7 @@ import {
   getChildrenServer,
   getRelatedConceptsServer,
   getConceptContentServer,
-  getExercisesForConceptServer,
-  getConceptVideoDataServer
+  getExercisesForConceptServer
 } from "@/lib/concepts/server-concepts";
 import type { ConceptDetailSeed } from "@/components/concepts/lib/useConceptDetailData";
 import type { VideoSource } from "@/types/lesson";
@@ -41,14 +40,13 @@ export default async function AppConceptPage({ params }: Props) {
   let initialLeafData: ConceptDetailSeed | undefined;
   let conceptVideos: VideoSource[] = [];
   if (concept && !isCategory) {
-    const [content, relatedConcepts, relatedExercises, videoData] = await Promise.all([
+    const [content, relatedConcepts, relatedExercises] = await Promise.all([
       getConceptContentServer(slug, locale),
       getRelatedConceptsServer(slug, locale),
-      getExercisesForConceptServer(slug, locale),
-      getConceptVideoDataServer(slug)
+      getExercisesForConceptServer(slug, locale)
     ]);
-    initialLeafData = { concept, ancestors, content, relatedConcepts, relatedExercises, videoData };
-    conceptVideos = videoData ?? [];
+    initialLeafData = { concept, ancestors, content, relatedConcepts, relatedExercises };
+    conceptVideos = concept.video ? [concept.video] : [];
   }
 
   // Structured data: describe the concept as a LearningResource, emit a VideoObject

--- a/app/app/(hybrid)/[locale]/concepts/[slug]/page.tsx
+++ b/app/app/(hybrid)/[locale]/concepts/[slug]/page.tsx
@@ -13,7 +13,6 @@ import {
   getExercisesForConceptServer
 } from "@/lib/concepts/server-concepts";
 import type { ConceptDetailSeed } from "@/components/concepts/lib/useConceptDetailData";
-import type { VideoSource } from "@/types/lesson";
 
 interface Props {
   params: Promise<{ slug: string; locale: string }>;
@@ -38,7 +37,6 @@ export default async function AppConceptPage({ params }: Props) {
   // Leaf pages seed the full detail view (body, sidebar, video) so logged-out
   // visitors render entirely on the server.
   let initialLeafData: ConceptDetailSeed | undefined;
-  let conceptVideos: VideoSource[] = [];
   if (concept && !isCategory) {
     const [content, relatedConcepts, relatedExercises] = await Promise.all([
       getConceptContentServer(slug, locale),
@@ -46,28 +44,29 @@ export default async function AppConceptPage({ params }: Props) {
       getExercisesForConceptServer(slug, locale)
     ]);
     initialLeafData = { concept, ancestors, content, relatedConcepts, relatedExercises };
-    conceptVideos = concept.video ? [concept.video] : [];
   }
 
   // Structured data: describe the concept as a LearningResource, emit a VideoObject
-  // per walkthrough video (so Google can index the concept video), and place the
-  // concept in a breadcrumb trail.
+  // for its recap video (so Google can index it), and place the concept in a
+  // breadcrumb trail.
   const jsonLd = concept
     ? [
         conceptLearningResourceSchema(concept, locale),
-        ...conceptVideos.map((v) =>
-          videoObjectSchema({
-            path: `/concepts/${concept.slug}`,
-            locale,
-            name: concept.title,
-            description: concept.description,
-            uploadDate: v.uploadDate,
-            durationSeconds: v.durationSeconds,
-            provider: v.provider,
-            videoKey: v.id,
-            isAccessibleForFree: true
-          })
-        ),
+        ...(concept.video
+          ? [
+              videoObjectSchema({
+                path: `/concepts/${concept.slug}`,
+                locale,
+                name: concept.title,
+                description: concept.description,
+                uploadDate: concept.video.uploadDate,
+                durationSeconds: concept.video.durationSeconds,
+                provider: concept.video.provider,
+                videoKey: concept.video.id,
+                isAccessibleForFree: true
+              })
+            ]
+          : []),
         breadcrumbSchema(
           [
             { name: "Concepts", path: "/concepts" },

--- a/app/app/dev/choose-language/page.tsx
+++ b/app/app/dev/choose-language/page.tsx
@@ -7,7 +7,6 @@ import type { ProgrammingLanguage } from "@/types/course";
 type ChooseLanguageLesson = Lesson & {
   type: "choose_language";
   data: {
-    sources: VideoSource[];
     language_options: ProgrammingLanguage[];
   };
 };
@@ -16,20 +15,18 @@ type ChooseLanguageLesson = Lesson & {
 const mockLessonData: ChooseLanguageLesson = {
   slug: "welcome-to-coding-fundamentals",
   type: "choose_language",
-  walkthrough_video_data: null,
   data: {
-    sources: [
-      {
-        provider: "mux",
-        id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
-        durationSeconds: 120,
-        uploadDate: "2026-01-01"
-      }
-    ],
     language_options: ["javascript", "python"]
   }
 };
 
+const mockVideo: VideoSource = {
+  provider: "mux",
+  id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+  durationSeconds: 120,
+  uploadDate: "2026-01-01"
+};
+
 export default function ChooseLanguagePage() {
-  return <ChooseLanguage lessonData={mockLessonData} onReady={() => {}} />;
+  return <ChooseLanguage lessonData={mockLessonData} video={mockVideo} onReady={() => {}} />;
 }

--- a/app/app/dev/curriculum-videos/CurriculumVideosClient.tsx
+++ b/app/app/dev/curriculum-videos/CurriculumVideosClient.tsx
@@ -6,115 +6,66 @@ import styles from "./page.module.css";
 interface VideoSource {
   provider: string;
   id: string;
-  language?: string;
+  durationSeconds: number;
+  uploadDate: string;
 }
 
-interface CurriculumLesson {
-  slug: string;
-  title: string;
-  type: string;
-  data?: { sources?: VideoSource[] } | Record<string, unknown>;
-  walkthrough_video_data?: VideoSource[] | null;
-}
-
-export interface CurriculumLevel {
-  slug: string;
-  title: string;
-  lessons: CurriculumLesson[];
-}
+/** The authored catalog: video slug -> locale (or "fallback") -> source. */
+export type VideoCatalog = Record<string, Record<string, VideoSource>>;
 
 interface VideoEntry {
-  levelTitle: string;
-  levelSlug: string;
-  lessonTitle: string;
-  lessonSlug: string;
+  slug: string;
+  locale: string;
   source: VideoSource;
-  kind: "video" | "walkthrough";
 }
 
-function collectVideos(levels: CurriculumLevel[]): VideoEntry[] {
+function collectVideos(catalog: VideoCatalog): VideoEntry[] {
   const entries: VideoEntry[] = [];
-  for (const level of levels) {
-    for (const lesson of level.lessons) {
-      if (lesson.type === "video" && lesson.data && "sources" in lesson.data) {
-        const sources = (lesson.data as { sources?: VideoSource[] }).sources ?? [];
-        for (const source of sources) {
-          entries.push({
-            levelTitle: level.title,
-            levelSlug: level.slug,
-            lessonTitle: lesson.title,
-            lessonSlug: lesson.slug,
-            source,
-            kind: "video"
-          });
-        }
-      }
-      if (lesson.walkthrough_video_data) {
-        for (const source of lesson.walkthrough_video_data) {
-          entries.push({
-            levelTitle: level.title,
-            levelSlug: level.slug,
-            lessonTitle: lesson.title,
-            lessonSlug: lesson.slug,
-            source,
-            kind: "walkthrough"
-          });
-        }
-      }
+  for (const [slug, localeMap] of Object.entries(catalog)) {
+    for (const [locale, source] of Object.entries(localeMap)) {
+      entries.push({ slug, locale, source });
     }
   }
   return entries;
 }
 
-export default function CurriculumVideosClient({ levels }: { levels: CurriculumLevel[] }) {
-  const videos = collectVideos(levels);
-
-  const grouped = videos.reduce<Record<string, VideoEntry[]>>((acc, entry) => {
-    const key = `${entry.levelSlug}::${entry.levelTitle}`;
-    (acc[key] ??= []).push(entry);
-    return acc;
-  }, {});
+export default function CurriculumVideosClient({ catalog }: { catalog: VideoCatalog }) {
+  const videos = collectVideos(catalog);
 
   return (
     <div className={styles.page}>
       <div className={styles.container}>
         <h1 className={styles.title}>Curriculum Videos</h1>
         <p className={styles.intro}>
-          {videos.length} videos across {Object.keys(grouped).length} levels, sourced from{" "}
-          <code className={styles.inlineCode}>api/db/seeds/curriculum.json</code>.
+          {videos.length} recordings across {Object.keys(catalog).length} videos, sourced from{" "}
+          <code className={styles.inlineCode}>curriculum/src/videos/videos.json</code>.
         </p>
 
-        {Object.entries(grouped).map(([key, entries]) => {
-          const [, levelTitle] = key.split("::");
-          return (
-            <section key={key} className={styles.level}>
-              <h2 className={styles.levelTitle}>{levelTitle}</h2>
-              <div className={styles.grid}>
-                {entries.map((entry, idx) => (
-                  <div key={`${entry.lessonSlug}-${entry.source.id}-${idx}`} className={styles.card}>
-                    <div className={styles.cardHeader}>
-                      <div>
-                        <h3 className={styles.lessonTitle}>{entry.lessonTitle}</h3>
-                        <p className={styles.lessonSlug}>{entry.lessonSlug}</p>
-                      </div>
-                      {entry.kind === "walkthrough" && <span className={styles.walkthroughTag}>walkthrough</span>}
-                    </div>
-                    <div className={styles.videoWrapper}>
-                      {entry.source.provider === "mux" ? (
-                        <JikiMuxPlayer playbackId={entry.source.id} autoPlay={false} />
-                      ) : (
-                        <div className={styles.unsupported}>Unsupported provider: {entry.source.provider}</div>
-                      )}
-                    </div>
-                    <p className={styles.sourceMeta}>
-                      {entry.source.provider}:{entry.source.id}
-                    </p>
-                  </div>
-                ))}
+        <div className={styles.grid}>
+          {videos.map((entry) => (
+            <div key={`${entry.slug}-${entry.locale}`} className={styles.card}>
+              <div className={styles.cardHeader}>
+                <div>
+                  <h3 className={styles.lessonTitle}>{entry.slug}</h3>
+                  <p className={styles.lessonSlug}>
+                    {entry.source.uploadDate} · {entry.source.durationSeconds}s
+                  </p>
+                </div>
+                <span className={styles.walkthroughTag}>{entry.locale}</span>
               </div>
-            </section>
-          );
-        })}
+              <div className={styles.videoWrapper}>
+                {entry.source.provider === "mux" ? (
+                  <JikiMuxPlayer playbackId={entry.source.id} autoPlay={false} />
+                ) : (
+                  <div className={styles.unsupported}>Unsupported provider: {entry.source.provider}</div>
+                )}
+              </div>
+              <p className={styles.sourceMeta}>
+                {entry.source.provider}:{entry.source.id}
+              </p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/app/app/dev/curriculum-videos/page.tsx
+++ b/app/app/dev/curriculum-videos/page.tsx
@@ -1,20 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
-import CurriculumVideosClient, { type CurriculumLevel } from "./CurriculumVideosClient";
+import CurriculumVideosClient, { type VideoCatalog } from "./CurriculumVideosClient";
 
 export const dynamic = "force-dynamic";
 
-interface Curriculum {
-  levels: CurriculumLevel[];
-}
-
-function loadCurriculum(): Curriculum {
-  const filePath = path.resolve(process.cwd(), "../../api/db/seeds/curriculum.json");
-  const raw = fs.readFileSync(filePath, "utf8");
-  return JSON.parse(raw) as Curriculum;
+function loadCatalog(): VideoCatalog {
+  const filePath = path.resolve(process.cwd(), "../curriculum/src/videos/videos.json");
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as VideoCatalog;
 }
 
 export default function CurriculumVideosPage() {
-  const curriculum = loadCurriculum();
-  return <CurriculumVideosClient levels={curriculum.levels} />;
+  return <CurriculumVideosClient catalog={loadCatalog()} />;
 }

--- a/app/app/dev/hints-walkthrough/page.tsx
+++ b/app/app/dev/hints-walkthrough/page.tsx
@@ -11,14 +11,12 @@ const sampleHints = [
   { question: "Hint", answer: "Consider using the <code>modulo</code> operator to check for even/odd numbers." }
 ];
 
-const walkthroughVideoData: VideoSource[] = [
-  {
-    provider: "mux",
-    id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
-    durationSeconds: 120,
-    uploadDate: "2026-01-01"
-  }
-];
+const walkthroughVideo: VideoSource = {
+  provider: "mux",
+  id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+  durationSeconds: 120,
+  uploadDate: "2026-01-01"
+};
 
 export default function HintsWalkthroughPage() {
   return (
@@ -29,11 +27,11 @@ export default function HintsWalkthroughPage() {
 
         <div className={styles.sections}>
           <Section label="Hints + Walkthrough Video">
-            <HintsPanel hints={sampleHints} walkthroughVideoData={walkthroughVideoData} lessonSlug="maze-solve-basic" />
+            <HintsPanel hints={sampleHints} walkthroughVideo={walkthroughVideo} lessonSlug="maze-solve-basic" />
           </Section>
 
           <Section label="Walkthrough Video Only (no hints)">
-            <HintsPanel hints={[]} walkthroughVideoData={walkthroughVideoData} lessonSlug="maze-solve-basic" />
+            <HintsPanel hints={[]} walkthroughVideo={walkthroughVideo} lessonSlug="maze-solve-basic" />
           </Section>
 
           <Section label="Hints Only (no walkthrough)">

--- a/app/app/dev/unlock-animation/page.tsx
+++ b/app/app/dev/unlock-animation/page.tsx
@@ -50,10 +50,13 @@ export default function UnlockAnimationTest() {
       slug: "maze-solve-basic",
       type: "video" as const,
       title: "Introduction to Variables",
-      description: "Learn about variables and data types",
-      walkthrough_video_data: [
-        { provider: "mux" as const, id: "mock-video-id-1", durationSeconds: 120, uploadDate: "2026-01-01" }
-      ]
+      description: "Learn about variables and data types"
+    },
+    walkthroughVideo: {
+      provider: "mux" as const,
+      id: "mock-video-id-1",
+      durationSeconds: 120,
+      uploadDate: "2026-01-01"
     },
     completed: lessonCompleted,
     locked: false,
@@ -66,10 +69,13 @@ export default function UnlockAnimationTest() {
       slug: "using-functions",
       type: "quiz" as const,
       title: "Variables Quiz",
-      description: "Test your knowledge of variables",
-      walkthrough_video_data: [
-        { provider: "mux" as const, id: "mock-video-id-2", durationSeconds: 120, uploadDate: "2026-01-01" }
-      ]
+      description: "Test your knowledge of variables"
+    },
+    walkthroughVideo: {
+      provider: "mux" as const,
+      id: "mock-video-id-2",
+      durationSeconds: 120,
+      uploadDate: "2026-01-01"
     },
     completed: false,
     locked: animationState === "completing" || (!recentlyUnlocked && animationState === "idle"),

--- a/app/app/dev/video-exercise/page.tsx
+++ b/app/app/dev/video-exercise/page.tsx
@@ -2,25 +2,23 @@
 import VideoExercise from "@/components/video-exercise/VideoExercise";
 import type { Lesson, VideoSource } from "@/types/lesson";
 
-type VideoLesson = Lesson & { type: "video"; data: { sources: VideoSource[] } };
+type VideoLesson = Lesson & { type: "video" };
 
 // Mock data for the dev page (matching backend structure)
 const mockLessonData: VideoLesson = {
   slug: "welcome-to-coding-fundamentals",
-  type: "video",
-  walkthrough_video_data: null,
-  data: {
-    sources: [
-      {
-        provider: "mux",
-        id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
-        durationSeconds: 120,
-        uploadDate: "2026-01-01"
-      }
-    ]
-  }
+  type: "video"
+};
+
+const mockVideo: VideoSource = {
+  provider: "mux",
+  id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+  durationSeconds: 120,
+  uploadDate: "2026-01-01"
 };
 
 export default function VideoExercisePage() {
-  return <VideoExercise lessonTitle="Solve the Maze" lessonData={mockLessonData} onReady={() => {}} />;
+  return (
+    <VideoExercise lessonTitle="Solve the Maze" lessonData={mockLessonData} video={mockVideo} onReady={() => {}} />
+  );
 }

--- a/app/app/dev/walkthrough-card/page.tsx
+++ b/app/app/dev/walkthrough-card/page.tsx
@@ -10,15 +10,13 @@ function createLesson(overrides: Partial<LessonDisplayData> = {}): LessonDisplay
       title: "Solve the Maze",
       description: "Guide Jiki through a maze.",
       slug: "maze-solve-basic",
-      type: "exercise",
-      walkthrough_video_data: [
-        {
-          provider: "mux",
-          id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
-          durationSeconds: 120,
-          uploadDate: "2026-01-01"
-        }
-      ]
+      type: "exercise"
+    },
+    walkthroughVideo: {
+      provider: "mux",
+      id: "PNbgUkVhy38y7OELdYseo1GAD01XG8FGLJ1nj9BvuKCU",
+      durationSeconds: 120,
+      uploadDate: "2026-01-01"
     },
     completed: false,
     locked: false,

--- a/app/components/choose-language/ChooseLanguage.tsx
+++ b/app/components/choose-language/ChooseLanguage.tsx
@@ -17,7 +17,6 @@ import styles from "./ChooseLanguage.module.css";
 type ChooseLanguageLesson = Lesson & {
   type: "choose_language";
   data: {
-    sources: VideoSource[];
     language_options: ProgrammingLanguage[];
   };
 };
@@ -27,10 +26,12 @@ type LanguageOption = ProgrammingLanguage | "random";
 
 interface ChooseLanguageProps {
   lessonData: ChooseLanguageLesson;
+  // Resolved for the active locale by the parent; absent if none is authored.
+  video?: VideoSource;
   onReady: () => void;
 }
 
-export default function ChooseLanguage({ lessonData, onReady }: ChooseLanguageProps) {
+export default function ChooseLanguage({ lessonData, video, onReady }: ChooseLanguageProps) {
   const router = useRouter();
   const [step, setStep] = useState<Step>("video");
   const [isInitializing, setIsInitializing] = useState(true);
@@ -104,7 +105,7 @@ export default function ChooseLanguage({ lessonData, onReady }: ChooseLanguagePr
 
       {step === "video" && (
         <VideoStep
-          lessonData={lessonData}
+          video={video}
           onReady={handleReady}
           onProceedToSelector={handleProceedToSelector}
           hasVisitedSelector={hasVisitedSelector}

--- a/app/components/choose-language/ui/VideoStep.tsx
+++ b/app/components/choose-language/ui/VideoStep.tsx
@@ -1,31 +1,21 @@
 "use client";
 
 import { useRef, useState, useEffect } from "react";
-import type { Lesson, VideoSource } from "@/types/lesson";
-import type { ProgrammingLanguage } from "@/types/course";
+import type { VideoSource } from "@/types/lesson";
 import MuxPlayer, { type MuxPlayerRefAttributes } from "@/components/ui/JikiMuxPlayer";
 import { useTranslations } from "next-intl";
 import styles from "../ChooseLanguage.module.css";
 
-type ChooseLanguageLesson = Lesson & {
-  type: "choose_language";
-  data: {
-    sources: VideoSource[];
-    language_options: ProgrammingLanguage[];
-  };
-};
-
 interface VideoStepProps {
-  lessonData: ChooseLanguageLesson;
+  video?: VideoSource;
   onReady: () => void;
   onProceedToSelector: () => void;
   hasVisitedSelector: boolean;
 }
 
-export function VideoStep({ lessonData, onReady, onProceedToSelector, hasVisitedSelector }: VideoStepProps) {
+export function VideoStep({ video, onReady, onProceedToSelector, hasVisitedSelector }: VideoStepProps) {
   const t = useTranslations("misc.chooseLanguage");
-  const videoSource = lessonData.data.sources[0] as VideoSource | undefined;
-  const playbackId = videoSource?.id ?? "";
+  const playbackId = video?.id ?? "";
 
   const playerRef = useRef<MuxPlayerRefAttributes>(null);
   const [isVideoVisible, setIsVideoVisible] = useState(false);

--- a/app/components/coding-exercise/RHS.tsx
+++ b/app/components/coding-exercise/RHS.tsx
@@ -83,12 +83,12 @@ export function RHS({ orchestrator }: RHSProps) {
         return <FunctionsView functions={orchestrator.getExercise().functions} />;
       case "hints": {
         const context = orchestrator.getStore().getState().context;
-        const walkthroughVideoData = context.type === "lesson" ? context.walkthroughVideoData : undefined;
+        const walkthroughVideo = context.type === "lesson" ? context.walkthroughVideo : undefined;
         const lessonSlug = context.slug;
         return (
           <HintsPanel
             hints={orchestrator.getExercise().hints}
-            walkthroughVideoData={walkthroughVideoData}
+            walkthroughVideo={walkthroughVideo}
             lessonSlug={lessonSlug}
           />
         );

--- a/app/components/coding-exercise/lib/types.ts
+++ b/app/components/coding-exercise/lib/types.ts
@@ -30,7 +30,7 @@ export interface CompletionResponseData {
 // The slug identifies both the thing the student opened (routes, progress) and
 // the curriculum exercise it runs — they're the same slug.
 export type ExerciseContext =
-  | { type: "lesson"; slug: ExerciseLessonSlug; walkthroughVideoData?: VideoSource[] | null }
+  | { type: "lesson"; slug: ExerciseLessonSlug; walkthroughVideo?: VideoSource }
   | { type: "challenge"; slug: ChallengeSlug };
 
 // CodeMirror editor types

--- a/app/components/coding-exercise/ui/HintsPanel.tsx
+++ b/app/components/coding-exercise/ui/HintsPanel.tsx
@@ -24,18 +24,18 @@ const MuxPlayer = dynamic(() => import("@/components/ui/JikiMuxPlayer"), { ssr: 
 
 interface HintsViewProps {
   hints: Hint[] | undefined;
-  walkthroughVideoData?: VideoSource[] | null;
+  walkthroughVideo?: VideoSource;
   lessonSlug?: string;
   className?: string;
 }
 
-export default function HintsPanel({ hints, walkthroughVideoData, lessonSlug, className = "" }: HintsViewProps) {
+export default function HintsPanel({ hints, walkthroughVideo, lessonSlug, className = "" }: HintsViewProps) {
   const t = useTranslations("codingExercise.hintsPanel");
   const [revealedHints, setRevealedHints] = useState<Set<number>>(new Set());
   const [walkthroughUnlocked, setWalkthroughUnlocked] = useState(false);
 
   const hasHints = hints && hints.length > 0;
-  const hasWalkthrough = walkthroughVideoData && walkthroughVideoData.length > 0 && lessonSlug;
+  const hasWalkthrough = walkthroughVideo && lessonSlug;
 
   if (!hasHints && !hasWalkthrough) {
     return (
@@ -98,11 +98,11 @@ export default function HintsPanel({ hints, walkthroughVideoData, lessonSlug, cl
             <h3>{t("deepDiveHeading")}</h3>
             <p>{t("deepDiveDescription")}</p>
             {walkthroughUnlocked ? (
-              <InlineWalkthroughPlayer playbackId={walkthroughVideoData[0].id} lessonSlug={lessonSlug} />
+              <InlineWalkthroughPlayer playbackId={walkthroughVideo.id} lessonSlug={lessonSlug} />
             ) : (
               <div className={style.walkthroughThumbWrapper} onClick={handleWalkthroughClick}>
                 <img
-                  src={`https://image.mux.com/${walkthroughVideoData[0].id}/thumbnail.jpg?width=400&height=225`}
+                  src={`https://image.mux.com/${walkthroughVideo.id}/thumbnail.jpg?width=400&height=225`}
                   alt={t("walkthroughThumbnailAlt")}
                   className={style.walkthroughThumb}
                 />

--- a/app/components/concepts/ConceptLeafView.tsx
+++ b/app/components/concepts/ConceptLeafView.tsx
@@ -30,7 +30,6 @@ export function ConceptLeafView({ slug, initialData }: ConceptLeafViewProps) {
     relatedConcepts,
     relatedExercises,
     relatedChallenges,
-    videoData,
     isConceptUnlocked,
     getExerciseStatus,
     getChallengeStatus,
@@ -58,7 +57,7 @@ export function ConceptLeafView({ slug, initialData }: ConceptLeafViewProps) {
               relatedConcepts={relatedConcepts}
               relatedExercises={relatedExercises}
               relatedChallenges={relatedChallenges}
-              videoData={videoData}
+              video={concept.video}
               isConceptUnlocked={isConceptUnlocked}
               getExerciseStatus={getExerciseStatus}
               getChallengeStatus={getChallengeStatus}

--- a/app/components/concepts/ConceptSidebar.tsx
+++ b/app/components/concepts/ConceptSidebar.tsx
@@ -14,7 +14,7 @@ interface ConceptSidebarProps {
   relatedConcepts: ConceptMeta[];
   relatedExercises: ExerciseInfo[];
   relatedChallenges: ChallengeInfo[];
-  videoData: VideoSource[] | null;
+  video: VideoSource | null;
   isConceptUnlocked: (slug: string) => boolean;
   getExerciseStatus: (slug: string) => LessonStatus;
   getChallengeStatus: (slug: string) => ChallengeStatus | "locked";
@@ -26,7 +26,7 @@ export function ConceptSidebar({
   relatedConcepts,
   relatedExercises,
   relatedChallenges,
-  videoData,
+  video,
   isConceptUnlocked,
   getExerciseStatus,
   getChallengeStatus,
@@ -39,9 +39,7 @@ export function ConceptSidebar({
           <UpgradeCard />
         </div>
       )}
-      {videoData && videoData.length > 0 && (
-        <VideoRecapCard conceptSlug={conceptSlug} videoData={videoData} isAuthenticated={isAuthenticated} />
-      )}
+      {video && <VideoRecapCard conceptSlug={conceptSlug} video={video} isAuthenticated={isAuthenticated} />}
       <RelatedConceptsPills concepts={relatedConcepts} isUnlocked={isConceptUnlocked} />
       <RelatedExercises exercises={relatedExercises} getStatus={getExerciseStatus} isAuthenticated={isAuthenticated} />
       <RelatedChallenges challenges={relatedChallenges} getStatus={getChallengeStatus} />

--- a/app/components/concepts/VideoRecapCard.tsx
+++ b/app/components/concepts/VideoRecapCard.tsx
@@ -5,12 +5,12 @@ import styles from "./VideoRecapCard.module.css";
 
 interface VideoRecapCardProps {
   conceptSlug: string;
-  videoData: VideoSource[];
+  video: VideoSource;
   isAuthenticated: boolean;
 }
 
-export function VideoRecapCard({ conceptSlug, videoData, isAuthenticated }: VideoRecapCardProps) {
-  const playbackId = videoData[0].id;
+export function VideoRecapCard({ conceptSlug, video, isAuthenticated }: VideoRecapCardProps) {
+  const playbackId = video.id;
 
   if (isAuthenticated) {
     return <LoggedInVideoRecapCard conceptSlug={conceptSlug} playbackId={playbackId} />;

--- a/app/components/concepts/lib/useConceptDetailData.ts
+++ b/app/components/concepts/lib/useConceptDetailData.ts
@@ -2,7 +2,6 @@ import { isChallengeSlug } from "@jiki/curriculum";
 import { fetchChallenges, type ChallengeData, type ChallengeStatus } from "@/lib/api/challenges";
 import { expandUnlocked, fetchUnlockedConceptSlugs, isUnlocked } from "@/lib/api/concept-unlocks";
 import {
-  fetchConceptVideoData,
   getAncestors,
   getConcept,
   getConceptContent,
@@ -14,7 +13,6 @@ import { fetchLessonStatusesBySlugs, type LessonStatus } from "@/lib/api/lesson-
 import { useAuthStore } from "@/lib/auth/authStore";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import type { ConceptAncestor, ConceptMeta, ExerciseInfo, ChallengeInfo } from "@/types/concepts";
-import type { VideoSource } from "@/types/lesson";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -26,7 +24,6 @@ export interface ConceptDetailSeed {
   content: string | null;
   relatedConcepts: ConceptMeta[];
   relatedExercises: ExerciseInfo[];
-  videoData: VideoSource[] | null;
 }
 
 interface ConceptDetailData {
@@ -37,7 +34,6 @@ interface ConceptDetailData {
   relatedConcepts: ConceptMeta[];
   relatedExercises: ExerciseInfo[];
   relatedChallenges: ChallengeInfo[];
-  videoData: VideoSource[] | null;
   isLoading: boolean;
   error: string | null;
   isAuthenticated: boolean;
@@ -60,15 +56,13 @@ interface ConceptSetupContext {
   setUnlockedConceptSlugs: (value: Set<string>) => void;
   setExerciseStatuses: (value: Record<string, LessonStatus>) => void;
   setChallengeStatuses: (value: Record<string, ChallengeStatus>) => void;
-  setVideoData: (value: VideoSource[] | null) => void;
 }
 
 async function setupForLoggedInUser(exercises: ExerciseInfo[], ctx: ConceptSetupContext) {
-  const [rawUnlockedSlugs, allConcepts, challengesResponse, video] = await Promise.all([
+  const [rawUnlockedSlugs, allConcepts, challengesResponse] = await Promise.all([
     fetchUnlockedConceptSlugs(),
     getConcepts(ctx.locale),
-    fetchChallenges({ per: 100 }).catch(() => ({ results: [] as ChallengeData[] })),
-    fetchConceptVideoData(ctx.slug)
+    fetchChallenges({ per: 100 }).catch(() => ({ results: [] as ChallengeData[] }))
   ]);
   if (ctx.isCancelled()) {
     return;
@@ -112,21 +106,14 @@ async function setupForLoggedInUser(exercises: ExerciseInfo[], ctx: ConceptSetup
   ctx.setUnlockedConceptSlugs(unlockedSlugs);
   ctx.setExerciseStatuses(lessonStatuses);
   ctx.setChallengeStatuses(projStatuses);
-  ctx.setVideoData(video);
 
   if (!unlockedSlugs.has(ctx.slug)) {
     ctx.router.push(ctx.conceptsPath);
   }
 }
 
-async function setupForExternalUser(exercises: ExerciseInfo[], ctx: ConceptSetupContext) {
+function setupForExternalUser(exercises: ExerciseInfo[], ctx: ConceptSetupContext) {
   ctx.setRelatedExercises(exercises);
-
-  const video = await fetchConceptVideoData(ctx.slug);
-  if (ctx.isCancelled()) {
-    return;
-  }
-  ctx.setVideoData(video);
 }
 
 export function useConceptDetailData(slug: string, initialData: ConceptDetailSeed | null = null): ConceptDetailData {
@@ -146,7 +133,6 @@ export function useConceptDetailData(slug: string, initialData: ConceptDetailSee
   const [relatedConcepts, setRelatedConcepts] = useState<ConceptMeta[]>(seeded ? initialData.relatedConcepts : []);
   const [relatedExercises, setRelatedExercises] = useState<ExerciseInfo[]>(seeded ? initialData.relatedExercises : []);
   const [relatedChallenges, setRelatedChallenges] = useState<ChallengeInfo[]>([]);
-  const [videoData, setVideoData] = useState<VideoSource[] | null>(seeded ? initialData.videoData : null);
   const [unlockedConceptSlugs, setUnlockedConceptSlugs] = useState<Set<string>>(new Set());
   const [exerciseStatuses, setExerciseStatuses] = useState<Record<string, LessonStatus>>({});
   const [challengeStatuses, setChallengeStatuses] = useState<Record<string, ChallengeStatus>>({});
@@ -171,15 +157,13 @@ export function useConceptDetailData(slug: string, initialData: ConceptDetailSee
       setRelatedChallenges,
       setUnlockedConceptSlugs,
       setExerciseStatuses,
-      setChallengeStatuses,
-      setVideoData
+      setChallengeStatuses
     };
 
     const load = async () => {
       try {
         setError(null);
         setContent(null);
-        setVideoData(null);
         setIsContentLoading(false);
 
         // Phase 1: resolve concept + ancestors (fast — served from in-memory cache).
@@ -238,7 +222,7 @@ export function useConceptDetailData(slug: string, initialData: ConceptDetailSee
         if (isAuthenticated) {
           await setupForLoggedInUser(exercises, ctx);
         } else {
-          await setupForExternalUser(exercises, ctx);
+          setupForExternalUser(exercises, ctx);
         }
       } catch {
         if (cancelled) {
@@ -281,7 +265,6 @@ export function useConceptDetailData(slug: string, initialData: ConceptDetailSee
     relatedConcepts,
     relatedExercises,
     relatedChallenges,
-    videoData,
     isLoading,
     error,
     isAuthenticated,

--- a/app/components/dashboard/exercise-path/hooks/useLevels.ts
+++ b/app/components/dashboard/exercise-path/hooks/useLevels.ts
@@ -63,12 +63,12 @@ export function buildLevelSections(
           slug: lesson.slug,
           type: lesson.type,
           title: lessonCopy.title,
-          description: lessonCopy.description,
-          walkthrough_video_data: lesson.walkthrough_video_data
+          description: lessonCopy.description
         },
         completed: lesson.status === "completed",
         locked: lesson.status === "locked",
         route: `/lesson/${lesson.slug}`,
+        walkthroughVideo: lessonCopy.walkthroughVideo,
         walkthroughVideoWatchedPercentage: lesson.walkthrough_video_watched_percentage
       };
     });

--- a/app/components/dashboard/exercise-path/types.ts
+++ b/app/components/dashboard/exercise-path/types.ts
@@ -1,4 +1,4 @@
-import type { LessonSummary } from "@/types/lesson";
+import type { LessonSummary, VideoSource } from "@/types/lesson";
 
 // Display wrapper for dashboard lesson rendering.
 //
@@ -7,6 +7,8 @@ import type { LessonSummary } from "@/types/lesson";
 // deliberately has neither.
 export interface LessonDisplayData {
   lesson: LessonSummary & { title: string; description: string };
+  // The recorded walkthrough solve, if this exercise has one.
+  walkthroughVideo?: VideoSource;
   completed: boolean;
   locked: boolean;
   route: string;

--- a/app/components/dashboard/exercise-path/ui/WalkthroughCard.tsx
+++ b/app/components/dashboard/exercise-path/ui/WalkthroughCard.tsx
@@ -11,8 +11,8 @@ interface WalkthroughCardProps {
 
 export function WalkthroughCard({ lesson, isCompleting }: WalkthroughCardProps) {
   const t = useTranslations("dashboard.exercisePath.walkthrough");
-  const walkthroughVideoData = lesson.lesson.walkthrough_video_data;
-  if (!walkthroughVideoData?.length) {
+  const walkthroughVideo = lesson.walkthroughVideo;
+  if (!walkthroughVideo) {
     return null;
   }
   const isLocked = !lesson.completed;
@@ -34,20 +34,20 @@ export function WalkthroughCard({ lesson, isCompleting }: WalkthroughCardProps) 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (isLocked || !walkthroughVideoData.length) {
+    if (isLocked) {
       return;
     }
-    showVideoWalkthrough({ playbackId: walkthroughVideoData[0].id, lessonSlug: lesson.lesson.slug });
+    showVideoWalkthrough({ playbackId: walkthroughVideo.id, lessonSlug: lesson.lesson.slug });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       e.stopPropagation();
-      if (isLocked || !walkthroughVideoData.length) {
+      if (isLocked) {
         return;
       }
-      showVideoWalkthrough({ playbackId: walkthroughVideoData[0].id, lessonSlug: lesson.lesson.slug });
+      showVideoWalkthrough({ playbackId: walkthroughVideo.id, lessonSlug: lesson.lesson.slug });
     }
   };
 

--- a/app/components/lesson/Lesson.tsx
+++ b/app/components/lesson/Lesson.tsx
@@ -112,6 +112,7 @@ export default function Lesson({ slug }: LessonProps) {
         <LessonContent
           lesson={lesson}
           lessonTitle={copy?.title ?? ""}
+          video={copy?.video}
           userCourse={userCourse}
           isCompleted={isCompleted}
           serverSubmission={serverSubmission}

--- a/app/components/lesson/Lesson.tsx
+++ b/app/components/lesson/Lesson.tsx
@@ -113,6 +113,7 @@ export default function Lesson({ slug }: LessonProps) {
           lesson={lesson}
           lessonTitle={copy?.title ?? ""}
           video={copy?.video}
+          walkthroughVideo={copy?.walkthroughVideo}
           userCourse={userCourse}
           isCompleted={isCompleted}
           serverSubmission={serverSubmission}

--- a/app/components/lesson/LessonContent.tsx
+++ b/app/components/lesson/LessonContent.tsx
@@ -20,6 +20,7 @@ interface LessonContentProps {
   // video is already resolved for the active locale; absent for non-video lessons.
   lessonTitle: string;
   video?: VideoSource;
+  walkthroughVideo?: VideoSource;
   userCourse: UserCourse | null;
   isCompleted: boolean;
   serverSubmission: LastSubmissionData | null;
@@ -30,6 +31,7 @@ export default function LessonContent({
   lesson,
   lessonTitle,
   video,
+  walkthroughVideo,
   userCourse,
   isCompleted,
   serverSubmission,
@@ -43,7 +45,7 @@ export default function LessonContent({
     return (
       <CodingExercise
         language={userCourse?.language || "javascript"}
-        context={{ type: "lesson", slug: lesson.slug }}
+        context={{ type: "lesson", slug: lesson.slug, walkthroughVideo }}
         isCompleted={isCompleted}
         serverSubmission={serverSubmission}
         onReady={onReady}

--- a/app/components/lesson/LessonContent.tsx
+++ b/app/components/lesson/LessonContent.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import type { UserCourse } from "@/types/course";
-import type { Lesson } from "@/types/lesson";
+import type { Lesson, VideoSource } from "@/types/lesson";
 import type { LastSubmissionData } from "@/lib/api/types/conversation";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import styles from "./LessonContent.module.css";
@@ -16,8 +16,10 @@ const ChooseLanguage = dynamic(() => import("@/components/choose-language/Choose
 
 interface LessonContentProps {
   lesson: Lesson;
-  // Curriculum copy resolved by the parent during the page load phase.
+  // Curriculum copy resolved by the parent during the page load phase. The
+  // video is already resolved for the active locale; absent for non-video lessons.
   lessonTitle: string;
+  video?: VideoSource;
   userCourse: UserCourse | null;
   isCompleted: boolean;
   serverSubmission: LastSubmissionData | null;
@@ -27,20 +29,21 @@ interface LessonContentProps {
 export default function LessonContent({
   lesson,
   lessonTitle,
+  video,
   userCourse,
   isCompleted,
   serverSubmission,
   onReady
 }: LessonContentProps) {
   if (lesson.type === "video") {
-    return <VideoExercise lessonData={lesson} lessonTitle={lessonTitle} onReady={onReady} />;
+    return <VideoExercise lessonData={lesson} lessonTitle={lessonTitle} video={video} onReady={onReady} />;
   }
 
   if (lesson.type === "exercise") {
     return (
       <CodingExercise
         language={userCourse?.language || "javascript"}
-        context={{ type: "lesson", slug: lesson.slug, walkthroughVideoData: lesson.walkthrough_video_data }}
+        context={{ type: "lesson", slug: lesson.slug }}
         isCompleted={isCompleted}
         serverSubmission={serverSubmission}
         onReady={onReady}
@@ -49,7 +52,7 @@ export default function LessonContent({
   }
 
   if (lesson.type === "choose_language") {
-    return <ChooseLanguage lessonData={lesson} onReady={onReady} />;
+    return <ChooseLanguage lessonData={lesson} video={video} onReady={onReady} />;
   }
 
   // Quiz type - not yet implemented

--- a/app/components/video-exercise/VideoExercise.tsx
+++ b/app/components/video-exercise/VideoExercise.tsx
@@ -11,20 +11,21 @@ import { NoVideoPlaceholder } from "./ui/NoVideoPlaceholder";
 import { useVideoExercise } from "./lib/useVideoExercise";
 import styles from "./VideoExercise.module.css";
 
-type VideoLesson = Lesson & { type: "video"; data: { sources: VideoSource[] } };
+type VideoLesson = Lesson & { type: "video" };
 
 export default function VideoExercise({
   lessonData,
   lessonTitle,
+  video,
   onReady
 }: {
   lessonData: VideoLesson;
   lessonTitle: string;
+  video?: VideoSource;
   onReady: () => void;
 }) {
   const t = useTranslations("videoExercise");
-  const videoSource = lessonData.data.sources[0] as VideoSource | undefined;
-  const playbackId = videoSource?.id ?? "";
+  const playbackId = video?.id ?? "";
 
   const {
     playerRef,
@@ -70,7 +71,7 @@ export default function VideoExercise({
               onCanPlay={autoplay}
             />
           ) : (
-            <NoVideoPlaceholder videoSource={videoSource} />
+            <NoVideoPlaceholder videoSource={video} />
           )}
 
           <div

--- a/app/lib/api/concepts.ts
+++ b/app/lib/api/concepts.ts
@@ -1,4 +1,3 @@
-import { api } from "./client";
 import { conceptIndexHashes } from "@/lib/generated/concept-hashes";
 import { assetsUrl } from "@/lib/assets";
 import { conceptIndexPath, conceptContentPath } from "@/lib/assets-paths";
@@ -10,7 +9,6 @@ import {
   selectRelatedConcepts
 } from "@/lib/concepts/select";
 import type { ConceptMeta, ConceptAncestor, ExerciseInfo } from "@/types/concepts";
-import type { VideoSource } from "@/types/lesson";
 
 // Promise-level cache to deduplicate concurrent requests for the same locale
 let cachedPromise: Promise<ConceptMeta[]> | null = null;
@@ -104,13 +102,4 @@ export async function getConceptContent(slug: string, locale: string): Promise<s
     throw new Error("Failed to fetch concept content");
   }
   return res.text();
-}
-
-export async function fetchConceptVideoData(slug: string): Promise<VideoSource[] | null> {
-  try {
-    const response = await api.get<{ concept: { video_data: VideoSource[] | null } }>(`/external/concepts/${slug}`);
-    return response.data.concept.video_data;
-  } catch {
-    return null;
-  }
 }

--- a/app/lib/api/curriculum-copy.ts
+++ b/app/lib/api/curriculum-copy.ts
@@ -1,10 +1,15 @@
 import { curriculumCopyHashes, badgeCopyHashes } from "@/lib/generated/curriculum-copy-hashes";
 import { assetsUrl } from "@/lib/assets";
 import { curriculumCopyPath, badgeCopyPath } from "@/lib/assets-paths";
+import type { VideoSource } from "@/types/lesson";
 
 export interface CurriculumCopy {
   title: string;
   description: string;
+  // Present only on video lessons: the video the lesson plays.
+  video?: VideoSource;
+  // Present only on exercises that have a recorded walkthrough solve.
+  walkthroughVideo?: VideoSource;
 }
 
 export interface BadgeCopy {

--- a/app/lib/api/levels.ts
+++ b/app/lib/api/levels.ts
@@ -50,7 +50,6 @@ export async function fetchLevelsWithProgress(): Promise<LevelWithProgress[]> {
         slug: lesson.slug,
         type: lesson.type,
         status: userLesson?.status || "locked",
-        walkthrough_video_data: lesson.walkthrough_video_data,
         walkthrough_video_watched_percentage: userLesson?.walkthrough_video_watched_percentage ?? 0
       };
     });

--- a/app/lib/concepts/server-concepts.ts
+++ b/app/lib/concepts/server-concepts.ts
@@ -11,9 +11,7 @@ import { getExerciseMetaBySlugsServer } from "@/lib/api/exercise-meta-server";
 import { assetsUrl } from "@/lib/server/origin";
 import { conceptIndexPath, conceptContentPath } from "@/lib/assets-paths";
 import { fetchStaticContent } from "@/lib/content/fetchStaticContent";
-import { getApiUrl } from "@/lib/api/config";
 import type { ConceptMeta, ConceptAncestor, ExerciseInfo } from "@/types/concepts";
-import type { VideoSource } from "@/types/lesson";
 
 /**
  * Server-side concept loading.
@@ -85,21 +83,3 @@ export async function getExercisesForConceptServer(slug: string, locale: string)
   const metas = await getExerciseMetaBySlugsServer(concept.exerciseSlugs, locale);
   return metas.map((m) => ({ slug: m.slug, title: m.title }));
 }
-
-/**
- * Video data for a concept from the Rails external API. Null when unavailable.
- * Wrapped in React's cache() so a single render (page body + JSON-LD) shares one
- * request, and fails open to null rather than breaking the SSR'd concept page.
- */
-export const getConceptVideoDataServer = cache(async (slug: string): Promise<VideoSource[] | null> => {
-  try {
-    const res = await fetch(getApiUrl(`/external/concepts/${slug}`));
-    if (!res.ok) {
-      return null;
-    }
-    const data = (await res.json()) as { concept: { video_data: VideoSource[] | null } };
-    return data.concept.video_data;
-  } catch {
-    return null;
-  }
-});

--- a/app/scripts/generate-concept-cache.js
+++ b/app/scripts/generate-concept-cache.js
@@ -29,6 +29,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import matter from "gray-matter";
 import { computeHash, writeFile } from "./lib/cache-utils.js";
+import { resolveVideo } from "./lib/videos.js";
 import { marked } from "marked";
 import hljs from "highlight.js/lib/core";
 import setupJikiscript from "@exercism/highlightjs-jikiscript";
@@ -266,6 +267,7 @@ function buildStaticFiles(concepts) {
         category: concept.config.category || false,
         childrenCount: concept.childrenCount,
         exerciseSlugs: concept.exerciseSlugs,
+        video: resolveVideo(concept.config.video, locale),
         contentHash
       });
     }

--- a/app/scripts/generate-curriculum-copy-cache.js
+++ b/app/scripts/generate-curriculum-copy-cache.js
@@ -47,6 +47,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import matter from "gray-matter";
 import { computeHash, writeFile } from "./lib/cache-utils.js";
+import { resolveVideo } from "./lib/videos.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const EXERCISES_DIR = path.join(__dirname, "../../curriculum/src/exercises");
@@ -78,6 +79,11 @@ function readExerciseCopy() {
       continue;
     }
 
+    // An exercise may name a walkthrough video (a recorded solve) in its
+    // metadata; the source is resolved per locale below.
+    const metadata = JSON.parse(fs.readFileSync(path.join(EXERCISES_DIR, slug, "metadata.json"), "utf-8"));
+    const walkthroughVideoSlug = metadata.walkthroughVideo || null;
+
     const instructionsDir = path.join(EXERCISES_DIR, slug, "instructions");
     if (!fs.existsSync(instructionsDir)) {
       continue;
@@ -102,7 +108,8 @@ function readExerciseCopy() {
       byLocale[locale] ??= {};
       byLocale[locale][slug] = {
         title: data.title,
-        description: data.description || ""
+        description: data.description || "",
+        ...(walkthroughVideoSlug ? { walkthroughVideo: resolveVideo(walkthroughVideoSlug, locale) } : {})
       };
     }
   }
@@ -213,10 +220,12 @@ function buildCatalogs(exerciseCopy, videoCopy) {
     }
 
     // Sorted for deterministic output, so the content hash only changes when the
-    // copy actually changes.
+    // copy actually changes. Video lessons additionally carry the source to play,
+    // resolved for this locale — a video lesson with no video is a broken lesson,
+    // so resolveVideo throws rather than emitting an unplayable entry.
     const merged = {};
     for (const slug of [...Object.keys(exercises), ...Object.keys(videos)].sort()) {
-      merged[slug] = exercises[slug] || videos[slug];
+      merged[slug] = slug in videos ? { ...videos[slug], video: resolveVideo(slug, locale) } : exercises[slug];
     }
 
     catalogs[locale] = merged;

--- a/app/scripts/lib/videos.js
+++ b/app/scripts/lib/videos.js
@@ -1,0 +1,92 @@
+/**
+ * Video catalog resolution.
+ *
+ * Every video the platform plays is authored once in
+ * `curriculum/src/videos/videos.json`, keyed by video slug. A video lesson's
+ * slug IS its video slug; concepts reference a video slug from their
+ * `config.json`.
+ *
+ * Each entry is a map of locale -> source, plus a required `fallback` used when
+ * a locale has no recording of its own:
+ *
+ *   "for-while-loops": {
+ *     "fallback": { provider, id, durationSeconds, uploadDate },
+ *     "hu": { provider, id, durationSeconds, uploadDate }
+ *   }
+ *
+ * Resolution happens here, at build time, so each locale's static payload
+ * carries exactly one flat source and the app never resolves at runtime.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CATALOG_PATH = path.join(__dirname, "../../../curriculum/src/videos/videos.json");
+
+const PROVIDERS = ["mux", "youtube"];
+
+let catalog = null;
+
+function validateSource(source, where) {
+  if (!source || typeof source !== "object") {
+    throw new Error(`Video ${where} must be an object`);
+  }
+  if (!PROVIDERS.includes(source.provider)) {
+    throw new Error(`Video ${where} has unknown provider "${source.provider}" (expected ${PROVIDERS.join(", ")})`);
+  }
+  if (typeof source.id !== "string" || source.id.length === 0) {
+    throw new Error(`Video ${where} is missing an id`);
+  }
+  // Both are required for the VideoObject JSON-LD on the public pages these
+  // videos appear on, so a source without them is a broken source.
+  if (typeof source.durationSeconds !== "number") {
+    throw new Error(`Video ${where} is missing durationSeconds`);
+  }
+  if (typeof source.uploadDate !== "string") {
+    throw new Error(`Video ${where} is missing uploadDate`);
+  }
+}
+
+export function loadVideoCatalog() {
+  if (catalog) {
+    return catalog;
+  }
+
+  if (!fs.existsSync(CATALOG_PATH)) {
+    throw new Error(`No video catalog at ${CATALOG_PATH}`);
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(CATALOG_PATH, "utf8"));
+
+  for (const [slug, entry] of Object.entries(parsed)) {
+    if (!entry.fallback) {
+      throw new Error(`Video "${slug}" has no fallback source`);
+    }
+    for (const [locale, source] of Object.entries(entry)) {
+      validateSource(source, `"${slug}" (${locale})`);
+    }
+  }
+
+  catalog = parsed;
+  return catalog;
+}
+
+/**
+ * The source to play for `slug` in `locale`: the locale's own recording, else
+ * the base language's (pt-BR -> pt), else the fallback. Returns null when the
+ * slug names no video at all.
+ */
+export function resolveVideo(slug, locale) {
+  if (!slug) {
+    return null;
+  }
+
+  const entry = loadVideoCatalog()[slug];
+  if (!entry) {
+    throw new Error(`Unknown video "${slug}" — not in curriculum/src/videos/videos.json`);
+  }
+
+  return entry[locale] || entry[locale.split("-")[0]] || entry.fallback;
+}

--- a/app/tests/e2e/badge-reveal.test.ts
+++ b/app/tests/e2e/badge-reveal.test.ts
@@ -4,12 +4,16 @@ import { mockAPIBadgeReveal, mockAPIBadges, mockAPIInternalMe, mockAPIFlag } fro
 import { AUTHENTICATION_COOKIE_NAME } from "@/lib/auth/cookie-config";
 import { createMockUser } from "../mocks/user";
 
+// Badge display copy is resolved from the curriculum badge catalog by slug (the
+// API's `name` is not rendered), so these slugs MUST exist in
+// curriculum/src/badges/locales/*/translation.json — an unknown slug renders as
+// the slug itself and every name assertion below fails.
 const BADGES_FIXTURE = {
   badges: [
     {
       id: 1,
       name: "First Steps",
-      slug: "first-steps",
+      slug: "first_lesson",
       icon: "test-icon-1",
       description: "Completed your first exercise",
       fun_fact: "This is the most common first badge earned",
@@ -19,8 +23,8 @@ const BADGES_FIXTURE = {
     },
     {
       id: 2,
-      name: "Code Warrior",
-      slug: "code-warrior",
+      name: "Maze Navigator",
+      slug: "maze_navigator",
       icon: "test-icon-2",
       description: "Completed 10 exercises",
       fun_fact: "Only 10% of users reach this milestone",
@@ -30,8 +34,8 @@ const BADGES_FIXTURE = {
     },
     {
       id: 3,
-      name: "Learning Journey",
-      slug: "learning-journey",
+      name: "Night Owl",
+      slug: "night_owl",
       icon: "test-icon-3",
       description: "Spent 5 hours learning",
       fun_fact: "The average time to earn this is 2 weeks",
@@ -72,7 +76,7 @@ test.describe("Badge Reveal E2E", () => {
     await mockAPIBadges(page, BADGES_FIXTURE);
     await mockAPIBadgeReveal(page, 2, {
       id: 2,
-      name: "Code Warrior",
+      name: "Maze Navigator",
       icon: "test-icon-2",
       description: "Completed 10 exercises",
       revealed: true,
@@ -86,14 +90,14 @@ test.describe("Badge Reveal E2E", () => {
     const allBadges = page.locator('[data-type="achievement"]');
     await expect(allBadges).toHaveCount(3);
 
-    const codeWarriorBadge = page.locator('[data-type="achievement"]:has-text("Code Warrior")').first();
-    await codeWarriorBadge.waitFor();
-    await expect(codeWarriorBadge).toContainText("Code Warrior");
+    const mazeNavigatorBadge = page.locator('[data-type="achievement"]:has-text("Maze Navigator")').first();
+    await mazeNavigatorBadge.waitFor();
+    await expect(mazeNavigatorBadge).toContainText("Maze Navigator");
 
-    const badgeClasses = await codeWarriorBadge.getAttribute("class");
+    const badgeClasses = await mazeNavigatorBadge.getAttribute("class");
     expect(badgeClasses).toContain("new");
 
-    await codeWarriorBadge.click();
+    await mazeNavigatorBadge.click();
 
     const modal = page.locator('[class*="modal"], [data-modal], [class*="Modal"], [class*="BadgeModal"]').first();
     await modal.waitFor({ state: "visible", timeout: 5000 });
@@ -110,12 +114,12 @@ test.describe("Badge Reveal E2E", () => {
     await modal.waitFor({ state: "hidden", timeout: 5000 });
     await page.waitForTimeout(1600);
 
-    const codeWarriorAfterClick = page.locator('[data-type="achievement"]:has-text("Code Warrior")').first();
+    const mazeNavigatorAfterClick = page.locator('[data-type="achievement"]:has-text("Maze Navigator")').first();
 
-    const codeWarriorHasNew = await codeWarriorAfterClick.locator(':text("NEW")').count();
-    expect(codeWarriorHasNew).toBe(1);
+    const mazeNavigatorHasNew = await mazeNavigatorAfterClick.locator(':text("NEW")').count();
+    expect(mazeNavigatorHasNew).toBe(1);
 
-    await expect(codeWarriorAfterClick).toBeVisible();
-    await expect(codeWarriorAfterClick).toContainText("NEW");
+    await expect(mazeNavigatorAfterClick).toBeVisible();
+    await expect(mazeNavigatorAfterClick).toContainText("NEW");
   });
 });

--- a/app/tests/unit/components/concepts-page/ConceptsGrid.test.tsx
+++ b/app/tests/unit/components/concepts-page/ConceptsGrid.test.tsx
@@ -14,6 +14,7 @@ const mockConcepts: ConceptForDisplay[] = [
     childrenCount: 0,
     exerciseSlugs: [],
     contentHash: "abc123",
+    video: null,
     isUnlocked: true
   },
   {
@@ -26,6 +27,7 @@ const mockConcepts: ConceptForDisplay[] = [
     childrenCount: 3,
     exerciseSlugs: [],
     contentHash: null,
+    video: null,
     isUnlocked: true
   }
 ];

--- a/app/tests/unit/components/dashboard/exercise-path/ExercisePath.test.tsx
+++ b/app/tests/unit/components/dashboard/exercise-path/ExercisePath.test.tsx
@@ -29,7 +29,6 @@ function createLesson(overrides: Partial<LessonWithProgress> = {}): LessonWithPr
     slug: "maze-solve-basic",
     type: "exercise",
     status: "not_started",
-    walkthrough_video_data: null,
     walkthrough_video_watched_percentage: 0,
     ...overrides
   };

--- a/app/tests/unit/components/dashboard/exercise-path/LessonNode.test.tsx
+++ b/app/tests/unit/components/dashboard/exercise-path/LessonNode.test.tsx
@@ -14,7 +14,6 @@ function createMockLessonDisplayData(overrides?: {
       title: "Test Lesson",
       description: "Test description",
       type: "exercise",
-      walkthrough_video_data: null,
       ...overrides?.lesson
     },
     completed: overrides?.completed ?? false,

--- a/app/tests/unit/components/dashboard/exercise-path/buildLevelSections.test.ts
+++ b/app/tests/unit/components/dashboard/exercise-path/buildLevelSections.test.ts
@@ -6,7 +6,6 @@ function createLesson(overrides: Partial<LessonWithProgress> = {}): LessonWithPr
     slug: "maze-solve-basic",
     type: "exercise",
     status: "not_started",
-    walkthrough_video_data: null,
     walkthrough_video_watched_percentage: 0,
     ...overrides
   };

--- a/app/tests/unit/components/dashboard/exercise-path/filterToPublishedLevels.test.ts
+++ b/app/tests/unit/components/dashboard/exercise-path/filterToPublishedLevels.test.ts
@@ -9,7 +9,6 @@ function createLesson(overrides: Partial<LessonWithProgress> = {}): LessonWithPr
     slug: "maze-solve-basic",
     type: "exercise",
     status: "not_started",
-    walkthrough_video_data: null,
     walkthrough_video_watched_percentage: 0,
     ...overrides
   };

--- a/app/tests/unit/lib/hooks/useConcepts.test.ts
+++ b/app/tests/unit/lib/hooks/useConcepts.test.ts
@@ -29,7 +29,8 @@ const mockConcepts = [
     category: true,
     childrenCount: 2,
     exerciseSlugs: ["sprouting-flower"],
-    contentHash: null
+    contentHash: null,
+    video: null
   },
   {
     slug: "functions",
@@ -40,7 +41,8 @@ const mockConcepts = [
     category: false,
     childrenCount: 0,
     exerciseSlugs: [],
-    contentHash: "abc123"
+    contentHash: "abc123",
+    video: null
   }
 ];
 

--- a/app/types/concepts.ts
+++ b/app/types/concepts.ts
@@ -10,7 +10,9 @@ export interface ConceptMeta {
   childrenCount: number;
   exerciseSlugs: string[];
   contentHash: string | null;
-  video_data?: VideoSource[] | null;
+  // The recap video to play, resolved for this locale at build time. Null for a
+  // concept with no video of its own.
+  video: VideoSource | null;
 }
 
 export interface ConceptForDisplay extends ConceptMeta {

--- a/app/types/lesson.ts
+++ b/app/types/lesson.ts
@@ -2,26 +2,29 @@ import type { ExerciseLessonSlug, LessonSlug, VideoLessonSlug } from "@jiki/curr
 import type { ProgrammingLanguage } from "./course";
 
 // Video source type (used across lessons, walkthroughs, concepts). Every source
-// carries duration + upload date (a documented API contract on the Rails
-// HasVideoData concern) so the front-end can emit schema.org VideoObject JSON-LD.
+// carries duration + upload date (enforced by the video catalog generator) so the
+// front-end can emit schema.org VideoObject JSON-LD.
+//
+// This is one already-resolved video, not a set to pick from: the catalog holds
+// each video's per-locale recordings and `scripts/lib/videos.js` resolves them at
+// build time, so a locale's payload carries exactly the source it plays.
 export interface VideoSource {
   provider: "youtube" | "mux";
   id: string;
   durationSeconds: number;
   uploadDate: string;
-  language?: ProgrammingLanguage;
 }
 
 export type LessonType = "exercise" | "video" | "quiz" | "choose_language";
 
 // What every lesson carries, whatever its type.
 //
-// This is only what the front end reads; the API's payload is wider. Display copy
-// is not part of it — titles and descriptions come from the curriculum copy
-// catalog (lib/api/curriculum-copy.ts), keyed by the slug.
+// This is only what the front end reads; the API's payload is wider. Neither
+// display copy nor videos are part of it — titles, descriptions and the video to
+// play all come from the curriculum copy catalog (lib/api/curriculum-copy.ts),
+// keyed by the slug.
 interface LessonFields {
   slug: LessonSlug;
-  walkthrough_video_data: VideoSource[] | null;
 }
 
 // An exercise lesson needs no data block: its slug is the curriculum exercise to
@@ -34,7 +37,6 @@ export interface ExerciseLesson extends LessonFields {
 export interface VideoLesson extends LessonFields {
   type: "video";
   slug: VideoLessonSlug;
-  data: { sources: VideoSource[] };
 }
 
 export interface QuizLesson extends LessonFields {
@@ -43,7 +45,7 @@ export interface QuizLesson extends LessonFields {
 
 export interface ChooseLanguageLesson extends LessonFields {
   type: "choose_language";
-  data: { sources: VideoSource[]; language_options: ProgrammingLanguage[] };
+  data: { language_options: ProgrammingLanguage[] };
 }
 
 // A lesson as the single-lesson endpoint returns it. Discriminate on `type` to

--- a/app/types/levels.ts
+++ b/app/types/levels.ts
@@ -1,5 +1,5 @@
 import type { LessonSlug } from "@jiki/curriculum";
-import type { LessonSummary, LessonType, VideoSource } from "./lesson";
+import type { LessonSummary, LessonType } from "./lesson";
 
 // Re-export for convenience
 export type { LessonSummary, LessonType };
@@ -8,7 +8,6 @@ export interface LessonWithProgress {
   slug: LessonSlug;
   type: LessonType;
   status: "not_started" | "started" | "completed" | "locked";
-  walkthrough_video_data: VideoSource[] | null;
   walkthrough_video_watched_percentage: number;
 }
 

--- a/curriculum/src/concepts/animation/config.json
+++ b/curriculum/src/concepts/animation/config.json
@@ -1,4 +1,5 @@
 {
   "order": 10,
-  "category": false
+  "category": false,
+  "video": "animation"
 }

--- a/curriculum/src/concepts/arithmetic/config.json
+++ b/curriculum/src/concepts/arithmetic/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "variables-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "variables-together"
 }

--- a/curriculum/src/concepts/arrays/config.json
+++ b/curriculum/src/concepts/arrays/config.json
@@ -1,4 +1,5 @@
 {
   "order": 0,
-  "parent": "arrays-group"
+  "parent": "arrays-group",
+  "video": "arrays"
 }

--- a/curriculum/src/concepts/break/config.json
+++ b/curriculum/src/concepts/break/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "loops-group",
   "order": 6,
-  "category": false
+  "category": false,
+  "video": "for-while-loops"
 }

--- a/curriculum/src/concepts/building-arrays/config.json
+++ b/curriculum/src/concepts/building-arrays/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "arrays-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "building-arrays"
 }

--- a/curriculum/src/concepts/colors/config.json
+++ b/curriculum/src/concepts/colors/config.json
@@ -1,4 +1,5 @@
 {
   "order": 0,
-  "parent": "colors-group"
+  "parent": "colors-group",
+  "video": "colors"
 }

--- a/curriculum/src/concepts/continue/config.json
+++ b/curriculum/src/concepts/continue/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "loops-group",
   "order": 7,
-  "category": false
+  "category": false,
+  "video": "for-while-loops"
 }

--- a/curriculum/src/concepts/creating-functions-with-inputs/config.json
+++ b/curriculum/src/concepts/creating-functions-with-inputs/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "functions-group",
   "order": 5,
-  "category": false
+  "category": false,
+  "video": "making-functions-with-inputs"
 }

--- a/curriculum/src/concepts/creating-functions-with-return-values/config.json
+++ b/curriculum/src/concepts/creating-functions-with-return-values/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "functions-group",
   "order": 6,
-  "category": false
+  "category": false,
+  "video": "making-functions-with-return-values"
 }

--- a/curriculum/src/concepts/creating-functions/config.json
+++ b/curriculum/src/concepts/creating-functions/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "functions-group",
   "order": 4,
-  "category": false
+  "category": false,
+  "video": "making-functions"
 }

--- a/curriculum/src/concepts/dictionaries/config.json
+++ b/curriculum/src/concepts/dictionaries/config.json
@@ -1,4 +1,5 @@
 {
   "order": 0,
-  "parent": "dictionaries-group"
+  "parent": "dictionaries-group",
+  "video": "dictionaries"
 }

--- a/curriculum/src/concepts/else-if/config.json
+++ b/curriculum/src/concepts/else-if/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 3,
-  "category": false
+  "category": false,
+  "video": "else-statements"
 }

--- a/curriculum/src/concepts/else/config.json
+++ b/curriculum/src/concepts/else/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 2,
-  "category": false
+  "category": false,
+  "video": "else-statements"
 }

--- a/curriculum/src/concepts/for-loops/config.json
+++ b/curriculum/src/concepts/for-loops/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "loops-group",
   "order": 4,
-  "category": false
+  "category": false,
+  "video": "for-while-loops"
 }

--- a/curriculum/src/concepts/function-composition/config.json
+++ b/curriculum/src/concepts/function-composition/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "functions-group",
   "order": 7,
-  "category": false
+  "category": false,
+  "video": "using-multiple-functions-together"
 }

--- a/curriculum/src/concepts/hsl/config.json
+++ b/curriculum/src/concepts/hsl/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "colors-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "colors"
 }

--- a/curriculum/src/concepts/if/config.json
+++ b/curriculum/src/concepts/if/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "if-statements"
 }

--- a/curriculum/src/concepts/logical-and/config.json
+++ b/curriculum/src/concepts/logical-and/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 4,
-  "category": false
+  "category": false,
+  "video": "logic-gates"
 }

--- a/curriculum/src/concepts/logical-not/config.json
+++ b/curriculum/src/concepts/logical-not/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 7,
-  "category": false
+  "category": false,
+  "video": "remainder"
 }

--- a/curriculum/src/concepts/logical-or/config.json
+++ b/curriculum/src/concepts/logical-or/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 5,
-  "category": false
+  "category": false,
+  "video": "logic-gates"
 }

--- a/curriculum/src/concepts/methods/config.json
+++ b/curriculum/src/concepts/methods/config.json
@@ -1,4 +1,5 @@
 {
   "order": 14,
-  "category": false
+  "category": false,
+  "video": "methods-and-strings"
 }

--- a/curriculum/src/concepts/modulo/config.json
+++ b/curriculum/src/concepts/modulo/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 6,
-  "category": false
+  "category": false,
+  "video": "remainder"
 }

--- a/curriculum/src/concepts/nested-loops/config.json
+++ b/curriculum/src/concepts/nested-loops/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "loops-group",
   "order": 2,
-  "category": false
+  "category": false,
+  "video": "nested-loops"
 }

--- a/curriculum/src/concepts/properties/config.json
+++ b/curriculum/src/concepts/properties/config.json
@@ -1,4 +1,5 @@
 {
   "order": 15,
-  "category": false
+  "category": false,
+  "video": "methods-and-strings"
 }

--- a/curriculum/src/concepts/random/config.json
+++ b/curriculum/src/concepts/random/config.json
@@ -1,4 +1,5 @@
 {
   "order": 11,
-  "category": false
+  "category": false,
+  "video": "random-numbers"
 }

--- a/curriculum/src/concepts/repeat-while/config.json
+++ b/curriculum/src/concepts/repeat-while/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "loops-group",
   "order": 3,
-  "category": false
+  "category": false,
+  "video": "repeat-without-count"
 }

--- a/curriculum/src/concepts/repeat/config.json
+++ b/curriculum/src/concepts/repeat/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "loops-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "repeat-loop"
 }

--- a/curriculum/src/concepts/rgb/config.json
+++ b/curriculum/src/concepts/rgb/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "colors-group",
   "order": 2,
-  "category": false
+  "category": false,
+  "video": "colors"
 }

--- a/curriculum/src/concepts/scenarios/config.json
+++ b/curriculum/src/concepts/scenarios/config.json
@@ -1,4 +1,5 @@
 {
   "order": 13,
-  "category": false
+  "category": false,
+  "video": "scenarios"
 }

--- a/curriculum/src/concepts/scope/config.json
+++ b/curriculum/src/concepts/scope/config.json
@@ -1,4 +1,5 @@
 {
   "order": 12,
-  "category": false
+  "category": false,
+  "video": "scope"
 }

--- a/curriculum/src/concepts/state/config.json
+++ b/curriculum/src/concepts/state/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "conditionals-group",
   "order": 8,
-  "category": false
+  "category": false,
+  "video": "state"
 }

--- a/curriculum/src/concepts/string-concatenation/config.json
+++ b/curriculum/src/concepts/string-concatenation/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "strings-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "string-concatenation"
 }

--- a/curriculum/src/concepts/string-indexing/config.json
+++ b/curriculum/src/concepts/string-indexing/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "strings-group",
   "order": 3,
-  "category": false
+  "category": false,
+  "video": "string-indexing"
 }

--- a/curriculum/src/concepts/string-iteration/config.json
+++ b/curriculum/src/concepts/string-iteration/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "strings-group",
   "order": 4,
-  "category": false
+  "category": false,
+  "video": "string-iteration"
 }

--- a/curriculum/src/concepts/string-templates/config.json
+++ b/curriculum/src/concepts/string-templates/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "strings-group",
   "order": 2,
-  "category": false
+  "category": false,
+  "video": "string-concatenation"
 }

--- a/curriculum/src/concepts/strings/config.json
+++ b/curriculum/src/concepts/strings/config.json
@@ -1,4 +1,5 @@
 {
   "order": 0,
-  "parent": "strings-group"
+  "parent": "strings-group",
+  "video": "strings"
 }

--- a/curriculum/src/concepts/updating-dictionaries/config.json
+++ b/curriculum/src/concepts/updating-dictionaries/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "dictionaries-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "updating-dictionaries"
 }

--- a/curriculum/src/concepts/updating-variables/config.json
+++ b/curriculum/src/concepts/updating-variables/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "variables-group",
   "order": 2,
-  "category": false
+  "category": false,
+  "video": "updating-variables"
 }

--- a/curriculum/src/concepts/using-functions-with-inputs/config.json
+++ b/curriculum/src/concepts/using-functions-with-inputs/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "functions-group",
   "order": 2,
-  "category": false
+  "category": false,
+  "video": "function-inputs"
 }

--- a/curriculum/src/concepts/using-functions-with-return-values/config.json
+++ b/curriculum/src/concepts/using-functions-with-return-values/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "functions-group",
   "order": 3,
-  "category": false
+  "category": false,
+  "video": "functions-that-return-things"
 }

--- a/curriculum/src/concepts/using-functions/config.json
+++ b/curriculum/src/concepts/using-functions/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "functions-group",
   "order": 1,
-  "category": false
+  "category": false,
+  "video": "using-functions"
 }

--- a/curriculum/src/concepts/variables/config.json
+++ b/curriculum/src/concepts/variables/config.json
@@ -1,4 +1,5 @@
 {
   "order": 0,
-  "parent": "variables-group"
+  "parent": "variables-group",
+  "video": "creating-variables"
 }

--- a/curriculum/src/concepts/while-loops/config.json
+++ b/curriculum/src/concepts/while-loops/config.json
@@ -1,5 +1,6 @@
 {
   "parent": "loops-group",
   "order": 5,
-  "category": false
+  "category": false,
+  "video": "for-while-loops"
 }

--- a/curriculum/src/videos/videos.json
+++ b/curriculum/src/videos/videos.json
@@ -1,0 +1,274 @@
+{
+  "welcome-to-coding-fundamentals": {
+    "fallback": {
+      "provider": "mux",
+      "id": "IpNiHV5Pfz3QpaSbGmtdhUqo519FBcDDyGfb57tF902w",
+      "durationSeconds": 191,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "using-functions": {
+    "fallback": {
+      "provider": "mux",
+      "id": "CO5Cn701GibUya1wuoK01kUU01rw02taIYZEdmvFHZgIjRc",
+      "durationSeconds": 276,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "function-inputs": {
+    "fallback": {
+      "provider": "mux",
+      "id": "mHahztg02TYzAve4qxUDkHYLnIrpLP948XMSuqYPqw8A",
+      "durationSeconds": 248,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "strings": {
+    "fallback": {
+      "provider": "mux",
+      "id": "saWa7N5mKY02ZwIjBcP5102bAGABwRJCaA7VacK543xuQ",
+      "durationSeconds": 237,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "repeat-loop": {
+    "fallback": {
+      "provider": "mux",
+      "id": "wD902h8Md3cYuXUoh00P0201ZKDl1p02Lm7GHaMlDsJIoa00U",
+      "durationSeconds": 267,
+      "uploadDate": "2026-07-10"
+    }
+  },
+  "creating-variables": {
+    "fallback": {
+      "provider": "mux",
+      "id": "Y1yaGd5ht6qerPuy58TKkc8ZvF1pToLPkvvI9N5AI1c",
+      "durationSeconds": 352,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "variables-together": {
+    "fallback": {
+      "provider": "mux",
+      "id": "x01ttw78cvyX005yob02zuyUCQDTF86gXYjWi6Tz8GVcEk",
+      "durationSeconds": 273,
+      "uploadDate": "2026-06-06"
+    }
+  },
+  "updating-variables": {
+    "fallback": {
+      "provider": "mux",
+      "id": "iGgimCTqArVVXR7bYkQKL5Nv00c2S2FMpmWuIxtMBNnE",
+      "durationSeconds": 290,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "functions-that-return-things": {
+    "fallback": {
+      "provider": "mux",
+      "id": "HqCtx5KALIqtL02wSgOCy83zuqzycMR8oy01BdHCmVSGM",
+      "durationSeconds": 187,
+      "uploadDate": "2026-07-10"
+    }
+  },
+  "colors": {
+    "fallback": {
+      "provider": "mux",
+      "id": "5X47O7800XWzyMa9ZUcjKtGzp19obzi5GLvUNS6cElwI",
+      "durationSeconds": 402,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "animation": {
+    "fallback": {
+      "provider": "mux",
+      "id": "jrj3bpJNuNQ1tQkcHYduxbtSPSNK5D8jpDuahU00xWQ8",
+      "durationSeconds": 194,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "random-numbers": {
+    "fallback": {
+      "provider": "mux",
+      "id": "ExAsqyg2trGCVVEy4FQ9GaFRWXuJdlqhv4Om7K2027y8",
+      "durationSeconds": 142,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "scope": {
+    "fallback": {
+      "provider": "mux",
+      "id": "wKaRbHv02BFW700ExsghQ00vvD9DQrg01444YZsb6fSwvAs",
+      "durationSeconds": 257,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "scenarios": {
+    "fallback": {
+      "provider": "mux",
+      "id": "CJLyjszp2rtBJl8L3kntt602yNA3iVtrITEDF4ivd7ME",
+      "durationSeconds": 158,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "nested-loops": {
+    "fallback": {
+      "provider": "mux",
+      "id": "01fZExWLXQgcl4nFP1XShPBxtK00idlA00fnDxBzIm9Y02o",
+      "durationSeconds": 263,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "if-statements": {
+    "fallback": {
+      "provider": "mux",
+      "id": "zcmxSxOKn9opIz1a5T00b8LRBIAoAZ8kxOBBZrxQS6uU",
+      "durationSeconds": 256,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "else-statements": {
+    "fallback": {
+      "provider": "mux",
+      "id": "YtnDfhkfV7CstaiFhLMIaeYknAbWqIJ9FTn9FlMn700c",
+      "durationSeconds": 256,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "logic-gates": {
+    "fallback": {
+      "provider": "mux",
+      "id": "yjZUdaMolP7AvvLBWuyilzEDPwf5UcJVour0122tTWoM",
+      "durationSeconds": 201,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "remainder": {
+    "fallback": {
+      "provider": "mux",
+      "id": "Px02iBHwKLMDkhRrMiwgdcjM00fVo6JVY5MgfwT4kU0000k",
+      "durationSeconds": 312,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "repeat-without-count": {
+    "fallback": {
+      "provider": "mux",
+      "id": "00CEptHgeayPLnkov5z7DJven01CbfGcEwAh8s02MLazjU",
+      "durationSeconds": 123,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "state": {
+    "fallback": {
+      "provider": "mux",
+      "id": "GprQMNbd7vE1AITiSyEFAcmiMMD6h200iy4fodZjD1zQ",
+      "durationSeconds": 156,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "making-functions": {
+    "fallback": {
+      "provider": "mux",
+      "id": "wAAkHJrzrZc97iirqkuhy3IGBftP6nMhSd8gyjqF3SA",
+      "durationSeconds": 219,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "making-functions-with-inputs": {
+    "fallback": {
+      "provider": "mux",
+      "id": "Iwn2PLYrpnbXeU5hNXebvbci2WOtuD9w1FhVs8wzgFo",
+      "durationSeconds": 213,
+      "uploadDate": "2026-07-10"
+    }
+  },
+  "making-functions-with-return-values": {
+    "fallback": {
+      "provider": "mux",
+      "id": "HQ8t4J78TeM3BGzTMTm5CHiefqTUlv006hzXNg85AlMU",
+      "durationSeconds": 187,
+      "uploadDate": "2026-07-10"
+    }
+  },
+  "string-concatenation": {
+    "fallback": {
+      "provider": "mux",
+      "id": "k895BIVPNi601prsiwe1Md2zaI01pxKlvD01DueWKdH7zA",
+      "durationSeconds": 213,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "string-indexing": {
+    "fallback": {
+      "provider": "mux",
+      "id": "f3GSAOXHJJ02yElfCKo2cHG00X6h6G5h1PUpNdwEphfi00",
+      "durationSeconds": 146,
+      "uploadDate": "2026-07-25"
+    }
+  },
+  "string-iteration": {
+    "fallback": {
+      "provider": "mux",
+      "id": "Sukf8Q003FG2KGq3WgQEhMqnNlieA9N02urIdqcZ8NTx00",
+      "durationSeconds": 208,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "using-multiple-functions-together": {
+    "fallback": {
+      "provider": "mux",
+      "id": "HqGxmSUhkGy5zF8nkKvCd3itMLgtOpV02CimiwgdCWDE",
+      "durationSeconds": 174,
+      "uploadDate": "2026-07-28"
+    }
+  },
+  "methods-and-strings": {
+    "fallback": {
+      "provider": "mux",
+      "id": "AzDWSOAgAsmfHGVXeGUlD01sY6VYlZ8icPvvRxBUqmF8",
+      "durationSeconds": 214,
+      "uploadDate": "2026-06-11"
+    }
+  },
+  "for-while-loops": {
+    "fallback": {
+      "provider": "mux",
+      "id": "ghCnw2FiEgPSf34NKSMYzH00UODStmO8jYEveiPpvX02Y",
+      "durationSeconds": 314,
+      "uploadDate": "2026-07-28"
+    }
+  },
+  "arrays": {
+    "fallback": {
+      "provider": "mux",
+      "id": "crld00MTVkFCyPjeLB1oK4iz00BbUSyZLcWTKzCD01Mejs",
+      "durationSeconds": 275,
+      "uploadDate": "2026-07-13"
+    }
+  },
+  "building-arrays": {
+    "fallback": {
+      "provider": "mux",
+      "id": "NauVD1prYbb01N9N02LCAHbrSkV8ziUs1AGST02dVM4IZU",
+      "durationSeconds": 92,
+      "uploadDate": "2026-07-12"
+    }
+  },
+  "dictionaries": {
+    "fallback": {
+      "provider": "mux",
+      "id": "CkkTxQwQH8LwilAQjWaYhJysSL02u3gRa8Ce01BrXGaFI",
+      "durationSeconds": 238,
+      "uploadDate": "2026-07-12"
+    }
+  },
+  "updating-dictionaries": {
+    "fallback": {
+      "provider": "mux",
+      "id": "nneymd6yNj2Sjop1xvhQsIUq7RigZoDyr02OVJxF4lqQ",
+      "durationSeconds": 170,
+      "uploadDate": "2026-07-13"
+    }
+  }
+}


### PR DESCRIPTION
Video metadata lived in the API: each video lesson carried a `data.sources` block in `curriculum.json`, and a concept borrowed its recap video from whichever lesson happened to unlock it. That indirection is why the Type Conversion concept page played the for/while/break/continue video, which covers none of it.

## The catalog

Videos now live with the curriculum, in one catalog keyed by video slug:

```json
// curriculum/src/videos/videos.json
"for-while-loops": {
  "fallback": { "provider": "mux", "id": "...", "durationSeconds": 314, "uploadDate": "2026-07-28" },
  "hu": { ... }
}
```

Concepts reference a video slug from their `config.json` (`"video": "for-while-loops"`); exercises may name a walkthrough video in their `metadata.json`. Both are direct links to a video rather than a hop through the thing that unlocks them, so **Type Conversion simply has no video and shows none**.

A locale map (rather than an array with a `locale` field) makes duplicate locales structurally impossible and needs no scan. `fallback` is required; each locale carries its own duration/uploadDate because a re-recorded localisation genuinely differs and both are required for the VideoObject JSON-LD.

## Resolution is build-time

`app/scripts/lib/videos.js` resolves exact locale → base language (`pt-BR` → `pt`) → `fallback`, and the concept + curriculum-copy generators emit one flat source per locale. Each locale's payload carries exactly the video it plays; the app never resolves at runtime. `VideoSource` is now a single resolved video, not an array to pick from.

That also retires the unused `javascript`/`python` filtering axis in `SerializeLesson#data` — video variants key on human locale, not programming language.

## Also

- The concept page loses two API round-trips (`fetchConceptVideoData`, `getConceptVideoDataServer`); the video ships in the concept index that page already loads.
- `/dev/curriculum-videos` now reads the catalog instead of the API seeds, and lists every locale recording.
- The generator hard-fails on a missing `fallback`, unknown provider, or missing duration/uploadDate, replacing the Rails `has_video_data` validation.

## Follow-up

`API_TODO.md` covers the API-side cleanup this unlocks — including removing the video programming-language axis. **Its first item is a prerequisite worth checking before merge:** lesson video sources were previously only reachable through authenticated `internal/` endpoints and now ship in a public static catalog. If the Mux assets use public playback policy, the catalog was effectively the paywall. Signed playback makes this a non-issue.

Typecheck, lint and all 2183 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrBvE3ba8EAfLQUyypoy9m