### PR TITLE
Add proprietary LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2026 Jiki Ltd.
+
+All rights reserved.
+
+This software and associated documentation files (the "Software") may not be
+used, copied, modified, merged, published, distributed, sublicensed, or sold
+without express written permission from the copyright holder.


### PR DESCRIPTION
## Summary
- Adds a LICENSE file declaring this repo is proprietary to Jiki Ltd. and may not be used/copied/distributed without permission, matching the license already used in the `api` and `config` repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)