### PR TITLE
Move content tag labels into the app catalog

### DIFF
--- a/app/components/articles/ArticlesContent.tsx
+++ b/app/components/articles/ArticlesContent.tsx
@@ -84,7 +84,7 @@ export default function ArticlesContent({
         )}
       </div>
 
-      <FilterSidebar tagSlugs={tagSlugs} selectedTag={selectedTag} locale={locale} />
+      <FilterSidebar tagSlugs={tagSlugs} selectedTag={selectedTag} />
     </div>
   );
 }

--- a/app/components/articles/FilterSidebar.tsx
+++ b/app/components/articles/FilterSidebar.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { type ArticleTagSlug, getArticleTagLabel } from "@/lib/content/types";
+import type { ArticleTagSlug } from "@/lib/content/types";
 import { FORUM_URL } from "@/lib/constants/social";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import styles from "./FilterSidebar.module.css";
@@ -11,11 +11,11 @@ import styles from "./FilterSidebar.module.css";
 interface FilterSidebarProps {
   tagSlugs: readonly ArticleTagSlug[];
   selectedTag: ArticleTagSlug | null;
-  locale: string;
 }
 
-export default function FilterSidebar({ tagSlugs, selectedTag, locale }: FilterSidebarProps) {
+export default function FilterSidebar({ tagSlugs, selectedTag }: FilterSidebarProps) {
   const t = useTranslations("articles.filterSidebar");
+  const tTags = useTranslations("articles.tags");
   const pathname = usePathname();
   const routes = useLocaleRoutes();
 
@@ -39,7 +39,7 @@ export default function FilterSidebar({ tagSlugs, selectedTag, locale }: FilterS
             href={buildTagUrl(slug)}
             className={`${styles.filterTag} ${selectedTag === slug ? styles.active : ""}`}
           >
-            {getArticleTagLabel(slug, locale)}
+            {tTags(slug)}
           </Link>
         ))}
       </div>

--- a/app/components/guides/GuideCard.tsx
+++ b/app/components/guides/GuideCard.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { localePath } from "@/lib/i18n/routes";
 import LockIcon from "@/icons/lock.svg";
 import { showPremiumUpgradeModal } from "@/lib/modal/app";
