### PR TITLE
Republish only the locale that changed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ Exercise content is served as static files, separate from the exercise modules i
 
 ### Translated Content in Development
 
-Translations live in the separate `i18n` repo and reach production via R2, not via this repo's build. To see them locally, clone `i18n` beside the front-end (or set `JIKI_I18N_REPO`); `pnpm dev` then runs `i18n-content:generate` and watches `../../i18n/locales/**`.
+Translations live in the separate `i18n` repo and reach production via R2, not via this repo's build. To see them locally, clone `i18n` beside the front-end (or set `JIKI_I18N_REPO`); `pnpm dev` then runs `i18n-content:generate` and watches `../../i18n/locales/**`. The watcher republishes only the locale whose file changed (the first segment under `locales/`), falling back to a full publish for anything it cannot place: one locale is ~0.4s and ~550 files against ~2.2s and ~7,800 for all of them, which matters when every save during a translation pass triggers it. Per-locale is as narrow as it can safely go, since a locale's indexes are assembled from its whole corpus and embed the content hashes of the files they point at.
 
 That script runs the **i18n repo's own publisher** with `--out-dir`, so the local tree is the same bytes at the same paths the R2 objects would be, produced by the same code. With no `i18n` checkout it prints one line and exits 0, so nothing is required of anyone who does not need translations. It is deliberately **not** part of `build`: a production build gets non-English content from R2 on the i18n repo's cadence, and baking a snapshot in would pin every locale to whatever was on disk at build time.
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -176,7 +176,7 @@ Exercise content is served as static files, separate from the exercise modules i
 
 ### Translated Content in Development
 
-Translations live in the separate `i18n` repo and reach production via R2, not via this repo's build. To see them locally, clone `i18n` beside the front-end (or set `JIKI_I18N_REPO`); `pnpm dev` then runs `i18n-content:generate` and watches `../../i18n/locales/**`.
+Translations live in the separate `i18n` repo and reach production via R2, not via this repo's build. To see them locally, clone `i18n` beside the front-end (or set `JIKI_I18N_REPO`); `pnpm dev` then runs `i18n-content:generate` and watches `../../i18n/locales/**`. The watcher republishes only the locale whose file changed (the first segment under `locales/`), falling back to a full publish for anything it cannot place: one locale is ~0.4s and ~550 files against ~2.2s and ~7,800 for all of them, which matters when every save during a translation pass triggers it. Per-locale is as narrow as it can safely go, since a locale's indexes are assembled from its whole corpus and embed the content hashes of the files they point at.
 
 That script runs the **i18n repo's own publisher** with `--out-dir`, so the local tree is the same bytes at the same paths the R2 objects would be, produced by the same code. With no `i18n` checkout it prints one line and exits 0, so nothing is required of anyone who does not need translations. It is deliberately **not** part of `build`: a production build gets non-English content from R2 on the i18n repo's cadence, and baking a snapshot in would pin every locale to whatever was on disk at build time.
 

--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,7 @@
     "curriculum-copy:generate": "node scripts/generate-curriculum-copy-cache.js",
     "curriculum-copy:watch": "onchange '../curriculum/src/video-lessons/messages.json' '../curriculum/src/badges/messages.json' '../curriculum/src/exercises/**/instructions.md' -- node scripts/generate-curriculum-copy-cache.js",
     "i18n-content:generate": "node scripts/generate-i18n-content.js",
-    "i18n-content:watch": "onchange '../../i18n/locales/**' -- node scripts/generate-i18n-content.js",
+    "i18n-content:watch": "onchange --delay 400 '../../i18n/locales/**' -- node scripts/generate-i18n-content.js {{changed}}",
     "locales:verify": "node scripts/verify-locale-completeness.js",
     "verify:locale": "npm-run-all --parallel content:generate exercise-cache:generate interpreter-i18n:generate messages-cache:generate concept-cache:generate levels-i18n:generate curriculum-copy:generate && node scripts/verify-locale.js",
     "seed-language": "node scripts/seed-language.js",

--- a/app/scripts/generate-i18n-content.js
+++ b/app/scripts/generate-i18n-content.js
@@ -31,6 +31,21 @@
  * clear their output directories on the way in, so running in parallel would
  * race them and delete the locales this had just written.
  *
