### PR TITLE
Fix two-fer: wrap the two exact output strings in code formatting

### DIFF
--- a/curriculum/src/exercises/two-fer/instructions.md
+++ b/curriculum/src/exercises/two-fer/instructions.md
@@ -11,8 +11,8 @@ Imagine a bakery that has a holiday offer where you can buy two cookies for the 
 
 Your task is to determine what you will say as you give away the extra cookie.
 
-- If you know the person's name (e.g. Alice), then you will say: "One for Alice, one for me."
-- If you don't know the person's name, you will say: "One for you, one for me."
+- If you know the person's name (e.g. Alice), then you will say: `"One for Alice, one for me."`
+- If you don't know the person's name, you will say: `"One for you, one for me."`
 
 Write a function called <define>`twoFer(name)`</define> that returns the appropriate dialogue.
 


### PR DESCRIPTION
## Summary
- The exercise instructions quote two exact strings the function must return (`"One for Alice, one for me."` / `"One for you, one for me."`) as plain prose, while the table further down the same page already wraps the identical strings in backticks. Flagged from the Arabic translation review — the untranslated English (correctly left as-is, since it's literal output) read confusingly without code formatting to signal it's not prose.
- Wraps both bullet-list occurrences in backticks to match the page's own existing convention.

## Test plan
- [x] Pre-commit checks (typecheck, lint, tests) passed locally
- [x] Propagated the same codeblock fix to all 19 i18n locale translations of this exercise (separate `i18n` repo commit) — content itself already correctly untranslated, only markup added

🤖 Generated with [Claude Code](https://claude.com/claude-code)