### PR TITLE
Extract prose rendering into @jiki.io/content-renderer

### DIFF
--- a/.github/workflows/content-renderer.yml
+++ b/.github/workflows/content-renderer.yml
@@ -1,0 +1,84 @@
+name: Content Renderer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "content-renderer/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "content-renderer/**"
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run typecheck
+        working-directory: content-renderer
+        run: pnpm run typecheck
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        working-directory: content-renderer
+        run: pnpm run format:check
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: content-renderer
+        run: pnpm test

--- a/.github/workflows/publish-content-renderer.yml
+++ b/.github/workflows/publish-content-renderer.yml
@@ -1,0 +1,74 @@
+# Publish @jiki.io/content-renderer to npm.
+#
+# ⚠️ DO NOT RENAME OR MOVE THIS FILE.
+#
+# This publishes with npm trusted publishing (OIDC): no token is stored anywhere,
+# GitHub Actions mints a short-lived OIDC token and npm verifies it came from a
+# trusted publisher it has on record. That record pins the repository owner, the
+# repository name, and THIS WORKFLOW'S FILENAME, including the `.yml` extension.
+# Renaming or moving this file breaks publishing until the trusted publisher is
+# updated at https://www.npmjs.com/package/@jiki.io/content-renderer/access, and
+# npm does not validate the config when it is saved, so the breakage first shows
+# up as an `ENEEDAUTH` on a release rather than as anything earlier.
+#
+# Publishing is manual on purpose (`workflow_dispatch`). The package version is
+# the byte-identity contract between this repo and the i18n repo: a release is a
+# deliberate act that both sides then pin, never a side effect of a merge.
+#
+# Requirements this workflow satisfies, per docs.npmjs.com/trusted-publishers:
+#   - `id-token: write`, which mints the OIDC token
+#   - npm CLI >= 11.5.1 and Node >= 22.14.0, so npm is upgraded explicitly rather
+#     than taken from whatever the runner image happens to ship
+#   - `registry-url`, which writes the .npmrc pointing at the public registry
+#   - NO NODE_AUTH_TOKEN and no secret reference at all; a token in the
+#     environment is exactly what this setup exists to remove
+#
+# Provenance attestations are generated automatically under trusted publishing,
+# so there is no `--provenance` flag here.
+
+name: Publish Content Renderer
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: content-renderer
+        run: pnpm test
+
+      - name: Build
+        working-directory: content-renderer
+        run: pnpm run build
+
+      # `npm publish`, not `pnpm publish`: trusted publishing is an npm CLI
+      # feature and the OIDC exchange is implemented there.
+      - name: Publish to npm
+        working-directory: content-renderer
+        run: npm publish

--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -273,6 +273,48 @@ future set), so going live is just the "Adding a New Locale" steps.
   hreflang keys. URLs, `<html lang>` and everything else keep the full internal id. Page
   metadata and the sitemap share `alternateLanguages`, so the mapping lives in one place.
 
+## Prose Rendering: `@jiki.io/content-renderer`
+
+Curriculum prose (concept pages and exercise instructions) is rendered by
+`@jiki.io/content-renderer`, a package in this monorepo at `content-renderer/` that is also
+**published to npm**. It is the only package here that goes to the registry.
+
+**Why it is a package rather than a module.** English prose is authored here; its translations live
+in the separate `i18n` repo. Both publish to the same content-hashed R2 tree, where an artifact's
+filename **is** the hash of its bytes:
+
+```
+/static/concepts/{slug}/{locale}/content-{hash}.html
+```
+
+The two repos therefore have to render byte-identical HTML for identical input, not merely similar
+HTML. One character of difference moves the hash, and the front-end then resolves a URL nothing was
+ever written to, so the page silently does not appear. Two implementations would drift and the
+drift would surface as a wrong-looking page rather than as an error. **The package version is the
+contract**: both repos pin an exact version, and a rendering change is a version bump both sides
+take deliberately.
+
+**What is in it.** `renderMarkdown` (the `marked` config plus the `jikiscript`/`javascript`
+highlight.js grammars), `prepareInstructions`, `stripInlineTags`, `contentHash`, and
+`RENDERER_VERSION`. Anything that can move a byte is part of the contract, so `marked` and the
+grammar packages are pinned exactly rather than ranged, and only Jiki's own two grammars are
+registered.
+
+**Who uses it here.** `scripts/generate-concept-cache.js` (rendering) and
+`scripts/generate-exercise-cache.js` (the inline-tag strip). Both formerly did this inline.
+
+**Not in it.** The blog and articles pipeline in `scripts/generate-content-cache.js` is a separate
+`marked` configuration with footnotes and the stock web-language grammars. It is front-end-only,
+`i18n` does not publish it, so it is deliberately left where it is rather than merged in.
+
+**Note on scope.** The package is `@jiki.io/content-renderer`, matching the npm org `jiki.io`. The
+monorepo's other packages are `@jiki/*`. They are workspace-only and unpublished, so their scope has
+never had to correspond to a real npm org; nothing depends on the two scopes matching.
+
+**The `<define>`/`<literal>` convention.** Authored English may carry `<define>` and `<literal>`
+inline tags. They are authoring markers, not output, and are stripped (keeping their inner text)
+before anything is hashed. Translated files arrive tag-free, so the strip is a no-op for them.
+
 ## Adding a New Locale
 
 When adding a new locale, you must:

--- a/app/.context/tech-stack.md
+++ b/app/.context/tech-stack.md
@@ -28,7 +28,9 @@ The compiler is configured in `next.config.ts` with `experimental.reactCompiler:
 - **Code Editor**: CodeMirror 6 with custom extensions
 - **Animations**: anime.js 4.1.3
 - **State Management**: Zustand 5.0.8
-- **Markdown**: marked 16.3.0
+- **Markdown**: marked 17
+- **Curriculum prose rendering**: `@jiki.io/content-renderer` (workspace package, also published to
+  npm; shared with the `i18n` repo so both render byte-identical HTML — see `.context/i18n.md`)
 - **Interpreters**: Custom workspace package for code execution
 - **Utilities**: lodash, diff
 - **Syntax Highlighting**: highlight.js with custom JikiScript support

--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "@exercism/highlightjs-jikiscript": "^0.0.2",
     "@floating-ui/dom": "^1.7.4",
     "@floating-ui/react": "^0.27.16",
+    "@jiki.io/content-renderer": "workspace:*",
     "@jiki/curriculum": "workspace:*",
     "@jiki/highlightjs-javascript": "github:jiki-education/highlightjs-javascript",
     "@jiki/interpreters": "workspace:*",

--- a/app/scripts/generate-concept-cache.js
+++ b/app/scripts/generate-concept-cache.js
@@ -29,38 +29,13 @@ import path from "path";
 import { fileURLToPath } from "url";
 import matter from "gray-matter";
 import { computeHash, writeFile } from "./lib/cache-utils.js";
-import { marked } from "marked";
-import hljs from "highlight.js/lib/core";
-import setupJikiscript from "@exercism/highlightjs-jikiscript";
-import setupJavascript from "@jiki/highlightjs-javascript";
+import { renderMarkdown } from "@jiki.io/content-renderer";
 
-// Match the syntax highlighting used by exercise instructions (InstructionsContent.tsx).
-// Highlighting is applied at build time so the static concept HTML is self-contained.
-hljs.registerLanguage("jikiscript", setupJikiscript);
-hljs.registerLanguage("javascript", setupJavascript);
-
-marked.use({
-  renderer: {
-    code({ text, lang }) {
-      const language = lang && hljs.getLanguage(lang) ? lang : null;
-      const highlighted = language
-        ? hljs.highlight(text, { language }).value
-        : text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-      const className = language ? ` class="hljs language-${language}"` : "";
-      return `<pre><code${className}>${highlighted}</code></pre>\n`;
-    }
-  },
-  hooks: {
-    // The authored English source (source.md) may contain custom inline tags
-    // <define>...</define> and <literal>...</literal>. The built English HTML is
-    // produced by stripping those tags while keeping their inner text. Translated
-    // files are already tag-free, so this is a no-op for them. Runs before the
-    // content hash is computed (the hash is over this postprocessed HTML).
-    postprocess(html) {
-      return html.replace(/<\/?(?:define|literal)(?:\s[^>]*)?>/gi, "");
-    }
-  }
-});
+// Markdown to HTML (marked config, the jikiscript/javascript highlight.js
+// grammars, and the <define>/<literal> strip) lives in @jiki.io/content-renderer
+// rather than here, because the i18n repo publishes translated concept pages to
+// the same content-hashed R2 tree and its bytes must match these exactly. See
+// that package's src/index.ts for why the version is the contract.
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONCEPTS_DIR = path.join(__dirname, "../../curriculum/src/concepts");
@@ -203,7 +178,7 @@ function processConcepts() {
         // Render markdown to HTML for non-category concepts
         let html = null;
         if (!config.category) {
-          html = marked.parse(markdown);
+          html = renderMarkdown(markdown);
         } else if (markdown.trim()) {
           console.warn(`   Warning: category concept "${slug}" has body content in ${file.name} — it will be ignored`);
         }

--- a/app/scripts/generate-exercise-cache.js
+++ b/app/scripts/generate-exercise-cache.js
@@ -31,6 +31,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import matter from "gray-matter";
 import { computeHash, writeFile } from "./lib/cache-utils.js";
+import { prepareInstructions } from "@jiki.io/content-renderer";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const EXERCISES_DIR = path.join(__dirname, "../../curriculum/src/exercises");
@@ -205,9 +206,10 @@ function processExercises() {
         // Exercise instructions are stored as raw markdown and rendered by marked
         // at runtime (InstructionsContent.tsx), so there is no build-time marked
         // hook to strip the custom <define>/<literal> tags the English source.md
-        // may carry. Strip them here (keeping inner text) before caching; a no-op
-        // for the already tag-free translated files.
-        const instructions = parsed.content.trim().replace(/<\/?(?:define|literal)(?:\s[^>]*)?>/gi, "");
+        // may carry. prepareInstructions does the trim and the strip, and lives in
+        // @jiki.io/content-renderer beside the concept renderer, because both
+        // repos that publish instructions must agree on these bytes.
+        const instructions = prepareInstructions(parsed.content);
 
         locales[locale] = {
           title: parsed.data.title,

--- a/content-renderer/.gitignore
+++ b/content-renderer/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/dist
+/coverage
+*.tsbuildinfo

--- a/content-renderer/.prettierignore
+++ b/content-renderer/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+coverage
+*.tsbuildinfo

--- a/content-renderer/.prettierrc.json
+++ b/content-renderer/.prettierrc.json
@@ -1,0 +1,27 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "none",
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "quoteProps": "as-needed",
+  "endOfLine": "lf",
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "embeddedLanguageFormatting": "off",
+  "singleAttributePerLine": false,
+  "overrides": [
+    {
+      "files": ["*.css"],
+      "options": {
+        "tabWidth": 4,
+        "trailingComma": "none"
+      }
+    }
+  ]
+}

--- a/content-renderer/README.md
+++ b/content-renderer/README.md
@@ -1,0 +1,95 @@
+# @jiki.io/content-renderer
+
+The one implementation of "Jiki curriculum prose to the exact bytes Jiki serves".
+
+## Why it exists
+
+Jiki's English prose is authored in the front-end monorepo. Its translations live in the separate
+[`i18n`](https://github.com/jiki-education/i18n) repo. Both publish to the same content-hashed R2
+tree, where an artifact's filename **is** the hash of its bytes:
+
+```
+/static/concepts/{slug}/{locale}/content-{hash}.html
+```
+
+So the two repos do not need to render similar HTML, they need to render **byte-identical** HTML
+for identical input. A one-character difference moves the hash, and the front-end then computes a
+URL that nothing was ever written to. A second implementation in `i18n` would be two renderers
+drifting apart, and the drift would surface as a wrong-looking page rather than as an error.
+
+**The package version is the contract.** Both repos pin an exact version, and a rendering change is
+a version bump both sides take deliberately.
+
+## API
+
+| Export                    | What it is                                                                 |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `renderMarkdown(md)`      | Concept-page Markdown to the exact HTML Jiki serves                        |
+| `prepareInstructions(md)` | Exercise instructions prepared for caching: trim plus the inline-tag strip |
+| `stripInlineTags(text)`   | Removes `<define>`/`<literal>`, keeping the inner text                     |
+| `contentHash(content)`    | The cache tree's fingerprint: first 12 hex chars of SHA-256                |
+| `RENDERER_VERSION`        | This package's version, for recording in artifact metadata                 |
+| `registeredLanguages()`   | The highlight.js grammars registered here                                  |
+| `isSupportedLanguage(l)`  | Whether a fenced block's language has a grammar here                       |
+
+Input to `renderMarkdown` is the Markdown **body**, frontmatter already removed. Frontmatter
+parsing is not this package's job: the two repos parse it differently on purpose, and it never
+reaches the rendered bytes.
+
+## The two prose pipelines
+
+Jiki's two prose types are cached differently, and both are byte-sensitive:
+
+- **Concept pages** are rendered to HTML at build time and served as `content-{hash}.html`.
+  `renderMarkdown` is that pipeline.
+- **Exercise instructions** are cached as Markdown inside a JSON content file and rendered in the
+  browser at runtime, so the build-time step is only the inline-tag strip and the trim.
+  `prepareInstructions` is that pipeline.
+
+They share `stripInlineTags`, which is the whole reason they can disagree.
+
+## What is part of the contract
+
+Anything that can move a byte:
+
+- the `marked` version and its configuration
+- the set of highlight.js grammars registered, and their versions
+- the `<define>`/`<literal>` strip
+
+Grammar and `marked` versions are therefore **pinned exactly**, not ranged. Only Jiki's own two
+grammars are registered (`jikiscript`, and a Jiki-specific `javascript`), on a private
+`hljs.newInstance()`. A fence in any other language is escaped as plain text rather than
+highlighted, deliberately: picking up whatever grammars the host process happened to register would
+make the bytes depend on the caller.
+
+For the same reason `marked` is used through a private `new Marked()` instance and never the
+module-level singleton, whose `.use()` mutates global state shared with the front-end's blog
+pipeline.
+
+## The `@jiki/highlightjs-javascript` dependency
+
+That grammar is not on npm, and a published package cannot depend on an unpublished one. It does
+not have to be published, because it is depended on as a **git URL pinned to a commit SHA**:
+
+```
+git+https://github.com/jiki-education/highlightjs-javascript.git#1801576...
+```
+
+npm and pnpm both resolve a git dependency of a published package for external consumers. The repo
+is public, its `dist/` is committed so no build step runs on install, and resolution falls back to
+HTTPS when no SSH key is present, which is verified by installing the packed tarball into a clean
+project with a cold cache and SSH disabled.
+
+The SHA pin is not optional. A branch pin would let the grammar move under a released version of
+this package, which would silently break the byte-identity contract in exactly the way the version
+pin exists to prevent. Bumping the grammar means bumping the SHA and this package's version
+together.
+
+Publishing it to npm as `@jiki.io/highlightjs-javascript` would be tidier and would restore
+integrity checking on install. It is not required, so it is not done here.
+
+## Releasing
+
+Publishing is manual, via the **Publish Content Renderer** workflow, using npm trusted publishing
+(OIDC). No token is stored. npm's trusted publisher record pins this repository and the publish
+workflow's **filename**, so that file must not be renamed or moved.

--- a/content-renderer/package.json
+++ b/content-renderer/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@jiki.io/content-renderer",
+  "version": "0.1.0",
+  "description": "Jiki's curriculum prose renderer: the single implementation of Markdown to the exact HTML bytes Jiki serves.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "author": "iHiD",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jiki-education/front-end.git",
+    "directory": "content-renderer"
+  },
+  "keywords": [
+    "jiki",
+    "markdown",
+    "renderer",
+    "curriculum"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "prepare": "pnpm run build"
+  },
+  "dependencies": {
+    "@exercism/highlightjs-jikiscript": "0.0.2",
+    "@jiki/highlightjs-javascript": "git+https://github.com/jiki-education/highlightjs-javascript.git#180157677b2637335e7677e81d6d0aeb0210546d",
+    "highlight.js": "11.11.1",
+    "marked": "17.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.9",
+    "prettier": "^3.8.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.17"
+  }
+}

--- a/content-renderer/src/highlighting.ts
+++ b/content-renderer/src/highlighting.ts
@@ -1,0 +1,38 @@
+import hljs from "highlight.js/lib/core";
+import setupJikiscript from "@exercism/highlightjs-jikiscript";
+import setupJavascript from "@jiki/highlightjs-javascript";
+
+/**
+ * The highlight.js instance curriculum prose is highlighted with.
+ *
+ * It is a private core instance carrying exactly two grammars, both of them
+ * Jiki's own: `jikiscript` and a Jiki-specific `javascript` that differs from
+ * highlight.js's stock one. Nothing else is registered, so a fenced block in an
+ * unknown language falls through to the plain-text branch in `renderMarkdown`
+ * rather than picking up whichever grammars some other part of the process
+ * happened to register on a shared singleton.
+ *
+ * Language set and grammar versions are part of the byte contract: registering a
+ * language here changes the HTML of every document that fences it, and so moves
+ * its content hash. That is why the grammar packages are pinned exactly and why
+ * this package's version is what the two repos agree on.
+ */
+const highlighter = hljs.newInstance();
+
+highlighter.registerLanguage("jikiscript", setupJikiscript);
+highlighter.registerLanguage("javascript", setupJavascript);
+
+/** Whether a fenced block's language has a grammar registered here. */
+export function isSupportedLanguage(lang: string | undefined | null): boolean {
+  return Boolean(lang && highlighter.getLanguage(lang));
+}
+
+/** Highlight source to hljs markup. Only call for a supported language. */
+export function highlight(code: string, language: string): string {
+  return highlighter.highlight(code, { language }).value;
+}
+
+/** Every grammar registered here, sorted. Exposed so tests can assert the set. */
+export function registeredLanguages(): string[] {
+  return [...highlighter.listLanguages()].sort();
+}

