### PR TITLE
Resolve a logged-in user's language from all three /internal/me fields

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -116,9 +116,10 @@ in a catalog that does exist are marked with the `�` (U+FFFD) placeholder.
 ### Locale resolution model
 
 The guiding split is **cacheable/public pages resolve locale from the URL; auth-gated per-user
-pages resolve from the user's preference** (`user.locale` via `/internal/me`). The `NEXT_LOCALE`
-cookie is an optimistic, FE-owned SSR hint that self-heals from `/me` — it is never the source of
-truth.
+pages resolve from the user's preference** (the locale fields on `/internal/me`, combined by
+`resolveUserLocale()` — see [User locale from the API](#user-locale-from-the-api)). The
+`NEXT_LOCALE` cookie is an optimistic, FE-owned SSR hint that self-heals from `/me` — it is never
+the source of truth.
 
 - **Server resolution** (`lib/i18n/resolveLocale.ts`), precedence:
   1. Explicit URL locale segment — surfaced by `middleware.ts` as the `x-url-locale` request header
@@ -131,14 +132,15 @@ truth.
 - **Provider + client correction** (`components/i18n/ClientLocaleProvider.tsx`): `app/layout.tsx`
   resolves `getLocale()`/`getMessages()` server-side and passes them as `initialLocale`/
   `initialMessages`. The provider renders that seed for first paint (so external/anon SSR is
-  unaffected), then watches `user.locale` from the auth store. When the authoritative locale differs
+  unaffected), then watches `resolveUserLocale(user)` from the auth store. When the authoritative locale differs
   from the seed it dynamic-imports that catalog and swaps in place. "Swap pending"
   (`authoritative !== active`) is derived synchronously and the provider renders `LoadingJiki` during
   a swap, so the app never paints in the wrong locale; a failed catalog load is recorded so the swap
   settles instead of spinning forever. For anon users `user` is null, so no swap ever occurs.
 - **Cookie writes** (`lib/i18n/localeCookie.ts` `setLocaleCookie`): `authStore.setUser` mirrors the
-  authoritative `user.locale` into `NEXT_LOCALE` (covers `/me`, login, signup, confirm). The cookie
-  can be stale but never lastingly wrong, since `/me` re-seeds it.
+  authoritative locale into `NEXT_LOCALE` (covers `/me`, login, signup, confirm), resolved through
+  the same `resolveUserLocale()` the provider uses so the cookie cannot disagree with what renders.
+  The cookie can be stale but never lastingly wrong, since `/me` re-seeds it.
 - **`<html lang>`**: set server-side in `app/layout.tsx` from the seed; `ClientLocaleProvider`
   corrects `document.documentElement.lang` after a swap.
 - **Signup seeding** (`lib/i18n/detectSeedLocale.ts`): `SignupForm` sends `locale` inside the `user`
@@ -149,11 +151,34 @@ truth.
 
 ### Backend contract
 
-- `/internal/me` returns `user.locale` (required, never null for a real row — the backend
-  lazy-backfills from `Accept-Language` on first read). `User.locale` is typed required.
+- `/internal/me` returns three locale fields on `user` — see
+  [User locale from the API](#user-locale-from-the-api).
 - `POST /auth/signup` accepts an optional `user.locale` and ignores unsupported values.
 - `PATCH /internal/settings/locale` persists an explicit change (no in-app switcher UI yet — see
-  deferred).
+  deferred). It is what sets `explicit_locale`.
+
+### User locale from the API
+
+`/internal/me` returns three locale fields on `user`:
+
+- `explicit_locale` — the locale the user deliberately chose, or `null` if they never have.
+- `locale` — the persisted account preference (required, never null for a real row: the backend
+  lazy-backfills it from `Accept-Language` on first read). `User.locale` is typed required.
+- `locales` — every locale the API parsed out of the browser's `Accept-Language` string that it
+  recognised as valid, in the browser's own preference order.
+
+`resolveUserLocale()` (`lib/i18n/userLocale.ts`) is the single resolver, in precedence order
+`explicit_locale` → first served entry of `locales` → `locale`. It returns `undefined` when none of
+them yields a served locale, so callers keep whatever locale they already resolved rather than being
+forced back to English. `explicit_locale` wins outright: a deliberate choice must not be overridden
+by what the browser happens to be asking for, or switching language would silently revert on the
+next load.
+
+`locales` is read defensively rather than trusted from the type, so an API that has not shipped it
+yet degrades to `locale` instead of throwing.
+
+Two callers share it, which is the point: `ClientLocaleProvider` picks the authoritative UI locale
+with it, and `authStore.setUser` mirrors that same resolved value into the `NEXT_LOCALE` cookie.
 
 ### Using translations
 