-import { getGuideTagLabel, type GuideMeta, type GuideTagSlug } from "@/lib/content/types";
+import type { GuideMeta, GuideTagSlug } from "@/lib/content/types";
 import styles from "./GuideCard.module.css";
 
 interface GuideCardProps {
@@ -18,8 +18,9 @@ interface GuideCardProps {
 
 export default function GuideCard({ guide, locale, premiumLocked = false, compact = false }: GuideCardProps) {
   const t = useTranslations("guides.guideCard");
+  const tTags = useTranslations("guides.tags");
   const firstTag = guide.tags[0] as GuideTagSlug | undefined;
-  const tagLabel = firstTag ? getGuideTagLabel(firstTag, locale) : null;
+  const tagLabel = firstTag ? tTags(firstTag) : null;
 
   const inner = (
     <>

--- a/app/components/guides/GuidesContent.tsx
+++ b/app/components/guides/GuidesContent.tsx
@@ -9,7 +9,7 @@ import StudyBookIcon from "@/icons/study-book.svg";
 import { ConceptsLayout } from "@/components/concepts";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { tierIncludes } from "@/lib/pricing";
-import { getGuideTagLabel, type GuideMeta, type GuideTagSlug } from "@/lib/content/types";
+import type { GuideMeta, GuideTagSlug } from "@/lib/content/types";
 import { useGuidesSearch } from "@/lib/hooks/useGuidesSearch";
 import Pagination from "@/components/ui/Pagination";
 import GuideCard from "./GuideCard";
@@ -27,6 +27,7 @@ interface GuidesContentProps {
 
 export default function GuidesContent({ guides, locale, selectedTag, tagSlugs }: GuidesContentProps) {
   const t = useTranslations("guides.guidesContent");
+  const tTags = useTranslations("guides.tags");
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { searchQuery, setSearchQuery, searchResults } = useGuidesSearch(locale);
@@ -100,7 +101,7 @@ export default function GuidesContent({ guides, locale, selectedTag, tagSlugs }:
             href={buildTagUrl(slug)}
             className={`${styles.filterTag} ${selectedTag === slug ? styles.active : ""}`}
           >
-            {getGuideTagLabel(slug, locale)}
+            {tTags(slug)}
           </Link>
         ))}
       </div>

--- a/app/lib/content/index.ts
+++ b/app/lib/content/index.ts
@@ -58,5 +58,5 @@ export type {
   PrimaryTestimonial,
   TestimonialsData
 } from "./types";
-export { ARTICLE_TAG_SLUGS, ARTICLE_TAG_LABELS, getArticleTagLabel } from "./types";
-export { GUIDE_TAG_SLUGS, GUIDE_TAG_LABELS, getGuideTagLabel } from "./types";
+export { ARTICLE_TAG_SLUGS } from "./types";
+export { GUIDE_TAG_SLUGS } from "./types";

--- a/app/lib/content/types.ts
+++ b/app/lib/content/types.ts
@@ -2,33 +2,9 @@
 export const ARTICLE_TAG_SLUGS = ["legal", "premium", "exercises", "videos"] as const;
 export type ArticleTagSlug = (typeof ARTICLE_TAG_SLUGS)[number];
 
-// Tag labels for each locale
-export const ARTICLE_TAG_LABELS: Record<ArticleTagSlug, Record<string, string>> = {
-  legal: { en: "Legal", hu: "Jogi" },
-  premium: { en: "Premium", hu: "Prémium" },
-  exercises: { en: "Exercises", hu: "Gyakorlatok" },
-  videos: { en: "Videos", hu: "Videók" }
-};
-
-export function getArticleTagLabel(slug: ArticleTagSlug, locale: string): string {
-  return ARTICLE_TAG_LABELS[slug][locale] || ARTICLE_TAG_LABELS[slug].en;
-}
-
 // Guide tag slugs - used in URLs and frontmatter
 export const GUIDE_TAG_SLUGS = ["editors", "installation", "agentic-coding", "front-end-basics"] as const;
 export type GuideTagSlug = (typeof GUIDE_TAG_SLUGS)[number];
-
-// Tag labels for each locale
-export const GUIDE_TAG_LABELS: Record<GuideTagSlug, Record<string, string>> = {
-  editors: { en: "Editors", hu: "Szerkesztők" },
-  installation: { en: "Installation", hu: "Telepítés" },
-  "agentic-coding": { en: "Agentic Coding", hu: "Agentikus kódolás" },
-  "front-end-basics": { en: "Front-End Basics", hu: "Front-end alapok" }
-};
-
-export function getGuideTagLabel(slug: GuideTagSlug, locale: string): string {
-  return GUIDE_TAG_LABELS[slug][locale] || GUIDE_TAG_LABELS[slug].en;
-}
 
 export interface Frontmatter {
   title: string;

--- a/app/messages.json
+++ b/app/messages.json
@@ -1843,6 +1843,12 @@
     "guideCard": {
       "premium": "Premium"
     },
+    "tags": {
+      "editors": "Editors",
+      "installation": "Installation",
+      "agentic-coding": "Agentic Coding",
+      "front-end-basics": "Front-End Basics"
+    },
     "guideBreadcrumb": {
       "guides": "Guides"
     },
@@ -2037,6 +2043,12 @@
       "filterBy": "Filter by",
       "all": "All",
       "help": "Can't find what you're looking for? Try our <blogs>Blogs</blogs>, <faqs>FAQs</faqs>, <support>Contact support</support>, or ask in our <community>Community</community>"
+    },
+    "tags": {
+      "legal": "Legal",
+      "premium": "Premium",
+      "exercises": "Exercises",
+      "videos": "Videos"
     },
     "cta": {
       "minimalTitle": "Try Jiki for free",


### PR DESCRIPTION
Pairs with the i18n tag-labels PR (`ihid-tag-labels-i18n`).

## What changed

`ARTICLE_TAG_LABELS` and `GUIDE_TAG_LABELS` were per-locale translations hardcoded directly in TypeScript, and **only covered `en` and `hu` of the 33 supported locales**.

They move into `app-messages` as keys under `articles.tags` and `guides.tags`, which the three render sites already have in scope as client components using `useTranslations` — no new plumbing needed there.

## Why it helps

Per-key staleness means a change to one tag label invalidates **8 stale keys per locale** rather than the whole catalog going stale at once.

## What stays put

The tag slugs themselves stay in the front-end: they're untranslated data that appears in URLs, routing and frontmatter, and moving them would break links. **Only the human-facing labels move.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