--- a/content-renderer/src/index.ts
+++ b/content-renderer/src/index.ts
@@ -1,0 +1,136 @@
+/**
+ * @jiki.io/content-renderer — the one implementation of "Jiki curriculum prose
+ * to the exact bytes Jiki serves".
+ *
+ * ## Why this is a package
+ *
+ * Jiki's English prose is authored in the front-end monorepo and its
+ * translations live in the separate `i18n` repo. Both publish the results to the
+ * same content-hashed R2 tree, where an artifact's filename IS the hash of its
+ * bytes. So the two repos do not merely need to render similar HTML, they need
+ * to render byte-identical HTML for identical input, or a translated page is
+ * simply unreachable at the URL the front-end computed.
+ *
+ * A second implementation in `i18n` would be two renderers drifting apart, and
+ * the drift would surface as a wrong-looking page rather than as an error. So
+ * there is one implementation, here, and **the package version is the contract**:
+ * both repos pin it, and a rendering change is a version bump that both sides
+ * take deliberately.
+ *
+ * ## The two prose pipelines
+ *
+ * Jiki's two prose types are cached differently, and this package covers both
+ * because both are byte-sensitive:
+ *
+ * - **Concept pages** are rendered to HTML at build time and served as
+ *   `content-{hash}.html`. `renderMarkdown` is that pipeline.
+ * - **Exercise instructions** are cached as Markdown inside a JSON content file
+ *   and rendered by the browser at runtime, so the build-time step is only the
+ *   inline-tag strip. `prepareInstructions` is that pipeline.
+ *
+ * Both share `stripInlineTags`, which is the whole reason they can disagree, and
+ * historically the reason they were easy to get subtly wrong in two places.
+ */
+
+import { createHash } from "node:crypto";
+import { Marked } from "marked";
+import { highlight, isSupportedLanguage } from "./highlighting.js";
+
+export { isSupportedLanguage, registeredLanguages } from "./highlighting.js";
+
+/**
+ * This package's version, recorded in published artifact metadata by both
+ * repos. A byte mismatch between two publishers is then diagnosable after the
+ * fact from the artifacts themselves, rather than only reproducible locally.
+ *
+ * Kept as a literal rather than read from package.json so the package works
+ * identically from source, from `dist`, and from a bundler that will not import
+ * JSON. A test asserts it against package.json, so the duplication cannot drift.
+ */
+export const RENDERER_VERSION = "0.1.0";
+
+/**
+ * Custom inline tags the authored English may carry.
+ *
+ * `<define>` and `<literal>` are authoring conventions, not output: they mark a
+ * term being defined and a string meant to be read literally, for the benefit of
+ * translators and of tooling that reads the source. They are stripped from the
+ * shipped bytes, keeping their inner text, so nothing renders them and nothing
+ * has to know about them downstream.
+ *
+ * Translated files are already tag-free (translators receive the stripped text),
+ * so the strip is a no-op for every locale but English. It still runs for all of
+ * them, because a rule that only runs on one input is a rule that is only tested
+ * on one input.
+ */
+const INLINE_TAGS = /<\/?(?:define|literal)(?:\s[^>]*)?>/gi;
+
+/** Remove `<define>`/`<literal>` tags, keeping their inner text. */
+export function stripInlineTags(text: string): string {
+  return text.replace(INLINE_TAGS, "");
+}
+
+/**
+ * A private `marked` instance, never the module-level `marked` singleton.
+ *
+ * `marked.use()` mutates a global, so a singleton makes the output of any one
+ * caller depend on which other callers ran first in the same process. That is
+ * exactly the failure this package exists to remove, and it is not hypothetical:
+ * the front-end's blog pipeline configures `marked` with footnotes and a
+ * different set of highlight.js grammars. An instance means the concept bytes
+ * are a function of the input alone.
+ */
+const renderer = new Marked({
+  renderer: {
+    code({ text, lang }) {
+      const language = lang && isSupportedLanguage(lang) ? lang : null;
+      const highlighted = language
+        ? highlight(text, language)
+        : text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      const className = language ? ` class="hljs language-${language}"` : "";
+      return `<pre><code${className}>${highlighted}</code></pre>\n`;
+    }
+  },
+  hooks: {
+    // Runs before the caller hashes the result, so the hash is over the shipped
+    // bytes rather than over an intermediate that still carries the tags.
+    postprocess(html: string) {
+      return stripInlineTags(html);
+    }
+  }
+});
+
+/**
+ * Render curriculum Markdown to the exact HTML Jiki serves for a concept page.
+ *
+ * Input is the Markdown BODY, with any frontmatter already removed. Frontmatter
+ * parsing is deliberately not this package's job: the two repos parse it
+ * differently on purpose (the front-end uses gray-matter, `i18n` keeps its
+ * scripts dependency-free), and it never reaches the rendered bytes.
+ */
+export function renderMarkdown(markdown: string): string {
+  return renderer.parse(markdown, { async: false }) as string;
+}
+
+/**
+ * Prepare exercise instructions for caching.
+ *
+ * Instructions are cached as Markdown and rendered in the browser at runtime, so
+ * there is no build-time `marked` pass to hang the inline-tag strip off. It
+ * happens here instead, along with the trim, and the result is what gets hashed.
+ */
+export function prepareInstructions(markdown: string): string {
+  return stripInlineTags(markdown.trim());
+}
+
+/**
+ * The cache tree's content fingerprint: the first 12 hex chars of the SHA-256 of
+ * the exact bytes written.
+ *
+ * It lives here because it is the other half of the same contract. A publisher
+ * that renders identical bytes but fingerprints them differently writes the
+ * right content to the wrong URL, which is the same outage.
+ */
+export function contentHash(content: string | Uint8Array): string {
+  return createHash("sha256").update(content).digest("hex").slice(0, 12);
+}

