### PR TITLE
Retitle break, continue, if to match the retitled concept-page set

### DIFF
--- a/curriculum/src/concepts/break/source.md
+++ b/curriculum/src/concepts/break/source.md
@@ -1,5 +1,5 @@
 ---
-title: "The \`break\` Keyword"
+title: "The `break` Keyword"
 description: "Using the `break` keyword inside a loop body to exit the loop immediately and move on to code that comes after it."
 ---
 

--- a/curriculum/src/concepts/break/source.md
+++ b/curriculum/src/concepts/break/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Break"
+title: "The \`break\` Keyword"
 description: "Using the `break` keyword inside a loop body to exit the loop immediately and move on to code that comes after it."
 ---
 

--- a/curriculum/src/concepts/continue/source.md
+++ b/curriculum/src/concepts/continue/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Continue"
+title: "The \`continue\` Keyword"
 description: "Using the `continue` keyword inside a loop to skip the rest of this iteration and jump straight to the next one."
 ---
 

--- a/curriculum/src/concepts/continue/source.md
+++ b/curriculum/src/concepts/continue/source.md
@@ -1,5 +1,5 @@
 ---
-title: "The \`continue\` Keyword"
+title: "The `continue` Keyword"
 description: "Using the `continue` keyword inside a loop to skip the rest of this iteration and jump straight to the next one."
 ---
 

--- a/curriculum/src/concepts/if/source.md
+++ b/curriculum/src/concepts/if/source.md
@@ -1,5 +1,5 @@
 ---
-title: "Understanding \`if\` Statements"
+title: "Understanding `if` Statements"
 description: "Using the `if` keyword to run a block of code only when some condition is true, like a bouncer letting people through."
 ---
 

--- a/curriculum/src/concepts/if/source.md
+++ b/curriculum/src/concepts/if/source.md
@@ -1,5 +1,5 @@
 ---
-title: "If Statements"
+title: "Understanding \`if\` Statements"
 description: "Using the `if` keyword to run a block of code only when some condition is true, like a bouncer letting people through."
 ---
 


### PR DESCRIPTION
## Summary
- Follow-up to #1056. `break`/`continue` had bare-keyword titles ("Break", "Continue") — the same shape that broke translation for `else`/`else-if` in #1056.
- `if` moves from "If Statements" to "Understanding `if` Statements", matching the "Understanding X" phrasing already used for `for-loops`/`while-loops`.

## Test plan
- [x] Pre-commit checks (typecheck, lint, all 825 tests) passed locally
- [ ] Existing translations of these 3 pages' titles need a follow-up fix pass in `i18n` (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)