### PR TITLE
Fix e2e landing headline assertions

### DIFF
--- a/app/tests/e2e/auth-flows.test.ts
+++ b/app/tests/e2e/auth-flows.test.ts
@@ -104,7 +104,7 @@ test.describe("Authentication Flows", () => {
     await waitForLoadingToComplete(page);
     await page.locator("h1").waitFor();
     const heading = await page.locator("h1").textContent();
-    expect(heading).toContain("Learn to code and build");
+    expect(heading).toContain("The modern way to learn to code & build");
   }
 
   async function assertSignUpButton(page: Page) {

--- a/app/tests/e2e/home.test.ts
+++ b/app/tests/e2e/home.test.ts
@@ -17,7 +17,7 @@ test.describe("Home Page E2E", () => {
 
   test("should display the marketing headline", async ({ page }) => {
     const headingText = await page.locator("h1").textContent();
-    expect(headingText).toContain("Learn to code and build");
+    expect(headingText).toContain("The modern way to learn to code & build");
   });
 
   test("should have login and signup links", async ({ page }) => {


### PR DESCRIPTION
## The failure

7 e2e specs failed on #1063:

- `tests/e2e/home.test.ts:18` (marketing headline)
- `tests/e2e/auth-flows.test.ts` 169/176/185/204/210/220 (all via the shared `assertLandingPage` helper)

All seven fail with the same assertion:

```
Expected substring: "Learn to code and build"
Received string:    "The modern way to learn to code & build"
```

## Root cause

Nothing to do with the `hu` locale or the re-enabled LanguageSwitcher. The landing page rebuild changed the marketing h1 (`messages.json` -> `"The modern way to learn to <highlight>code & build</highlight>"`) and these two e2e assertions were never updated. The UI is correct, the tests were stale, so the tests are what changed.

## The fix

Both assertions now expect "The modern way to learn to code & build".

## Verified locally

`CI=true pnpm test:e2e tests/e2e/home.test.ts tests/e2e/auth-flows.test.ts` -> 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)