--- a/content-renderer/tests/renderer.test.ts
+++ b/content-renderer/tests/renderer.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  RENDERER_VERSION,
+  contentHash,
+  prepareInstructions,
+  registeredLanguages,
+  renderMarkdown,
+  stripInlineTags
+} from "../src/index.js";
+
+const packageRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("RENDERER_VERSION", () => {
+  // The version is the byte-identity contract between the front-end and i18n, and
+  // it is also the value both record in artifact metadata. A literal that drifted
+  // from package.json would make a mismatch report the wrong version, which is
+  // worse than reporting none.
+  it("matches package.json", () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+    expect(RENDERER_VERSION).toBe(pkg.version);
+  });
+});
+
+describe("registeredLanguages", () => {
+  // Registering a grammar changes the HTML of every document that fences it, so
+  // the language SET is part of the contract, not an implementation detail.
+  it("is exactly jikiscript and javascript", () => {
+    expect(registeredLanguages()).toEqual(["javascript", "jikiscript"]);
+  });
+});
+
+describe("stripInlineTags", () => {
+  it("keeps the inner text of define and literal", () => {
+    expect(stripInlineTags("a <define>variable</define> holds <literal>1</literal>")).toBe("a variable holds 1");
+  });
+
+  it("strips tags carrying attributes", () => {
+    expect(stripInlineTags(`<define data-term="loop">loop</define>`)).toBe("loop");
+  });
+
+  it("is case insensitive", () => {
+    expect(stripInlineTags("<DEFINE>x</Define>")).toBe("x");
+  });
+
+  it("leaves other HTML alone", () => {
+    expect(stripInlineTags("<strong>x</strong>")).toBe("<strong>x</strong>");
+  });
+
+  it("is a no-op on tag-free text, which is every translated file", () => {
+    expect(stripInlineTags("egy változó")).toBe("egy változó");
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("renders headings and paragraphs", () => {
+    expect(renderMarkdown("# Title\n\nBody text.\n")).toBe("<h1>Title</h1>\n<p>Body text.</p>\n");
+  });
+
+  it("highlights a jikiscript fence", () => {
+    const html = renderMarkdown("```jikiscript\nset x to 1\n```\n");
+    expect(html).toContain(`<pre><code class="hljs language-jikiscript">`);
+    expect(html).toContain("hljs-keyword");
+  });
+
+  it("highlights a javascript fence", () => {
+    const html = renderMarkdown("```javascript\nconst x = 1;\n```\n");
+    expect(html).toContain(`<pre><code class="hljs language-javascript">`);
+  });
+
+  it("escapes an unknown language rather than highlighting it", () => {
+    // Deliberate: only Jiki's own grammars are registered, so a stock
+    // highlight.js language is NOT highlighted here even though it exists
+    // upstream. Anything else would make the bytes depend on what the host
+    // process happened to register.
+    const html = renderMarkdown("```ruby\nputs 1 & 2 < 3\n```\n");
+    expect(html).toBe("<pre><code>puts 1 &amp; 2 &lt; 3</code></pre>\n");
+  });
+
+  it("strips inline tags from the rendered HTML", () => {
+    expect(renderMarkdown("A <define>function</define> runs.\n")).toBe("<p>A function runs.</p>\n");
+  });
+
+  it("is a pure function of its input", () => {
+    const markdown = "# A\n\n```javascript\nconst x = 1;\n```\n";
+    expect(renderMarkdown(markdown)).toBe(renderMarkdown(markdown));
+  });
+});
+
+describe("prepareInstructions", () => {
+  it("trims and strips, leaving Markdown for the runtime renderer", () => {
+    expect(prepareInstructions("\n\n# Task\n\nUse a <define>loop</define>.\n\n")).toBe("# Task\n\nUse a loop.");
+  });
+});
+
+describe("contentHash", () => {
+  it("is the first 12 hex chars of the SHA-256", () => {
+    // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expect(contentHash("")).toBe("e3b0c44298fc");
+  });
+
+  it("hashes bytes, so a string and its UTF-8 buffer agree", () => {
+    expect(contentHash("árvíztűrő")).toBe(contentHash(Buffer.from("árvíztűrő", "utf8")));
+  });
+});

--- a/content-renderer/tsconfig.build.json
+++ b/content-renderer/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/content-renderer/tsconfig.json
+++ b/content-renderer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "types": ["@types/node"]
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/content-renderer/vitest.config.ts
+++ b/content-renderer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"]
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@floating-ui/react':
         specifier: ^0.27.16
         version: 0.27.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@jiki.io/content-renderer':
+        specifier: workspace:*
+        version: link:../content-renderer
       '@jiki/curriculum':
         specifier: workspace:*
         version: link:../curriculum
@@ -294,6 +297,34 @@ importers:
       prettier:
         specifier: ^3.8.0
         version: 3.8.3
+
+  content-renderer:
+    dependencies:
+      '@exercism/highlightjs-jikiscript':
+        specifier: 0.0.2
+        version: 0.0.2(typescript@5.9.3)
+      '@jiki/highlightjs-javascript':
+        specifier: git+https://github.com/jiki-education/highlightjs-javascript.git#180157677b2637335e7677e81d6d0aeb0210546d
+        version: https://codeload.github.com/jiki-education/highlightjs-javascript/tar.gz/180157677b2637335e7677e81d6d0aeb0210546d(typescript@5.9.3)
+      highlight.js:
+        specifier: 11.11.1
+        version: 11.11.1
+      marked:
+        specifier: 17.0.1
+        version: 17.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.9
+        version: 25.6.0
+      prettier:
+        specifier: ^3.8.0
+        version: 3.8.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/ui@4.1.5)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.8.4))
 
   curriculum:
     dependencies:
