### PR TITLE
Fix llm-chat-proxy for the prose/code content split

### DIFF
--- a/llm-chat-proxy/src/index.ts
+++ b/llm-chat-proxy/src/index.ts
@@ -115,14 +115,24 @@ app.post("/chat", async (c) => {
 
     // 2. Parse request
     const body = await c.req.json<ChatRequest>();
-    const { exerciseSlug, code, question, history = [], nextTaskId, language, contentHash, locale = "en" } = body;
+    const {
+      exerciseSlug,
+      code,
+      question,
+      history = [],
+      nextTaskId,
+      language,
+      proseHash,
+      codeHash,
+      locale = "en"
+    } = body;
 
     if (exerciseSlug === undefined || code === undefined || question === undefined || language === undefined) {
       return c.json({ error: "Missing required fields: exerciseSlug, code, question, language" }, 400);
     }
 
-    if (!contentHash) {
-      return c.json({ error: "Missing required field: contentHash" }, 400);
+    if (!proseHash || !codeHash) {
+      return c.json({ error: "Missing required fields: proseHash, codeHash" }, 400);
     }
 
     // 2b. Validate exerciseSlug in request matches JWT claim
@@ -139,8 +149,9 @@ app.post("/chat", async (c) => {
 
     // 2c. Validate locale/hash shape. Both are interpolated into the content URL,
     // so reject anything that could smuggle in path segments or query strings.
-    if (!/^[a-z0-9-]{2,20}$/i.test(locale) || !/^[a-f0-9]{6,64}$/i.test(contentHash)) {
-      return c.json({ error: "Invalid locale or contentHash" }, 400);
+    const isHash = (value: string) => /^[a-f0-9]{6,64}$/i.test(value);
+    if (!/^[a-z0-9-]{2,20}$/i.test(locale) || !isHash(proseHash) || !isHash(codeHash)) {
+      return c.json({ error: "Invalid locale or content hash" }, 400);
     }
 
     // 3. Fetch exercise content from the assets cache tree and build prompt.
@@ -155,7 +166,8 @@ app.post("/chat", async (c) => {
     // serves the same paths relatively from public/.
     const isDev = process.env.NODE_ENV === "development";
     const origin = isDev ? c.req.header("Origin") || "https://assets.jiki.io" : "https://assets.jiki.io";
-    const contentUrl = `${origin}/static/exercises/${exerciseSlug}/${locale}/${language}/content-${contentHash}.json`;
+    const proseUrl = `${origin}/static/exercises/${exerciseSlug}/${locale}/prose-${proseHash}.json`;
+    const codeUrl = `${origin}/static/exercises/${exerciseSlug}/code/${language}/code-${codeHash}.json`;
 
     const { systemInstruction, prompt } = await buildPrompt({
       exerciseSlug,
@@ -164,7 +176,8 @@ app.post("/chat", async (c) => {
       history,
       nextTaskId,
       language,
-      contentUrl
+      proseUrl,
+      codeUrl
     });
 
     // 4. Stream from Gemini and collect the full response. The stream is opened

--- a/llm-chat-proxy/src/prompt-builder.ts
+++ b/llm-chat-proxy/src/prompt-builder.ts
@@ -15,7 +15,10 @@ interface PromptOptions {
   history: ChatMessage[];
   nextTaskId?: string;
   language: Language;
-  contentUrl: string; // URL to fetch exercise content (instructions, stub, solution)
+  // Exercise content is two artifacts: prose (instructions, per locale) and
+  // code (stub/solution, per language). See app/lib/assets-paths.ts.
+  proseUrl: string;
+  codeUrl: string;
 }
 
 // Input validation limits to prevent abuse and prompt injection
@@ -81,10 +84,20 @@ function validateInput(question: string, history: ChatMessage[]): void {
 /**
  * Fetches exercise content (instructions, stub, solution) from the app's static files.
  */
-async function fetchExerciseContent(contentUrl: string): Promise<ExerciseContent> {
-  const res = await fetch(contentUrl);
+async function fetchExerciseContent(proseUrl: string, codeUrl: string): Promise<ExerciseContent> {
+  const [prose, code] = await Promise.all([fetchJson(proseUrl), fetchJson(codeUrl)]);
+
+  return {
+    instructions: (prose as { instructions: string }).instructions,
+    stub: (code as { stub: string }).stub,
+    solution: (code as { solution: string }).solution
+  };
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`Failed to fetch exercise content from ${contentUrl}: ${res.status}`);
+    throw new Error(`Failed to fetch exercise content from ${url}: ${res.status}`);
   }
   return res.json();
 }
@@ -99,7 +112,7 @@ async function fetchExerciseContent(contentUrl: string): Promise<ExerciseContent
  * @throws Error if exercise is not found or input validation fails
  */
 export async function buildPrompt(options: PromptOptions): Promise<{ systemInstruction: string; prompt: string }> {
-  const { exerciseSlug, code, question, history, nextTaskId, language, contentUrl } = options;
+  const { exerciseSlug, code, question, history, nextTaskId, language, proseUrl, codeUrl } = options;
 
   // Validate input before building prompt
   validateInput(question, history);
@@ -108,7 +121,7 @@ export async function buildPrompt(options: PromptOptions): Promise<{ systemInstr
   const { code: croppedCode, wasCropped: codeWasCropped } = cropCode(code);
 
   // Load exercise core (scenarios, tasks, level) and content (stub, solution) in parallel
-  const [exercise, content] = await Promise.all([getExercise(exerciseSlug), fetchExerciseContent(contentUrl)]);
+  const [exercise, content] = await Promise.all([getExercise(exerciseSlug), fetchExerciseContent(proseUrl, codeUrl)]);
 
   if (exercise === null) {
     throw new Error(`Exercise not found: ${exerciseSlug}`);

--- a/llm-chat-proxy/src/types.ts
+++ b/llm-chat-proxy/src/types.ts
@@ -7,7 +7,10 @@ export interface ChatRequest {
   history?: ChatMessage[];
   nextTaskId?: string;
   language: Language;
-  contentHash: string; // Hash for fetching exercise content from the assets cache tree
+  // Exercise content is two artifacts, so it takes two hashes to name it:
+  // prose (instructions, per locale) and code (stub/solution, per language).
+  proseHash: string;
+  codeHash: string;
   locale?: string; // Locale segment of the content path; defaults to "en" for older clients
 }
 

--- a/llm-chat-proxy/tests/auth.test.ts
+++ b/llm-chat-proxy/tests/auth.test.ts
@@ -200,7 +200,8 @@ describe("Chat Endpoint Authentication", () => {
           code: "test",
           question: "test",
           language: "jikiscript",
-          contentHash: "test-hash"
+          proseHash: "abc123",
+          codeHash: "def456"
         })
       },
       mockEnv
@@ -228,7 +229,8 @@ describe("Chat Endpoint Authentication", () => {
           code: "test",
           question: "test",
           language: "jikiscript",
-          contentHash: "test-hash"
+          proseHash: "abc123",
+          codeHash: "def456"
         })
       },
       mockEnv
@@ -256,7 +258,8 @@ describe("Chat Endpoint Authentication", () => {
           code: "test",
           question: "test",
           language: "jikiscript",
-          contentHash: "test-hash"
+          proseHash: "abc123",
+          codeHash: "def456"
         })
       },
       mockEnv
@@ -281,7 +284,8 @@ describe("Chat Endpoint Authentication", () => {
           code: "test",
           question: "test",
           language: "jikiscript",
-          contentHash: "test-hash"
+          proseHash: "abc123",
+          codeHash: "def456"
         })
       },
       mockEnv
@@ -309,7 +313,8 @@ describe("Chat Endpoint Authentication", () => {
           code: "test",
           question: "test",
           language: "jikiscript",
-          contentHash: "test-hash"
+          proseHash: "abc123",
+          codeHash: "def456"
         })
       },
       mockEnv

--- a/llm-chat-proxy/tests/prompt-builder.test.ts
+++ b/llm-chat-proxy/tests/prompt-builder.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { buildPrompt, INPUT_LIMITS } from "../src/prompt-builder";
 
-// Mock exercise content returned by fetch
-const mockContent = {
-  instructions: "Solve the maze by moving Jiki to the exit.",
+// Mock exercise content. Prose and code are separate artifacts served at
+// separate URLs, so the mocks are separate too: the prose file carries the
+// instructions, the code file the stub and solution.
+const mockProse = {
+  instructions: "Solve the maze by moving Jiki to the exit."
+};
+
+const mockCode = {
   stub: "// Write your code here",
   solution: "move_right()\nmove_down()\nmove_right()"
 };
@@ -11,15 +16,21 @@ const mockContent = {
 const PROSE_URL = "https://assets.jiki.io/static/exercises/maze-solve-basic/en/prose-abc123def456.json";
 const CODE_URL = "https://assets.jiki.io/static/exercises/maze-solve-basic/code/jikiscript/code-def456abc123.json";
 
-// Mock global fetch for content URL requests
-beforeEach(() => {
+// Mock global fetch, routing each content URL to the artifact it serves.
+function stubContentFetch(instructions: string = mockProse.instructions) {
   vi.stubGlobal(
     "fetch",
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockContent)
-    })
+    vi.fn().mockImplementation((url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(url === PROSE_URL ? { instructions } : mockCode)
+      })
+    )
   );
+}
+
+beforeEach(() => {
+  stubContentFetch();
 });
 
 function defaultOpts(overrides: Record<string, unknown> = {}) {
@@ -240,18 +251,12 @@ describe("Prompt Builder", () => {
     const prompt = await buildText(defaultOpts());
 
     expect(prompt).toContain("## Student's Instructions");
-    expect(prompt).toContain(mockContent.instructions);
+    expect(prompt).toContain(mockProse.instructions);
   });
 
   it("should blockquote the exercise instructions content", async () => {
     const multiline = "## Your Tasks\n\nDo the thing.";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ ...mockContent, instructions: multiline })
-      })
-    );
+    stubContentFetch(multiline);
 
     const prompt = await buildText(defaultOpts());
 
@@ -262,13 +267,7 @@ describe("Prompt Builder", () => {
 
   it("should keep the frontmatter title as an H1 and drop the description", async () => {
     const withFrontmatter = `---\ntitle: "Space Invaders: Repeat"\ndescription: "Destroy a wave of aliens."\n---\n\nThe aliens are back.`;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ ...mockContent, instructions: withFrontmatter })
-      })
-    );
+    stubContentFetch(withFrontmatter);
 
     const prompt = await buildText(defaultOpts());
 
@@ -289,9 +288,9 @@ describe("Prompt Builder", () => {
     const prompt = await buildText(defaultOpts());
 
     expect(prompt).toContain("## Initial Code");
-    expect(prompt).toContain(mockContent.stub);
+    expect(prompt).toContain(mockCode.stub);
     expect(prompt).toContain("## Target Code");
-    expect(prompt).toContain(mockContent.solution);
+    expect(prompt).toContain(mockCode.solution);
   });
 
   it("should fetch prose and code from the provided URLs", async () => {

--- a/llm-chat-proxy/tests/prompt-builder.test.ts
+++ b/llm-chat-proxy/tests/prompt-builder.test.ts
@@ -8,7 +8,8 @@ const mockContent = {
   solution: "move_right()\nmove_down()\nmove_right()"
 };
 
-const CONTENT_URL = "https://assets.jiki.io/static/exercises/maze-solve-basic/en/jikiscript/content-abc123def456.json";
+const PROSE_URL = "https://assets.jiki.io/static/exercises/maze-solve-basic/en/prose-abc123def456.json";
+const CODE_URL = "https://assets.jiki.io/static/exercises/maze-solve-basic/code/jikiscript/code-def456abc123.json";
 
 // Mock global fetch for content URL requests
 beforeEach(() => {
@@ -28,7 +29,8 @@ function defaultOpts(overrides: Record<string, unknown> = {}) {
     question: "test",
     history: [],
     language: "jikiscript" as const,
-    contentUrl: CONTENT_URL,
+    proseUrl: PROSE_URL,
+    codeUrl: CODE_URL,
     ...overrides
   };
 }
@@ -292,9 +294,10 @@ describe("Prompt Builder", () => {
     expect(prompt).toContain(mockContent.solution);
   });
 
-  it("should fetch content from the provided URL", async () => {
+  it("should fetch prose and code from the provided URLs", async () => {
     await buildPrompt(defaultOpts());
-    expect(fetch).toHaveBeenCalledWith(CONTENT_URL);
+    expect(fetch).toHaveBeenCalledWith(PROSE_URL);
+    expect(fetch).toHaveBeenCalledWith(CODE_URL);
   });
 });
 


### PR DESCRIPTION
All production chat requests were failing with `{"error":"Missing required field: contentHash"}`.

The app shipped the prose/code content split (`proseHash` + `codeHash`, served at `.../{locale}/prose-{hash}.json` and `.../code/{language}/code-{hash}.json`), but the proxy was never updated. It still required a single `contentHash` and fetched the dead `.../{locale}/{language}/content-{hash}.json` path, so every request 400'd before reaching Gemini.

- `src/types.ts`: `contentHash` → `proseHash` + `codeHash`
- `src/index.ts`: validates both hashes, builds the two new URLs
- `src/prompt-builder.ts`: fetches prose and code concurrently, merges into `{instructions, stub, solution}`
- tests updated; typecheck + 86 tests pass

Needs a proxy deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MGVna7nvj4VrqeDEQeSST