@@ -336,6 +361,13 @@ Some languages ship more than one content variant. The canonical ids (matching t
 `pt-PT` and `pt-BR`. These are not yet in `ALL_LOCALES` — the machinery below is already
 built and tested for them (`tests/unit/lib/i18n/futureLocales.test.ts` runs it against the
 future set), so going live is just the "Adding a New Locale" steps.
+
+The casing is load-bearing, not cosmetic: the locale id is also the catalog filename
+(`messages/pt-PT.json`), the content filename (`pt-PT.md`), the curriculum locale directory
+(`locales/pt-PT/`) and the URL segment. The cache-generation scripts derive the locale from the
+filename verbatim, so a locale id that disagrees with its files in case resolves to nothing — and
+`resolveLocaleRouting` would 308 the canonical URL away to the miscased one. Anywhere a locale id
+is written by hand (`TranslatathonBanner`'s copy table, for instance) must use the canonical casing.
 
 - **Accept-Language negotiation** (`LANGUAGE_VARIANTS` in `lib/i18n/localeBanner.ts`):
   Chromium sends `es-419` directly but Firefox/Safari send country codes (`es-CL`, `es-AR`),

--- a/app/components/i18n/ClientLocaleProvider.tsx
+++ b/app/components/i18n/ClientLocaleProvider.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/lib/auth/authStore";
 import { createCatalogLoader } from "@/lib/i18n/catalogLoader";
 import { DEFAULT_TIME_ZONE, getLocaleDirection, normalizeLocale, type Locale } from "@/lib/i18n/config";
 import { setLocaleCookie } from "@/lib/i18n/localeCookie";
+import { resolveUserLocale } from "@/lib/i18n/userLocale";
 import { NextIntlClientProvider, type AbstractIntlMessages } from "next-intl";
 import { useEffect, useState, type ReactNode } from "react";
 
@@ -22,8 +23,10 @@ interface ClientLocaleProviderProps {
  *
  * The provider renders `initialLocale`/`initialMessages` (the server-resolved
  * seed) for the first paint, so external/anon SSR is unaffected. Once the auth
- * check populates `user.locale` (the authoritative preference from /internal/me),
- * if it differs from the seed we load that catalog client-side and swap.
+ * check populates the user, we resolve their authoritative locale from /internal/me
+ * (`explicit_locale`, else the first served entry of `locales`, else `locale` — see
+ * lib/i18n/userLocale.ts); if it differs from the seed we load that catalog
+ * client-side and swap.
  *
  * While a swap is in flight the provider renders `LoadingJiki` in place of its
  * children, so the app never paints in the wrong locale. "Swap pending" is
@@ -39,7 +42,7 @@ export function ClientLocaleProvider({ initialLocale, initialMessages, children 
   const [locale, setLocale] = useState(initialLocale);
   const [messages, setMessages] = useState(initialMessages);
   const [abandoned, setAbandoned] = useState<string | null>(null);
-  const userLocale = useAuthStore((state) => state.user?.locale);
+  const userLocale = useAuthStore((state) => resolveUserLocale(state.user));
 
   // For anon/logged-out users `user` is null, so `userLocale` is null and
   // `authoritative` collapses to `normalizeLocale(initialLocale)`, which equals

--- a/app/components/i18n/TranslatathonBanner.tsx
+++ b/app/components/i18n/TranslatathonBanner.tsx
@@ -49,7 +49,7 @@ const TRANSLATATHON_URL = "https://i18n.jiki.io";
  * Fully-translated copy for each language in the Translatathon program, keyed by
  * the program's own locale ids (matching ../../translator/languages/names.json,
  * minus `hu` which we already ship). Multi-variant languages have one entry per
- * variant (es-419/es-ES, pt-BR/pt-pt, zh-CN/zh-TW); resolveTarget maps a browser
+ * variant (es-419/es-ES, pt-BR/pt-PT, zh-CN/zh-TW); resolveTarget maps a browser
  * tag to the right one. Each string is written in that language, with the
  * language's own name for itself and a translated phrase for the translation
  * session (we don't leave "Translatathon" untranslated); only "Jiki" stays as a
@@ -158,7 +158,7 @@ const COPY: Record<string, TranslatathonCopy> = {
     post: "",
     close: "Fechar"
   },
-  "pt-pt": {
+  "pt-PT": {
     pre: "Quer ajudar-nos a traduzir o Jiki para português? ",
     link: "Junte-se à sessão de tradução",
     post: "",
@@ -341,7 +341,7 @@ function programLocale(tag: string, base: string): string | undefined {
     return region(tag) === "ES" ? "es-ES" : "es-419";
   }
   if (base === "pt") {
-    return region(tag) === "PT" ? "pt-pt" : "pt-BR";
+    return region(tag) === "PT" ? "pt-PT" : "pt-BR";
   }
   if (base === "zh") {
     const r = region(tag);

--- a/app/lib/auth/authStore.ts
+++ b/app/lib/auth/authStore.ts
@@ -10,7 +10,7 @@ import type { LoginCredentials, LoginResponse, PasswordReset, SignupData, User }
 import { ApiError, AuthenticationError, NetworkError, RateLimitError } from "@/lib/api/client";
 import { setCriticalError, clearCriticalError } from "@/lib/api/errorHandlerStore";
 import { setLocaleCookie } from "@/lib/i18n/localeCookie";
-import { isSupportedLocale } from "@/lib/i18n/config";
+import { resolveUserLocale } from "@/lib/i18n/userLocale";
 import { create } from "zustand";
 import type { StoreApi } from "zustand";
 
@@ -209,10 +209,13 @@ export const useAuthStore = create<AuthStore>()((set, get) => ({
       error: null
     });
     // Mirror the authoritative locale into the NEXT_LOCALE cookie so the next
-    // SSR seed is correct. The cookie is an optimistic hint; user.locale is the
-    // source of truth. Ignore unsupported/absent values.
-    if (isSupportedLocale(user.locale)) {
-      setLocaleCookie(user.locale);
+    // SSR seed is correct. The cookie is an optimistic hint; /internal/me is the
+    // source of truth. Resolved via the same helper ClientLocaleProvider uses, so
+    // the cookie can't disagree with the locale actually rendered. Ignore
+    // unsupported/absent values.
+    const locale = resolveUserLocale(user);
+    if (locale) {
+      setLocaleCookie(locale);
     }
   },
   setNoUser: (error?: string | null) => {

--- a/app/lib/i18n/userLocale.ts
+++ b/app/lib/i18n/userLocale.ts
@@ -1,0 +1,37 @@
+import type { User } from "@/types/auth";
+import { isSupportedLocale } from "./config";
+import type { Locale } from "./config";
+
+type LocaleFields = Pick<User, "locale" | "locales" | "explicit_locale">;
+
+/**
+ * The UI locale to use for a logged-in user, in precedence order:
+ *
+ * 1. `explicit_locale` — a locale the user deliberately chose. It wins outright:
+ *    a deliberate choice must never be overridden by what the browser is asking
+ *    for, otherwise switching language would silently revert on the next load.
+ * 2. `locales` — every locale the API parsed out of the browser's Accept-Language
+ *    string, in the browser's preference order. We take the first served entry.
+ * 3. `locale` — the persisted account preference.
+ *
+ * Returns undefined when none of them yields a served locale, so callers can keep
+ * whatever locale they already resolved rather than being forced back to English.
+ */
+export function resolveUserLocale(user: LocaleFields | null | undefined): Locale | undefined {
+  if (!user) {
+    return undefined;
+  }
+
+  if (isSupportedLocale(user.explicit_locale)) {
+    return user.explicit_locale;
+  }
+
+  // Guarded rather than trusting the type: `locales` is new on /internal/me, so an
+  // API that hasn't shipped it yet must degrade to `locale`, not throw.
+  const preferred = Array.isArray(user.locales) ? user.locales.find(isSupportedLocale) : undefined;
+  if (preferred) {
+    return preferred;
+  }
+
+  return isSupportedLocale(user.locale) ? user.locale : undefined;
+}

--- a/app/tests/mocks/user.ts
+++ b/app/tests/mocks/user.ts
@@ -18,6 +18,8 @@ export function createMockUser(overrides?: Partial<User>): User {
     provider: "email",
     email_confirmed: true,
     locale: "en",
+    locales: ["en"],
+    explicit_locale: null,
     ...overrides
   };
 }

--- a/app/tests/unit/components/settings/subscription/SubscriptionSection.test.tsx
+++ b/app/tests/unit/components/settings/subscription/SubscriptionSection.test.tsx
@@ -34,6 +34,8 @@ function createMockUser(overrides?: Partial<User>): User {
     provider: "email",
     email_confirmed: true,
     locale: "en",
+    locales: ["en"],
+    explicit_locale: null,
     ...overrides
   };
 }

--- a/app/tests/unit/lib/i18n/userLocale.test.ts
+++ b/app/tests/unit/lib/i18n/userLocale.test.ts
@@ -1,0 +1,57 @@
+import { resolveUserLocale } from "@/lib/i18n/userLocale";
+import type { User } from "@/types/auth";
+
+type LocaleFields = Pick<User, "locale" | "locales" | "explicit_locale">;
+
+function user(locale: string, locales: string[], explicit: string | null = null): LocaleFields {
+  return { locale, locales, explicit_locale: explicit };
+}
+
+// `en` and `hu` are the served locales here (SUPPORTED_LOCALES resolves to the
+// full set outside a production build). `xx`/`zz` stand in for anything this
+// build does not serve.
+describe("resolveUserLocale", () => {
+  it("lets an explicit choice beat both the browser list and the account preference", () => {
+    expect(resolveUserLocale(user("en", ["xx", "en"], "hu"))).toBe("hu");
+  });
+
+  it("ignores an explicit choice this build doesn't serve", () => {
+    expect(resolveUserLocale(user("en", ["hu"], "xx"))).toBe("hu");
+  });
+
+  it("falls through to the browser list when no explicit choice was made", () => {
+    expect(resolveUserLocale(user("en", ["hu"], null))).toBe("hu");
+  });
+
+  it("prefers the first browser locale over the persisted account preference", () => {
+    expect(resolveUserLocale(user("en", ["hu", "en"]))).toBe("hu");
+  });
+
+  it("falls back to the account preference when the browser list is empty", () => {
+    expect(resolveUserLocale(user("hu", []))).toBe("hu");
+  });
+
+  it("skips leading browser locales this build doesn't serve", () => {
+    expect(resolveUserLocale(user("en", ["xx", "zz", "hu"]))).toBe("hu");
+  });
+
+  it("falls back to the account preference when no browser locale is served", () => {
+    expect(resolveUserLocale(user("hu", ["xx", "zz"]))).toBe("hu");
+  });
+
+  it("returns undefined when neither field yields a served locale", () => {
+    // Callers keep whatever locale they already resolved rather than being
+    // forced back to English.
+    expect(resolveUserLocale(user("xx", ["zz"]))).toBeUndefined();
+  });
+
+  it("returns undefined for an anonymous user", () => {
+    expect(resolveUserLocale(null)).toBeUndefined();
+    expect(resolveUserLocale(undefined)).toBeUndefined();
+  });
+
+  it("degrades to the account preference when the API hasn't shipped `locales` yet", () => {
+    const legacy = { locale: "hu" } as LocaleFields;
+    expect(resolveUserLocale(legacy)).toBe("hu");
+  });
+});

--- a/app/tests/unit/lib/seo/alternates.test.ts
+++ b/app/tests/unit/lib/seo/alternates.test.ts
@@ -1,6 +1,23 @@
-import { alternateLanguages, buildAlternates } from "@/lib/seo/alternates";
+import { SUPPORTED_LOCALES } from "@/lib/i18n/config";
+import { alternateLanguages, buildAlternates, hreflangLocale } from "@/lib/seo/alternates";
 
 const SITE = "https://jiki.io";
+
+// The hreflang map the site's URL rule implies for a locale-less path: default
+// locale naked, every other locale `/<locale>`-prefixed, plus x-default pointing
+// at the default-locale URL. Derived from SUPPORTED_LOCALES so adding a locale
+// doesn't need this file edited, while still asserting the rule itself.
+function expectedLanguages(localelessPath: string): Record<string, string> {
+  const naked = `${SITE}${localelessPath}`;
+  const prefixed = (locale: string) =>
+    localelessPath === "/" ? `${SITE}/${locale}` : `${SITE}/${locale}${localelessPath}`;
+
+  const languages: Record<string, string> = { "x-default": naked };
+  for (const locale of SUPPORTED_LOCALES) {
+    languages[hreflangLocale(locale)] = locale === "en" ? naked : prefixed(locale);
+  }
+  return languages;
+}
 
 describe("buildAlternates", () => {
   it("emits a self-referential canonical for the naked-en variant", () => {
@@ -15,11 +32,10 @@ describe("buildAlternates", () => {
 
   it("builds absolute, reciprocal language URLs with x-default pointing at en", () => {
     const alts = buildAlternates("/blog/hello-world", "hu");
-    expect(alts?.languages).toEqual({
-      en: `${SITE}/blog/hello-world`,
-      hu: `${SITE}/hu/blog/hello-world`,
-      "x-default": `${SITE}/blog/hello-world`
-    });
+    expect(alts?.languages).toEqual(expectedLanguages("/blog/hello-world"));
+    expect(alts?.languages?.en).toBe(`${SITE}/blog/hello-world`);
+    expect(alts?.languages?.hu).toBe(`${SITE}/hu/blog/hello-world`);
+    expect(alts?.languages?.["x-default"]).toBe(`${SITE}/blog/hello-world`);
   });
 
   it("returns the same languages map regardless of the current locale (only canonical differs)", () => {
@@ -32,20 +48,17 @@ describe("buildAlternates", () => {
   it("handles the root path", () => {
     const alts = buildAlternates("/", "en");
     expect(alts?.canonical).toBe(`${SITE}/`);
-    expect(alts?.languages).toEqual({
-      en: `${SITE}/`,
-      hu: `${SITE}/hu`,
-      "x-default": `${SITE}/`
-    });
+    expect(alts?.languages).toEqual(expectedLanguages("/"));
+    expect(alts?.languages?.en).toBe(`${SITE}/`);
+    expect(alts?.languages?.hu).toBe(`${SITE}/hu`);
   });
 });
 
 describe("alternateLanguages", () => {
   it("maps every supported locale plus x-default to absolute URLs", () => {
-    expect(alternateLanguages("/help/streaks")).toEqual({
-      en: `${SITE}/help/streaks`,
-      hu: `${SITE}/hu/help/streaks`,
-      "x-default": `${SITE}/help/streaks`
-    });
+    expect(alternateLanguages("/help/streaks")).toEqual(expectedLanguages("/help/streaks"));
+    expect(Object.keys(alternateLanguages("/help/streaks")).sort()).toEqual(
+      [...SUPPORTED_LOCALES.map(hreflangLocale), "x-default"].sort()
+    );
   });
 });

--- a/app/tests/unit/stores/authStore.checkAuth.test.ts
+++ b/app/tests/unit/stores/authStore.checkAuth.test.ts
@@ -40,7 +40,9 @@ describe("authStore.checkAuth", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.exercismLogin.test.ts
+++ b/app/tests/unit/stores/authStore.exercismLogin.test.ts
@@ -31,7 +31,9 @@ describe("AuthStore - Exercism Authentication", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "exercism",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.login.test.ts
+++ b/app/tests/unit/stores/authStore.login.test.ts
@@ -33,7 +33,9 @@ describe("AuthStore - Login", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.logout.test.ts
+++ b/app/tests/unit/stores/authStore.logout.test.ts
@@ -32,7 +32,9 @@ describe("AuthStore - Logout", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/tests/unit/stores/authStore.test.ts
+++ b/app/tests/unit/stores/authStore.test.ts
@@ -31,7 +31,9 @@ describe("AuthStore - Google Authentication", () => {
     premium_prices: { currency: "usd", monthly: 999, annual: 9900, country_code: null },
     provider: "email",
     email_confirmed: true,
-    locale: "en"
+    locale: "en",
+    locales: ["en"],
+    explicit_locale: null
   };
 
   beforeEach(() => {

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -18,6 +18,15 @@ export interface User {
   provider: string;
   email_confirmed: boolean;
   locale: string;
+  // The locale the user picked deliberately, or null if they never have. Beats
+  // both `locales` and `locale` when choosing the UI locale: an explicit choice
+  // must not be overridden by what the browser happens to be asking for.
+  explicit_locale: string | null;
+  // Every locale parsed out of the user's browser Accept-Language string that the
+  // API recognised as valid, in the browser's own preference order. Sits alongside
+  // `locale` (the persisted account preference) on /internal/me; the first entry is
+  // preferred over `locale` when picking the UI locale. See lib/i18n/userLocale.ts.
+  locales: string[];
 }
 
 export interface LoginCredentials {


### PR DESCRIPTION
`/internal/me` carries three locale fields. The app only ever read one of them.

## What changes

`resolveUserLocale()` is the single resolver, in precedence order:

1. **`explicit_locale`** — a language the user deliberately chose. Wins outright, because otherwise choosing a language would silently revert on the next load when the browser's preference reasserted itself.
2. **`locales`** — every language the API parsed from the browser's `Accept-Language`, in the browser's own order. The first one this build serves.
3. **`locale`** — the persisted account preference. This is the only field the app reads today.

It returns `undefined` when none of them yields a served language, so callers keep whatever they already resolved rather than being forced back to English.

Two callers share it, which is the point: `ClientLocaleProvider` picks the UI language with it, and `authStore.setUser` mirrors the same resolved value into the `NEXT_LOCALE` cookie, so the cookie cannot disagree with what actually renders.

`locales` is read defensively rather than trusted from the type, so an API that has not shipped that field yet degrades to `locale` instead of throwing.

## Effect in production

None. Production serves English only, so every branch of the precedence order can only resolve to `en` or to nothing, and the SSR seed is already `en`. No catalog swap can occur. The behaviour this enables is visible on staging, where the full locale set is served.

## Also here

`TranslatathonBanner` uses the canonical `pt-PT` casing rather than `pt-pt`. That string is simultaneously a catalog filename, a content filename, a curriculum directory name and a URL segment, so the casing is load-bearing rather than cosmetic.