@@ -6656,6 +6687,11 @@ packages:
     resolution: {integrity: sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg==}
     peerDependencies:
       marked: '>=7.0.0'
+
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marked@17.0.6:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
@@ -15725,6 +15761,8 @@ snapshots:
   marked-footnote@1.4.0(marked@17.0.6):
     dependencies:
       marked: 17.0.6
+
+  marked@17.0.1: {}
 
   marked@17.0.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "app"
   - "content"
+  - "content-renderer"
   - "curriculum"
   - "interpreters"
   - "llm-chat-proxy"


### PR DESCRIPTION
## The problem

Translations have moved into the separate `i18n` repo, which publishes to the same content-hashed R2 tree the front-end does. Catalogs already publish byte-identically from both sides. **Prose does not.**

Concept pages are pre-rendered to HTML here and served as `/static/concepts/{slug}/{locale}/content-{hash}.html`, where the filename **is** the hash of the bytes. So `i18n` cannot publish a translated concept page unless it renders byte-identically: one character of difference moves the hash, the front-end resolves a URL nothing was written to, and the page silently does not appear.

Reimplementing the pipeline over there would be two renderers drifting apart, and the drift would surface as a wrong-looking page rather than as an error.

## The change

One implementation, in a new workspace package `content-renderer/`, published to npm as **`@jiki.io/content-renderer`**. **The package version is the byte-identity contract**: both repos pin an exact version, and a rendering change is a version bump both sides take deliberately.

