### PR TITLE
Make the locale banner one ICU message, and name languages via ICU

### DIFF
--- a/app/.context/i18n.md
+++ b/app/.context/i18n.md
@@ -135,12 +135,26 @@ fragile. Use a single ICU message:
 - Inline markup/styling: `t.rich("key", { highlight: (c) => <span className={...}>{c}</span> })`
 - Links: `t.rich("key", { link: (c) => <Link href={...}>{c}</Link> })`
 - Embedded components (e.g. live prices): self-closing tags — `t.rich("key", { price: () => <PremiumPrice /> })`
+- Interactive chunks: a tag may render a control, not just markup. The locale banner is the worked
+  example — `layout.localeBanner.message` is one sentence whose `<link>` chunk is the switch link
+  and whose `<dismiss>` chunk is the close button, so the button's accessible name is the translated
+  copy and a translator can reorder the whole sentence. The client bar
+  (`components/i18n/LocaleBannerBar.tsx`) takes the rendered sentence as `children` and exposes its
+  dismiss action through a context that `LocaleBannerDismiss` consumes.
 - Values: `{name}` interpolation; counts: ICU `{count, plural, one {...} other {...}}` (never a
   hand-rolled `count === 1 ? t("singular") : t("plural")`).
 
 `tests/unit/messages.test.ts` guards the catalogs: every message must parse as valid ICU, the
 `en`/`hu` key trees must be identical, and no message may have leading/trailing whitespace
 (whitespace-padded fragments are how concatenation bugs sneak back in).
+
+### Language names
+
+`languageName(locale, inLocale)` (`lib/i18n/languageNames.ts`) writes a language's name using
+`Intl.DisplayNames`. There is no authored catalog of language names: one would need an entry for
+every locale in every other locale, so it would grow as the square of the locale list and go stale
+silently each time a locale is added. ICU already ships that data, including region-suffixed ids
+like `es-419` and `pt-BR`, and falls back to the locale code itself when it has no name.
 
 ### Building locale-aware links
 

--- a/app/components/i18n/LocaleBanner.tsx
+++ b/app/components/i18n/LocaleBanner.tsx
@@ -1,6 +1,8 @@
-import { LocaleBannerBar } from "@/components/i18n/LocaleBannerBar";
+import { LocaleBannerBar, LocaleBannerDismiss } from "@/components/i18n/LocaleBannerBar";
+import Link from "next/link";
 import { AUTHENTICATION_COOKIE_NAME } from "@/lib/auth/cookie-config";
 import { LOCALE_COOKIE_NAME, PATHNAME_HEADER } from "@/lib/i18n/config";
+import { languageName } from "@/lib/i18n/languageNames";
 import { resolveBannerOffer } from "@/lib/i18n/localeBanner";
 import { getTranslations } from "next-intl/server";
 import { cookies, headers } from "next/headers";
@@ -32,19 +34,16 @@ export async function LocaleBanner() {
     return null;
   }
 
-  const [t, names] = await Promise.all([
-    getTranslations({ locale: offer.offered, namespace: "layout.localeBanner" }),
-    getTranslations({ locale: offer.offered, namespace: "common.languageNames" })
-  ]);
+  const t = await getTranslations({ locale: offer.offered, namespace: "layout.localeBanner" });
 
   return (
-    <LocaleBannerBar
-      href={offer.href}
-      offered={offer.offered}
-      prefix={t("prefix", { language: names(offer.current) })}
-      cta={t("cta", { language: names(offer.offered) })}
-      or={t("or")}
-      close={t("close")}
-    />
+    <LocaleBannerBar offered={offer.offered}>
+      {t.rich("message", {
+        current: languageName(offer.current, offer.offered),
+        offered: languageName(offer.offered, offer.offered),
+        link: (chunks) => <Link href={offer.href}>{chunks}</Link>,
+        dismiss: (chunks) => <LocaleBannerDismiss>{chunks}</LocaleBannerDismiss>
+      })}
+    </LocaleBannerBar>
   );
 }

--- a/app/components/i18n/LocaleBannerBar.tsx
+++ b/app/components/i18n/LocaleBannerBar.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import Link from "next/link";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { createContext, useContext, useEffect, useLayoutEffect, useState, type ReactNode } from "react";
 import styles from "./LocalBanner.module.css";
 
 interface LocaleBannerBarProps {
-  href: string;
-  prefix: string;
-  cta: string;
-  or: string;
-  close: string;
+  /**
+   * The whole banner sentence, already translated into the offered language and
+   * rendered as rich text by the server (see LocaleBanner). It embeds the link
+   * and the <LocaleBannerDismiss> button, so no copy or punctuation is glued
+   * together in JSX.
+   */
+  children: ReactNode;
   /** The offered locale; dismissal is remembered per offered language. */
   offered: string;
 }
