### PR TITLE
Make forum links locale-aware; fix hardcoded external blog link

### DIFF
--- a/app/components/articles/FilterSidebar.tsx
+++ b/app/components/articles/FilterSidebar.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ArticleTagSlug } from "@/lib/content/types";
-import { FORUM_URL } from "@/lib/constants/social";
+import { useForumUrl } from "@/lib/i18n/externalLinks";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import styles from "./FilterSidebar.module.css";
 
@@ -18,6 +18,7 @@ export default function FilterSidebar({ tagSlugs, selectedTag }: FilterSidebarPr
   const tTags = useTranslations("articles.tags");
   const pathname = usePathname();
   const routes = useLocaleRoutes();
+  const forumUrl = useForumUrl();
 
   const buildTagUrl = (tag: ArticleTagSlug | null) => {
     if (tag === null) {
@@ -50,7 +51,7 @@ export default function FilterSidebar({ tagSlugs, selectedTag }: FilterSidebarPr
             faqs: (chunks) => <Link href={routes.article("faqs")}>{chunks}</Link>,
             support: (chunks) => <Link href={routes.article("support")}>{chunks}</Link>,
             community: (chunks) => (
-              <a href={FORUM_URL} target="_blank" rel="noopener noreferrer">
+              <a href={forumUrl} target="_blank" rel="noopener noreferrer">
                 {chunks}
               </a>
             )

--- a/app/components/coding-exercise/ui/test-results-view/UnhandledErrorView.tsx
+++ b/app/components/coding-exercise/ui/test-results-view/UnhandledErrorView.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from "next-intl";
 import { CopyToClipboardButton } from "@/components/ui-kit/CopyToClipboardButton";
-import { FORUM_URL } from "@/lib/constants/social";
+import { useForumUrl } from "@/lib/i18n/externalLinks";
 import { useOrchestratorStore } from "../../lib/Orchestrator";
 import { useOrchestrator } from "../../lib/OrchestratorContext";
 import RunButton from "../RunButton";
@@ -11,6 +11,7 @@ export function UnhandledErrorView() {
   const t = useTranslations("codingExercise.unhandledError");
   const orchestrator = useOrchestrator();
   const { unhandledErrorBase64 } = useOrchestratorStore(orchestrator);
+  const forumUrl = useForumUrl();
 
   return (
     <div className={styles.container}>
@@ -33,7 +34,7 @@ export function UnhandledErrorView() {
           {t.rich("message", {
             strong: (chunks) => <strong className={unhandledStyles.bodyStrong}>{chunks}</strong>,
             link: (chunks) => (
-              <a href={FORUM_URL} target="_blank" rel="noopener noreferrer">
+              <a href={forumUrl} target="_blank" rel="noopener noreferrer">
                 {chunks}
               </a>
             )

--- a/app/components/layout/header/ExternalButtons.tsx
+++ b/app/components/layout/header/ExternalButtons.tsx
@@ -15,7 +15,7 @@ export default function ExternalButtons() {
   return (
     <>
       <div className={styles.navLinks}>
-        <Link href="https://jiki.io/blog/the-backstory-of-jiki" className={styles.navLink}>
+        <Link href={routes.blogPost("the-backstory-of-jiki")} className={styles.navLink}>
           {t("aboutJiki")}
         </Link>
         <Link href={routes.premium()} className={styles.navLink}>
@@ -88,7 +88,7 @@ function MobileMenu() {
 
       {isOpen && (
         <div className={styles.menuDropdown} role="menu">
-          <Link href="https://jiki.io/blog/the-backstory-of-jiki" className={styles.menuLink} onClick={close}>
+          <Link href={routes.blogPost("the-backstory-of-jiki")} className={styles.menuLink} onClick={close}>
             {t("aboutJiki")}
           </Link>
           <Link href={routes.premium()} className={styles.menuLink} onClick={close}>

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -19,7 +19,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { useAuthStore } from "@/lib/auth/authStore";
 import { YOUTUBE_URL } from "@/lib/constants/social";
 import { forumUrl } from "@/lib/i18n/externalLinks";
-import { localePath } from "@/lib/i18n/routes";
+import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
 import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { tierIncludes } from "@/lib/pricing";
 import { NavigationItem } from "./NavigationItem";
@@ -47,46 +47,10 @@ interface NavItem {
   external?: boolean;
 }
 
-const navigationGroups: Array<{
-  id: "learnToCode" | "learnToBuild" | "community" | "more";
-  items: NavItem[];
-}> = [
-  {
-    id: "learnToCode",
-    items: [
-      { id: "learn", href: "/dashboard", icon: BrainLightningIcon },
-      { id: "challenges", href: "/challenges", icon: ChallengesIcon },
-      { id: "concepts", href: "/concepts", icon: FolderIcon }
-    ]
-  },
-  {
-    id: "learnToBuild",
-    items: [
-      { id: "build", href: "/build", icon: LearningComputerIcon },
-      { id: "guides", href: "/guides", icon: StudyBookIcon }
-    ]
-  },
-  {
-    id: "community",
-    items: [
-      { id: "videos", href: YOUTUBE_URL, icon: VideoLibIcon, external: true },
-      { id: "blog", href: "/blog", icon: RssIcon },
-      { id: "forum", href: "forum", icon: ChatBubbleIcon, external: true }
-    ]
-  },
-  {
-    id: "more",
-    items: [
-      { id: "achievements", href: "/achievements", icon: MedalIcon },
-      { id: "settings", href: "/settings", icon: SettingsIcon },
-      { id: "help", href: "/help", icon: HelpIcon }
-    ]
-  }
-];
-
 export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
   const t = useTranslations("layout.sidebar");
   const locale = useLocale();
+  const routes = useLocaleRoutes();
   const router = useRouter();
   const logout = useAuthStore((state) => state.logout);
   const user = useAuthStore((state) => state.user);
@@ -95,9 +59,46 @@ export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
   const handleLogout = async () => {
     const result = await logout();
     if (result.success) {
-      router.push(localePath("/", locale));
+      router.push(routes.home());
     }
   };
+
+  const navigationGroups: Array<{
+    id: "learnToCode" | "learnToBuild" | "community" | "more";
+    items: NavItem[];
+  }> = [
+    {
+      id: "learnToCode",
+      items: [
+        { id: "learn", href: routes.dashboard(), icon: BrainLightningIcon },
+        { id: "challenges", href: routes.challenges(), icon: ChallengesIcon },
+        { id: "concepts", href: routes.concepts(), icon: FolderIcon }
+      ]
+    },
+    {
+      id: "learnToBuild",
+      items: [
+        { id: "build", href: routes.build(), icon: LearningComputerIcon },
+        { id: "guides", href: routes.guides(), icon: StudyBookIcon }
+      ]
+    },
+    {
+      id: "community",
+      items: [
+        { id: "videos", href: YOUTUBE_URL, icon: VideoLibIcon, external: true },
+        { id: "blog", href: routes.blog(), icon: RssIcon },
+        { id: "forum", href: forumUrl(locale), icon: ChatBubbleIcon, external: true }
+      ]
+    },
+    {
+      id: "more",
+      items: [
+        { id: "achievements", href: routes.achievements(), icon: MedalIcon },
+        { id: "settings", href: routes.settings(), icon: SettingsIcon },
+        { id: "help", href: routes.articles(), icon: HelpIcon }
+      ]
+    }
+  ];
 
   const renderItem = (item: NavItem) => (
     <NavigationItem
@@ -105,7 +106,7 @@ export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
       id={item.id}
       label={t(`nav.${item.id}`)}
       isActive={activeItem === item.id}
-      href={item.id === "forum" ? forumUrl(locale) : item.external ? item.href : localePath(item.href, locale)}
+      href={item.href}
       external={item.external}
       icon={item.icon}
       showPremiumPill={item.showPremiumPill}

--- a/app/components/layout/sidebar/Sidebar.tsx
+++ b/app/components/layout/sidebar/Sidebar.tsx
@@ -17,7 +17,8 @@ import type { ComponentType } from "react";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { useAuthStore } from "@/lib/auth/authStore";
-import { YOUTUBE_URL, FORUM_URL } from "@/lib/constants/social";
+import { YOUTUBE_URL } from "@/lib/constants/social";
+import { forumUrl } from "@/lib/i18n/externalLinks";
 import { localePath } from "@/lib/i18n/routes";
 import { showPremiumUpgradeModal } from "@/lib/modal/app";
 import { tierIncludes } from "@/lib/pricing";
@@ -70,7 +71,7 @@ const navigationGroups: Array<{
     items: [
       { id: "videos", href: YOUTUBE_URL, icon: VideoLibIcon, external: true },
       { id: "blog", href: "/blog", icon: RssIcon },
-      { id: "forum", href: FORUM_URL, icon: ChatBubbleIcon, external: true }
+      { id: "forum", href: "forum", icon: ChatBubbleIcon, external: true }
     ]
   },
   {
@@ -104,7 +105,7 @@ export default function Sidebar({ activeItem = "blog" }: SidebarProps) {
       id={item.id}
       label={t(`nav.${item.id}`)}
       isActive={activeItem === item.id}
-      href={item.external ? item.href : localePath(item.href, locale)}
+      href={item.id === "forum" ? forumUrl(locale) : item.external ? item.href : localePath(item.href, locale)}
       external={item.external}
       icon={item.icon}
       showPremiumPill={item.showPremiumPill}

--- a/app/lib/i18n/externalLinks.ts
+++ b/app/lib/i18n/externalLinks.ts
@@ -1,0 +1,26 @@
+import { useLocale } from "next-intl";
+import { DEFAULT_LOCALE, normalizeLocale } from "./config";
+import { FORUM_URL } from "@/lib/constants/social";
+
+/**
+ * Locale-aware forum URL. The forum (Discourse) is a separate app, so it can't
+ * use `localePath`'s in-app path-prefix scheme; Discourse instead reads locale
+ * from a `tl` query param (site setting "set locale from param" must be enabled
+ * on the forum for this to take effect). The default locale is omitted, matching
+ * `localePath`'s "default locale is naked" convention.
+ */
+export function forumUrl(locale: string): string {
+  const activeLocale = normalizeLocale(locale);
+  if (activeLocale === DEFAULT_LOCALE) {
+    return FORUM_URL;
+  }
+  return `${FORUM_URL}?tl=${activeLocale}`;
+}
+
+/**
+ * `forumUrl` bound to the ambient UI locale via next-intl's sync `useLocale()`.
+ * Works in both client components and synchronously-rendered server components.
+ */
+export function useForumUrl(): string {
+  return forumUrl(useLocale());
+}

--- a/app/lib/i18n/routes.ts
+++ b/app/lib/i18n/routes.ts
@@ -81,10 +81,13 @@ export function makeRoutes(locale: Locale) {
     guide: (slug: string) => path(`/guides/${slug}`),
     concepts: () => path("/concepts"),
     concept: (slug: string) => path(`/concepts/${slug}`),
+    build: () => path("/build"),
 
     // Auth-gated app routes (no [locale] tree -> always naked; locale ignored)
     dashboard: () => path("/dashboard"),
-    settings: () => path("/settings")
+    settings: () => path("/settings"),
+    challenges: () => path("/challenges"),
+    achievements: () => path("/achievements")
   };
 }
 

--- a/app/lib/toasts/lessonSaveError.tsx
+++ b/app/lib/toasts/lessonSaveError.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from "next-intl";
 import toast from "react-hot-toast";
-import { FORUM_URL } from "@/lib/constants/social";
+import { useForumUrl } from "@/lib/i18n/externalLinks";
 
 /**
  * Show an error toast when a lesson's progress could not be saved to the API
@@ -13,12 +13,13 @@ export function showLessonSaveErrorToast() {
 
 function LessonSaveErrorMessage() {
   const t = useTranslations("toasts");
+  const forumUrl = useForumUrl();
   return (
     <span>
       {t.rich("exercise.lessonSaveError", {
         link: (chunks) => (
           <a
-            href={FORUM_URL}
+            href={forumUrl}
             target="_blank"
             rel="noopener noreferrer"
             style={{ fontWeight: 500, textDecoration: "underline", textUnderlineOffset: "1px" }}


### PR DESCRIPTION
## Summary
- Add `lib/i18n/externalLinks.ts` (`forumUrl`/`useForumUrl`) which appends Discourse's `?tl=<locale>` query param for non-default locales, matching `localePath`'s "default locale is naked" convention.
- Route all forum links (sidebar, articles filter sidebar, unhandled-error view, lesson-save-error toast) through the new helper instead of the raw `FORUM_URL` constant.
- Fix the header "About Jiki" link (`ExternalButtons.tsx`, desktop + mobile menu), which was hardcoded to the absolute `https://jiki.io/blog/the-backstory-of-jiki` URL for what is actually an internal, already-translated blog post — now uses `routes.blogPost(...)`.

Left unlocalized on purpose (not locale-aware services): status page (jiki.instatus.com), YouTube, Exercism OAuth, Discord redirect.

Note: the `?tl=` param only takes effect once forum.jiki.io has Discourse's "set locale from param" site setting enabled — that's a Discourse admin setting, not something this repo controls.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter app run lint` clean (pre-existing unrelated warning only)
- [x] Full app test suite passes via pre-commit hook (2271 tests)
- [ ] Manually verify forum links carry `?tl=hu` when UI locale is `hu`, and are naked for `en`
- [ ] Manually verify header "About Jiki" link opens the localized blog post in-app rather than jiki.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2jr4CM7fXn5hM479qT3pk