It holds `renderMarkdown` (the `marked` config plus the two highlight.js grammars), `prepareInstructions`, `stripInlineTags`, `contentHash` and `RENDERER_VERSION`. `generate-concept-cache.js` and `generate-exercise-cache.js` import it instead of doing this inline.

Companion PR: jiki-education/i18n#(this branch's PR), which renders translated concept pages with it and adds a corpus-wide cross-repo check.

## Acceptance test: no behaviour change

Caches regenerated before and after, compared programmatically over the whole corpus (SHA-256 of every file, plus the relative paths, so a moved hash shows up as a changed filename):

| Tree | Result |
|---|---|
| `public/static/concepts` | **183 files byte-identical**, filenames included |
| `public/static/exercises` | **638 files byte-identical**, filenames included |
| `lib/generated/*-hashes.ts`, `concept-meta-server.json` | **identical** |

Spot values, unchanged: `using-functions/en/content-b01687e313d2.html`, `using-functions/hu/content-74723ff3436b.html`.

## Two things the investigation turned up

**The two generators were never doing the same thing.** The concept generator renders Markdown to HTML at build time. The exercise generator does **not** render at all: it caches raw Markdown inside a JSON content file and the browser renders it at runtime, so its only build-time step is the `<define>`/`<literal>` strip. Both are byte-sensitive, so the package covers both, but they are `renderMarkdown` and `prepareInstructions` rather than one shared call.