@@ -19,10 +20,11 @@ interface LocaleBannerBarProps {
 // ThemeProvider.
 const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
+const DismissContext = createContext<(() => void) | null>(null);
+
 // Presentational, dismissible bar. The offer is computed server-side (see
-// LocaleBanner); this owns the dismissed state and persists it. All strings
-// arrive already translated into the offered language.
-export function LocaleBannerBar({ href, prefix, cta, or, close, offered }: LocaleBannerBarProps) {
+// LocaleBanner); this owns the dismissed state and persists it.
+export function LocaleBannerBar({ children, offered }: LocaleBannerBarProps) {
   const [dismissed, setDismissed] = useState(false);
   const storageKey = `${DISMISS_KEY_PREFIX}${offered}`;
 
@@ -39,23 +41,29 @@ export function LocaleBannerBar({ href, prefix, cta, or, close, offered }: Local
     return null;
   }
 
+  const dismiss = () => {
+    setDismissed(true);
+    writeDismissed(storageKey);
+  };
+
   return (
     <div className={styles.banner}>
-      <span>{prefix} </span>
-      <Link href={href}>{cta}</Link> {or}{" "}
-      <button
-        type="button"
-        onClick={() => {
-          setDismissed(true);
-          writeDismissed(storageKey);
-        }}
-        aria-label={close}
-        className={styles.close}
-      >
-        {close}
-      </button>
-      .
+      <DismissContext value={dismiss}>{children}</DismissContext>
     </div>
+  );
+}
+
+/**
+ * The `<dismiss>` chunk of the banner message. Its label comes from the
+ * translated string, so the button's accessible name is the translated copy.
+ */
+export function LocaleBannerDismiss({ children }: { children: ReactNode }) {
+  const dismiss = useContext(DismissContext);
+
+  return (
+    <button type="button" onClick={() => dismiss?.()} className={styles.close}>
+      {children}
+    </button>
   );
 }
 

--- a/app/lib/i18n/languageNames.ts
+++ b/app/lib/i18n/languageNames.ts
@@ -1,0 +1,21 @@
+import type { Locale } from "./config";
+
+/**
+ * The display name of `locale`, written in `inLocale`.
+ *
+ * Uses `Intl.DisplayNames` rather than an authored `common.languageNames` catalog
+ * entry, because that catalog would need an entry for every locale in every other
+ * locale (a 30x30 matrix) and would silently go stale each time a locale is added.
+ * ICU already ships this data, including for region-suffixed ids like `es-419`
+ * ("Latin American Spanish") and `pt-BR`.
+ *
+ * Falls back to the locale code itself if ICU has no name for it (or is built
+ * without the data), so the caller always has something renderable.
+ */
+export function languageName(locale: Locale | string, inLocale: Locale | string): string {
+  try {
+    return new Intl.DisplayNames([inLocale], { type: "language" }).of(locale) ?? locale;
+  } catch {
+    return locale;
+  }
+}

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -83,10 +83,7 @@
       "subtitle": "Preparing your learning experience"
     },
     "localeBanner": {
-      "prefix": "You are viewing the {language} version of this page.",
-      "cta": "Change to {language}",
-      "or": "or",
-      "close": "close this notice"
+      "message": "You are viewing the {current} version of this page. <link>Change to {offered}</link> or <dismiss>close this notice</dismiss>."
     }
   },
   "common": {
@@ -97,10 +94,6 @@
     "processing": "Processing...",
     "reloadPage": "Reload Page",
     "loading": "Loading...",
-    "languageNames": {
-      "en": "English",
-      "hu": "Hungarian"
-    },
     "verifying": "Verifying...",
     "sending": "Sending...",
     "perMonth": "/month",

--- a/app/messages/hu.json
+++ b/app/messages/hu.json
@@ -83,10 +83,7 @@
       "subtitle": "Előkészítjük a tanulási élményed"
     },
     "localeBanner": {
-      "prefix": "Az oldal {language} nyelvű verzióját látod.",
-      "cta": "Váltás erre: {language}",
-      "or": "vagy",
-      "close": "értesítés bezárása"
+      "message": "Az oldal {current} nyelvű verzióját látod. <link>Váltás erre: {offered}</link> vagy <dismiss>értesítés bezárása</dismiss>."
     }
   },
   "common": {
@@ -97,10 +94,6 @@
     "processing": "Feldolgozás...",
     "reloadPage": "Oldal újratöltése",
     "loading": "Betöltés...",
-    "languageNames": {
-      "en": "Angol",
-      "hu": "Magyar"
-    },
     "verifying": "Ellenőrzés...",
     "sending": "Küldés...",
     "perMonth": "/hó",

--- a/app/tests/unit/components/i18n/LocaleBannerBar.test.tsx
+++ b/app/tests/unit/components/i18n/LocaleBannerBar.test.tsx
@@ -1,18 +1,21 @@
-import { LocaleBannerBar } from "@/components/i18n/LocaleBannerBar";
+import { LocaleBannerBar, LocaleBannerDismiss } from "@/components/i18n/LocaleBannerBar";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import Link from "next/link";
 
-const props = {
-  href: "/blog/x",
-  offered: "en",
-  prefix: "You are viewing the Hungarian version of this page.",
-  cta: "Change to English",
-  or: "or",
-  close: "close this notice"
-};
+// Stands in for the rich-text output the server component builds from the
+// single `layout.localeBanner.message` key.
+function message() {
+  return (
+    <>
+      You are viewing the Hungarian version of this page. <Link href="/blog/x">Change to English</Link> or{" "}
+      <LocaleBannerDismiss>close this notice</LocaleBannerDismiss>.
+    </>
+  );
+}
 
-function renderBar(overrides: Partial<typeof props> = {}) {
-  return render(<LocaleBannerBar {...props} {...overrides} />);
+function renderBar(offered = "en") {
+  return render(<LocaleBannerBar offered={offered}>{message()}</LocaleBannerBar>);
 }
 
 describe("LocaleBannerBar", () => {
@@ -46,7 +49,7 @@ describe("LocaleBannerBar", () => {
 
   it("still renders when a different locale was the one dismissed", () => {
     window.localStorage.setItem("locale-banner-dismissed:hu", "1");
-    renderBar({ offered: "en" });
+    renderBar("en");
 
     expect(screen.getByText(/You are viewing the Hungarian version/)).toBeInTheDocument();
   });


### PR DESCRIPTION
Pulled out of the translatathon stack so it can land on its own. This is only the banner change: the `/internal/me` locale resolution work (`resolveUserLocale`, `ClientLocaleProvider`, `authStore` cookie mirroring) stays in the stack.

## Why the sentence is no longer assembled

`LocaleBannerBar` took five copy props (`prefix`, `cta`, `or`, `close`, plus the link `href`) and glued the sentence together in JSX, full stop included:

```jsx
<span>{prefix} </span>
<Link href={href}>{cta}</Link> {or}{" "}
<button aria-label={close}>{close}</button>
.
```

`.context/i18n.md` ("ICU, not string concatenation") forbids that outright: *"Never split a sentence across multiple keys to inject markup, links, or dynamic values — word order differs across languages and whitespace-padded fragments are fragile."* A translator had no way to move the link, drop the conjunction, or change the punctuation. This was the one place in the codebase still doing it.

It is now a single message:

```
"You are viewing the {current} version of this page. <link>Change to {offered}</link> or <dismiss>close this notice</dismiss>."
```

The server component renders it with `t.rich`, mapping `<link>` to the switch `Link` and `<dismiss>` to a `LocaleBannerDismiss` button. `LocaleBannerBar` receives the rendered sentence as `children` and exposes its dismiss action through a small context, so it still owns the dismissed state and its persistence but owns no copy. A side benefit: the button's accessible name is now the translated label from the message, instead of a separate `close` key that could drift from it.

## Why ICU names languages

`lib/i18n/languageNames.ts` is new. `languageName(locale, inLocale)` uses `Intl.DisplayNames` in place of the authored `common.languageNames` catalog.

That catalog was keyed by locale code and had to be filled in per catalog, so it needed an entry for every locale written in every other locale. It grows as the square of the locale list, and with the locale list about to expand it would have gone stale silently: a new locale simply renders as a missing-key placeholder in every existing catalog, with nothing failing. ICU already ships this data, including for region-suffixed ids like `es-419` and `pt-BR`, and `languageName` falls back to the locale code itself if ICU has no name for it.

Nothing else referenced `common.languageNames`, so it is removed from `en.json` and `hu.json`.

## Notes

- The Hungarian `message` is assembled from the Hungarian fragments already in `hu.json`. No new copy is introduced and nothing is machine-translated.
- The `pt-pt` to `pt-PT` casing fix in `TranslatathonBanner` from the same upstream commit is independent of this and stays in the stack.

## Verification

- `pnpm typecheck` from the monorepo root: clean.
- Full unit suite: 181 suites, 2159 tests passing.
- `pnpm run build` from a cleared generated tree (`public/static/exercises`, `public/static/content`, `lib/generated`, `.next` removed): succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)