+ * ## Scope
+ *
+ * With no argument it publishes every locale, which is what a cold `pnpm dev`
+ * wants. The watcher passes the path that changed, and then only that path's
+ * locale is republished: a full run is ~2.2s and 7,800 files, one locale is
+ * ~0.4s and ~550, and someone mid-translation triggers this on every save.
+ *
+ * Per-locale is as narrow as it can safely go. Each locale's output includes
+ * indexes assembled from its whole corpus (the curriculum catalog, the exercise
+ * prose index, the concept and post copy indexes, the search indexes), and they
+ * embed the content hashes of the files they point at. Publishing one file
+ * without rebuilding those would leave an index naming an artifact that no
+ * longer exists. Rebuilding them costs ~60ms once node is up, so there is
+ * nothing to win by going finer.
+ *
  * ## When there is no i18n checkout
  *
  * It says so once and exits 0. Most work in this repo needs no translations,
@@ -62,9 +77,30 @@ if (!fs.existsSync(publisher)) {
   process.exit(0);
 }
 
-console.log(`Generating translated content from ${i18nRepo}...\n`);
+// The locale a changed path belongs to, or null for anything unrecognised. The
+// locale is always the first segment under `locales/`. Unparseable input falls
+// back to a full publish rather than guessing: the publisher hard-fails on a
+// locale it does not know, and a slow refresh beats a dead watcher.
+function localeFromChangedPath(changed) {
+  if (!changed) return null;
 
-const result = spawnSync("node", [publisher, "all", `--out-dir=${PUBLIC_DIR}`], {
+  const relative = path.relative(path.join(i18nRepo, "locales"), path.resolve(changed));
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return null;
+
+  const [locale] = relative.split(path.sep);
+  const { targets } = JSON.parse(fs.readFileSync(path.join(i18nRepo, "locales.json"), "utf8"));
+  return targets.includes(locale) ? locale : null;
+}
+
+const target = localeFromChangedPath(process.argv[2]) ?? "all";
+
+console.log(
+  target === "all"
+    ? `Generating translated content from ${i18nRepo}...\n`
+    : `Generating ${target} content from ${i18nRepo}...\n`
+);
+
+const result = spawnSync("node", [publisher, target, `--out-dir=${PUBLIC_DIR}`], {
   cwd: i18nRepo,
   stdio: "inherit"
 });


### PR DESCRIPTION
`bin/dev`'s i18n watcher ran the publisher as `all` on any change under `i18n/locales/**`, so editing one Italian string rebuilt all 33 locales across exercises, concepts, curriculum, interpreters and app catalogs. Measured: **2.24s and 7,833 files**. During a translation pass that fires on every save, which is what prompted this.

The watcher now passes the changed path through (`{{changed}}`), and the script derives the locale from it — always the first segment under `locales/` — and publishes just that one: **0.40s and 549 files**.

Anything it cannot place falls back to a full publish. The publisher hard-fails on a locale it does not recognise, and a slow refresh beats a dead watcher.

It also debounces at 400ms, so saving several files in one pass is one run rather than N.

## Why per-locale and not per-file

Per-file was investigated and rejected. Each locale's output includes indexes assembled from its whole corpus — the curriculum catalog, the exercise prose index, the concept and post copy indexes, the two search indexes — and every artifact is content-hashed, so those indexes embed the hashes of the files they name. Publishing one file without rebuilding them would leave an index pointing at a hash that no longer exists. A change to an `exercise-categories` base catalog also fans out to every member exercise.

Rebuilding all of that costs ~60ms once node is up, against ~340ms of interpreter/renderer startup. So per-file would reimplement most of `publishLocale` to save tens of milliseconds.

## Notes

- A cold `pnpm dev` is unchanged: it invokes the script with no argument, which still publishes everything.
- Nothing is deleted by a narrow run. The publisher only wipes `dist/` when `--out-dir` is absent, which is never the case here.
- `publish.mjs` already accepted `<locale|all>`, so this needs no change in the i18n repo.
- One trap worth recording: a single-locale run writes a `completeness.json` containing only that locale. Harmless here (the front-end reads that file from `assets.jiki.io`, not the local tree) but a reason to keep single-locale runs strictly a dev-watcher thing and never wire one to `--upload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)