**The blog pipeline is deliberately left out.** `generate-content-cache.js` is a third, different `marked` configuration (footnotes, stock web-language grammars). It is front-end-only and `i18n` does not publish it, so merging it in would have been scope for no benefit.

Two robustness changes came out of this and are the only intentional behaviour differences, neither of which moves a byte today:

- `marked` is used through a private `new Marked()` instance rather than the module-level singleton, whose `.use()` mutates global state shared with the blog pipeline.
- highlight.js runs on a private `hljs.newInstance()` with exactly the two Jiki grammars, so the output cannot depend on what another part of the process registered.

## The `@jiki/highlightjs-javascript` question

A published package cannot depend on an unpublished one, and that grammar is not on npm. **It does not need to be published.** It is depended on as a git URL pinned to a commit SHA:

```
git+https://github.com/jiki-education/highlightjs-javascript.git#1801576...
```

The repo is public, `dist/` is committed so nothing builds on install, and npm resolves it for external consumers. Verified rather than assumed: the packed tarball installs into a clean project **with a cold npm cache and SSH disabled** (it falls back to HTTPS) and renders correctly.

The SHA pin is not optional. A branch pin would let the grammar move under a released version of this package, breaking the byte contract in exactly the way the version pin exists to prevent.

Publishing it as `@jiki.io/highlightjs-javascript` would be tidier and would restore integrity checking on install. It is not required, so it is not done here.

