### PR TITLE
e2e: update landing headline assertion after landing page rebuild

### DIFF
--- a/app/tests/e2e/auth-flows.test.ts
+++ b/app/tests/e2e/auth-flows.test.ts
@@ -104,7 +104,7 @@ test.describe("Authentication Flows", () => {
     await waitForLoadingToComplete(page);
     await page.locator("h1").waitFor();
     const heading = await page.locator("h1").textContent();
-    expect(heading).toContain("Learn to code and build");
+    expect(heading).toContain("The modern way to learn to code & build");
   }
 
   async function assertSignUpButton(page: Page) {

--- a/app/tests/e2e/home.test.ts
+++ b/app/tests/e2e/home.test.ts
@@ -17,7 +17,7 @@ test.describe("Home Page E2E", () => {
 
   test("should display the marketing headline", async ({ page }) => {
     const headingText = await page.locator("h1").textContent();
-    expect(headingText).toContain("Learn to code and build");
+    expect(headingText).toContain("The modern way to learn to code & build");
   });
 
   test("should have login and signup links", async ({ page }) => {


### PR DESCRIPTION
The landing page rebuild changed the marketing `h1` to "The modern way to learn to code & build", but `home.test.ts` and `auth-flows.test.ts` still asserted the old "Learn to code and build". Seven specs failed on a plain string mismatch (six of them through the shared `assertLandingPage()` helper) — the page renders correctly, the assertions were stale.

One line changed in each of the two files.

Verified locally: `CI=true pnpm test:e2e tests/e2e/home.test.ts tests/e2e/auth-flows.test.ts` → 20 passed.

Supersedes #1068, which targeted `ihid-hu-production-locale`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)