### PR TITLE
Retitle keyword/syntax concept pages, fixing the else/else-if translation bug

### DIFF
--- a/curriculum/src/concepts/else-if/source.md
+++ b/curriculum/src/concepts/else-if/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Else If"
+title: "Using `else if` Chains"
 description: "Chaining `else if` clauses to check several conditions in order, running only the first block whose condition is true."
 ---
 

--- a/curriculum/src/concepts/else/source.md
+++ b/curriculum/src/concepts/else/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Else"
+title: "The `else` Keyword"
 description: "Adding an `else` clause after an `if` so a different block of code runs when the condition turns out to be false."
 ---
 

--- a/curriculum/src/concepts/for-loops/source.md
+++ b/curriculum/src/concepts/for-loops/source.md
@@ -1,5 +1,5 @@
 ---
-title: "For Loops"
+title: "Understanding `for` Loops"
 description: "A loop with three parts (an initializer, a condition, and an increment) giving you full control over iteration."
 ---
 

--- a/curriculum/src/concepts/logical-and/source.md
+++ b/curriculum/src/concepts/logical-and/source.md
@@ -1,5 +1,5 @@
 ---
-title: "The `and` keyword"
+title: "The `&&` (And) Operator"
 description: "Combining two conditions with `&&` so the whole condition is only true when both parts are true."
 ---
 

--- a/curriculum/src/concepts/logical-not/source.md
+++ b/curriculum/src/concepts/logical-not/source.md
@@ -1,5 +1,5 @@
 ---
-title: "The `not` operator"
+title: "The `!` (Not) Operator"
 description: "Using `!` to flip a boolean: true becomes false and false becomes true, useful for toggling or inverting checks."
 ---
 

--- a/curriculum/src/concepts/logical-or/source.md
+++ b/curriculum/src/concepts/logical-or/source.md
@@ -1,5 +1,5 @@
 ---
-title: "The `or` keyword"
+title: "The `||` (Or) Operator"
 description: "Combining two conditions with `||` so the whole condition is true when at least one of the parts is true."
 ---
 

--- a/curriculum/src/concepts/modulo/source.md
+++ b/curriculum/src/concepts/modulo/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Remainder"
+title: "Using the `%` Operator for Remainders"
 description: "Using the `%` operator to get what's left over after division, often used to check if a number is even or odd."
 ---
 

--- a/curriculum/src/concepts/repeat-while/source.md
+++ b/curriculum/src/concepts/repeat-while/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Repeat Without Count"
+title: "Using `repeat` Without a Count"
 description: "Leaving the brackets of a repeat loop empty so Jiki keeps going until something else tells him to stop."
 ---
 

--- a/curriculum/src/concepts/repeat/source.md
+++ b/curriculum/src/concepts/repeat/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Repeat Loop"
+title: "The `repeat` Loop"
 description: "Using the `repeat` keyword to tell Jiki to run the code inside the curly brackets a specific number of times."
 ---
 

--- a/curriculum/src/concepts/string-iteration/source.md
+++ b/curriculum/src/concepts/string-iteration/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Iterating Through Strings"
+title: "Looping Through Strings with `for ... of`"
 description: "Using a `for of` loop to step through every letter in a string, doing something with each one in turn."
 ---
 

--- a/curriculum/src/concepts/strings/source.md
+++ b/curriculum/src/concepts/strings/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Strings"
+title: "Introducing Strings"
 description: "Pieces of text wrapped in quotes (a letter, a word, a sentence, or a whole paragraph) that Jiki writes on paper."
 ---
 

--- a/curriculum/src/concepts/updating-dictionaries/source.md
+++ b/curriculum/src/concepts/updating-dictionaries/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Changing Dictionaries"
+title: "Updating Dictionaries"
 description: "Using `dict[key] = value` to update existing entries or add new ones, plus the `has` method for checking keys."
 ---
 

--- a/curriculum/src/concepts/while-loops/source.md
+++ b/curriculum/src/concepts/while-loops/source.md
@@ -1,5 +1,5 @@
 ---
-title: "While Loops"
+title: "Understanding `while` Loops"
 description: "A loop that keeps running while some condition stays true."
 ---
 


### PR DESCRIPTION
## Summary
- `else` and `else-if` had titles that were literally just the bare English keyword ("Else", "Else If") with no surrounding noun. Discovered from the Arabic content review: a model asked to translate a title that's nothing but a language keyword passes it through as code rather than writing a heading. Swept every locale — this broke `else`'s title in 16 of 17 languages and `else-if`'s in 14 of 17.
- Rather than patch just those two, retitled the full set of keyword/operator concept pages for clarity and internal consistency: `else`, `else-if`, `for-loops`, `while-loops`, `repeat`, `repeat-while`, `string-iteration`, `strings`, `updating-dictionaries`, `logical-and`, `logical-or`, `logical-not`, `modulo`.
- All 13 titles now use the same Title Case convention (previously a mix of Title Case and sentence case).

## Test plan
- [x] Pre-commit checks (typecheck, lint, all 825 tests) passed locally
- [ ] Once merged, existing translations of these 13 pages' titles need a follow-up fix pass in the `i18n` repo (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)