## Scope inconsistency, for a separate decision

The npm org is `jiki.io`, so the publishable name is `@jiki.io/content-renderer`. The monorepo's other packages are `@jiki/app`, `@jiki/curriculum`, `@jiki/interpreters`, `@jiki/content`. They are **not** renamed here.

Checked rather than assumed: nothing depends on the two scopes matching. The others are resolved by `workspace:*` links and are unpublished, so their scope has never had to correspond to a real org. Whether they should eventually move to `@jiki.io/*` is a separate call.

## Publishing

`.github/workflows/publish-content-renderer.yml`, manual `workflow_dispatch`, using **npm trusted publishing (OIDC)**. No `NPM_TOKEN`, no stored credential. `id-token: write`, `registry-url`, an explicit npm upgrade (OIDC needs npm >= 11.5.1 and Node >= 22.14.0), no `NODE_AUTH_TOKEN`. Provenance is automatic under trusted publishing, so there is no `--provenance` flag.

⚠️ **npm's trusted publisher record pins the workflow's filename**, so that file must not be renamed or moved. npm does not validate the config when saved, so the breakage would first appear as `ENEEDAUTH` on a release. There is a warning at the top of the file.

### Runbook for the first release

Trusted publishing cannot do a first-ever publish: npm requires the package to already exist before a trusted publisher can be attached (npm/cli#8544 is open, there is no "pending publisher" equivalent). So:

1. From this branch, locally: `cd content-renderer && pnpm install && pnpm test && pnpm run build`
2. `npm publish` (logged in as a member of the `jiki.io` org, 2FA prompt once). `publishConfig.access` is already `public`, which a new scoped package needs.
3. On https://www.npmjs.com/package/@jiki.io/content-renderer, under **Settings → Trusted publisher**, add a GitHub Actions publisher: organization `jiki-education`, repository `front-end`, workflow `publish-content-renderer.yml`, no environment.
4. Every later release: bump `version` in `content-renderer/package.json` and the `RENDERER_VERSION` literal beside it (a test fails if they disagree), merge, then run the **Publish Content Renderer** workflow.

`npm pack --dry-run` output, so there are no surprises: 10 files, 5.7 kB packed / 25.5 kB unpacked, shipping `dist/` (js + d.ts + maps), `src/`, `README.md`, `package.json`. Tests and configs are excluded.

**First version is `0.1.0`.** Pre-1.0 because the surface is still settling, and 1.0.0 would claim a stability commitment that has not been earned. The version is the contract, but the contract is enforced by pinning an **exact** version on both sides, never a range, so the major number is not doing the work here.

## Testing

- `pnpm typecheck` from the monorepo root: passes (6 projects)
- `content-renderer`: 16 tests pass
- `app`: **181 suites / 2159 tests pass**. Three suites fail on a checkout with ungenerated caches (`content-meta-server.json`, i18n hashes); that is pre-existing and unrelated, and they pass once the generators have run.
- `pnpm run lint` in `app`: 0 errors (1 pre-existing warning in `postcss-plugins/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
