### PR TITLE
Landing/blog tweaks: card byline, hero CTA shadow, Learn to Code copy

### DIFF
--- a/app/components/blog/BlogPostCard.module.css
+++ b/app/components/blog/BlogPostCard.module.css
@@ -84,18 +84,6 @@
     flex-grow: 1;
 }
 
-.postAuthor {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-top: 16px;
-    padding-top: 16px;
-    border-top: 1px solid var(--color-gray-100);
-    font-size: 14px;
-    color: var(--color-gray-500);
-    font-weight: 500;
-}
-
 @media (max-width: 1024px) {
     .blogPostsGrid {
         grid-template-columns: repeat(2, 1fr);

--- a/app/components/blog/BlogPostCard.tsx
+++ b/app/components/blog/BlogPostCard.tsx
@@ -1,9 +1,7 @@
 import Link from "next/link";
-import { useTranslations } from "next-intl";
 import type { BlogPostMeta } from "@/lib/content/types";
 import { formatBlogDate } from "@/lib/utils";
 import { useLocaleRoutes } from "@/lib/i18n/useLocaleRoutes";
-import AuthorAvatar from "@/components/ui/AuthorAvatar";
 
 interface BlogPostCardProps {
   post: BlogPostMeta;
@@ -11,7 +9,7 @@ interface BlogPostCardProps {
    * Scoped CSS module from the consuming section, so each surface keeps its own
    * look (e.g. blog page vs landing page) while sharing this markup. Must expose
    * the `blogPostCard`/`postImage`/`postMeta`/`postDate`/`postBadge`/`postTitle`/
-   * `postExcerpt`/`postAuthor` classes.
+   * `postExcerpt` classes.
    */
   styles: Record<string, string>;
   /** Semantic heading level for the card title (context-dependent). */
@@ -19,7 +17,6 @@ interface BlogPostCardProps {
 }
 
 export default function BlogPostCard({ post, styles, headingLevel = "h2" }: BlogPostCardProps) {
-  const t = useTranslations("landing.latestNews");
   const routes = useLocaleRoutes();
   const Heading = headingLevel;
   const firstTag = post.tags[0];
@@ -36,10 +33,6 @@ export default function BlogPostCard({ post, styles, headingLevel = "h2" }: Blog
       </div>
       <Heading className={styles.postTitle}>{post.title}</Heading>
       <p className={styles.postExcerpt}>{post.excerpt}</p>
-      <div className={styles.postAuthor}>
-        <AuthorAvatar author={post.author} />
-        <span>{t("byAuthor", { name: post.author.name })}</span>
-      </div>
     </Link>
   );
 }

--- a/app/components/landing-page/SignupButton.module.css
+++ b/app/components/landing-page/SignupButton.module.css
@@ -10,7 +10,9 @@
     font-size: 18px;
     border: 1px solid #c1b1dc;
     border-radius: 12px;
-    animation: btn-pulse 4.8s ease-in-out infinite;
+    box-shadow:
+        0 0 20px -8px rgba(2, 6, 23, 0.55),
+        0 0 12px -3px rgba(2, 6, 23, 0.4);
     transition:
         background-color 0.3s ease,
         box-shadow 0.3s ease,
@@ -18,10 +20,8 @@
 }
 
 .btn:hover {
-    /* The pulse keeps rewriting box-shadow, so it has to stop for the hover shadow to
-       show at all. A shadow cast behind rather than a halo around it: on the dark hero a
-       purple glow lit the button up, where a drop shadow lifts it off the grid instead. */
-    animation: none;
+    /* A shadow cast behind rather than a halo around it: on the dark hero a purple glow
+       lit the button up, where a drop shadow lifts it off the grid instead. */
     background: var(--color-purple-600);
     box-shadow:
         0 14px 30px -8px rgba(2, 6, 23, 0.75),
@@ -35,22 +35,5 @@
 
     @media (max-width: 767px) {
         display: none;
-    }
-}
-
-/* The resting drop shadow is carried inside the keyframes rather than set on .btn:
-   an animation on box-shadow overwrites the property outright, so a separately
-   declared shadow would never render. */
-@keyframes btn-pulse {
-    0%,
-    100% {
-        box-shadow:
-            0 8px 24px color-mix(in srgb, var(--color-purple-500) 40%, transparent),
-            0 0 5px rgba(255, 255, 255, 0.35);
-    }
-    50% {
-        box-shadow:
-            0 8px 24px color-mix(in srgb, var(--color-purple-500) 40%, transparent),
-            0 0 12px rgba(255, 255, 255, 0.55);
     }
 }

--- a/app/components/landing-page/track-cards/LearnToCodeCard.module.css
+++ b/app/components/landing-page/track-cards/LearnToCodeCard.module.css
@@ -23,7 +23,7 @@
     line-height: 1.05;
     font-weight: 600;
     color: var(--color-gray-900);
-    margin-block: 40px 20px;
+    margin-block: 40px 10px;
 
     @media (min-width: 640px) {
         font-size: 48px;

--- a/app/messages.json
+++ b/app/messages.json
@@ -531,7 +531,7 @@
     },
     "learnToCode": {
       "heading": "Learn to <word>Code</word>",
-      "intro": "Master the core skill we use to translate our thoughts into languages that a computer can understand. We'll help you <highlight>build rock solid coding foundations</highlight>.",
+      "intro": "Master coding, the core skill we use to communicate our desires to a computer. We'll help you <highlight>build rock solid coding foundations</highlight>.",
       "demo": {
         "stageDescription": "An animation of the Jiki app: a learner runs a space-invaders exercise, the code moves the laser cannon off the edge of the grid, they ask Jiki for help, correct the boundary from 20 to 11, and the exercise passes.",
         "run": "Run Code",


### PR DESCRIPTION
Three small unrelated-but-adjacent tweaks, batched into one PR.

**Blog listing cards** no longer show the author row. The divider bar came from that row's `border-top`, so both go together, along with the now-unused `AuthorAvatar` import. The featured post at the top of the blog page still names the author in its meta row.

**Hero signup button:** the `btn-pulse` animation is removed. Its keyframes existed only to carry the resting shadow (an animation on `box-shadow` overwrites the property outright, so a separately declared one would never have rendered); with the animation gone the shadow is declared on `.btn` directly, and the `animation: none` in the hover rule that existed purely to defeat the pulse goes with it.

**Learn to Code card:** heading bottom margin 20px → 10px, and the intro is reworded to "Master coding, the core skill we use to communicate our desires to a computer."

🤖 Generated with [Claude Code](https://claude.com/claude-code)