### PR TITLE
Stop RSC flight data being cacheable at the document's URL

### DIFF
--- a/app/lib/cache/cache-key-generator.ts
+++ b/app/lib/cache/cache-key-generator.ts
@@ -49,15 +49,34 @@ export function normalizeSearchParams(searchParams: URLSearchParams): string {
 }
 
 /**
+ * Query params carrying the cache-key dimensions that aren't in the URL.
+ *
+ * They must be query params rather than a `#deployId@bucket` suffix: the Cache
+ * API parses the key as a URL, and a URL fragment is not part of a request's
+ * identity, so anything after `#` is discarded before the lookup. Written that
+ * way, neither the deploy ID nor the locale bucket reached the key at all, and
+ * entries outlived the deploy that produced them.
+ *
+ * Double-underscored so they can't collide with a real param, and absent from
+ * ALLOWED_PARAMS so a visitor can't forge one and pick their own cache entry.
+ */
+const DEPLOY_PARAM = "__deploy";
+const LANG_PARAM = "__lang";
+
+/**
  * Generate a cache key for the Cache API
  *
- * Format: /blog/post?page=1#abc1234@en
+ * Format: https://jiki.io/blog/post?page=1&__deploy=abc1234&__lang=en
  *
  * Components:
- * - Pathname (preserves locale)
+ * - Origin and pathname (preserves locale)
  * - Normalized query params (page, criteria)
  * - Deploy ID (git SHA)
  * - Locale bucket (the banner's offered language: "en" | "hu" | "none")
+ *
+ * The key is an absolute URL because the Cache API resolves it via `new
+ * Request(key)`, which rejects a relative one. It is built on the incoming
+ * request's own origin, so it is never used to address anything but this zone.
  *
  * Note: Only HTML requests are cached. RSC requests (client-side navigation) are not cached.
  *
@@ -73,5 +92,11 @@ export function generateCacheKey(request: Request, deployId: string): string {
     readCookie(request.headers.get("Cookie"), LOCALE_PREF_COOKIE_NAME)
   );
 
-  return `${url.pathname}${normalizedParams}#${deployId}@${langBucket}`;
+  // normalizeSearchParams has already filtered and sorted the visitor's params;
+  // appending the two internal ones after keeps the whole key deterministic.
+  const key = new URL(`${url.pathname}${normalizedParams}`, url.origin);
+  key.searchParams.set(DEPLOY_PARAM, deployId);
+  key.searchParams.set(LANG_PARAM, langBucket);
+
+  return key.toString();
 }

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -120,14 +120,29 @@ export function middleware(request: NextRequest) {
   }
 
   //
-  // Set cache headers for unauthenticated external URL requests
-  // Skip for RSC requests (client-side navigation)
+  // Set cache headers for unauthenticated external URL requests.
+  //
+  // RSC requests (client-side navigation) are marked explicitly uncacheable
+  // rather than merely skipped. An RSC response is flight data, not a document,
+  // but it is served from the same URL as the document — the two are told apart
+  // only by the `RSC` request header, and Cloudflare varies on nothing but
+  // Accept-Encoding. So if flight data is ever marked publicly cacheable, one
+  // edge node can store it under the document's key and serve raw flight text to
+  // browsers asking for HTML, until it expires. What normally keeps them apart is
+  // the `_rsc=<hash>` cache-buster Next appends to prefetch URLs, but that is an
+  // implementation detail of the client router, not a guarantee: an RSC request
+  // that reaches the bare URL lands on the document's key. Leaving the header
+  // unset let whatever Next emitted decide, which for a prerendered public route
+  // can be `public`. Setting it here closes that off at the origin, for every
+  // RSC request, with or without the buster.
   //
   const isAuthenticated = request.cookies.has(AUTHENTICATION_COOKIE_NAME);
   const isRscRequest = request.headers.has("rsc");
   if (staging) {
     response.headers.set("Cache-Control", "no-store");
-  } else if (!isAuthenticated && !isRscRequest && isCacheableRoute(path)) {
+  } else if (isRscRequest) {
+    response.headers.set("Cache-Control", "private, no-store");
+  } else if (!isAuthenticated && isCacheableRoute(path)) {
     response.headers.set("Cache-Control", "public, max-age=600, s-maxage=600");
     response.headers.set("Vary", "Cookie");
   }

--- a/app/tests/unit/lib/cache/cache-key-generator.test.ts
+++ b/app/tests/unit/lib/cache/cache-key-generator.test.ts
@@ -88,39 +88,39 @@ describe("cache-key-generator", () => {
     it("generates cache key with pathname and deploy ID", () => {
       const request = new Request("https://jiki.io/blog");
       const result = generateCacheKey(request, deployId);
-      expect(result).toBe("/blog#abc1234@none");
+      expect(result).toBe("https://jiki.io/blog?__deploy=abc1234&__lang=none");
     });
 
     it("includes allowed query params", () => {
       const request = new Request("https://jiki.io/blog?page=2");
       const result = generateCacheKey(request, deployId);
-      expect(result).toBe("/blog?page=2#abc1234@none");
+      expect(result).toBe("https://jiki.io/blog?page=2&__deploy=abc1234&__lang=none");
     });
 
     it("strips disallowed query params", () => {
       const request = new Request("https://jiki.io/blog?page=1&utm_source=google&ref=twitter");
       const result = generateCacheKey(request, deployId);
-      expect(result).toBe("/blog?page=1#abc1234@none");
+      expect(result).toBe("https://jiki.io/blog?page=1&__deploy=abc1234&__lang=none");
     });
 
     it("preserves locale in pathname", () => {
       const request = new Request("https://jiki.io/de/blog?page=1");
       const result = generateCacheKey(request, deployId);
-      expect(result).toBe("/de/blog?page=1#abc1234@none");
+      expect(result).toBe("https://jiki.io/de/blog?page=1&__deploy=abc1234&__lang=none");
     });
 
     it("sorts allowed params", () => {
       const request = new Request("https://jiki.io/blog?page=2&criteria=popular");
       const result = generateCacheKey(request, deployId);
-      expect(result).toBe("/blog?criteria=popular&page=2#abc1234@none");
+      expect(result).toBe("https://jiki.io/blog?criteria=popular&page=2&__deploy=abc1234&__lang=none");
     });
 
     it("buckets by the offered banner language from Accept-Language", () => {
       const en = new Request("https://jiki.io/blog", { headers: { "accept-language": "en-US,en;q=0.9" } });
       const hu = new Request("https://jiki.io/blog", { headers: { "accept-language": "hu-HU,hu;q=0.9,en;q=0.8" } });
 
-      expect(generateCacheKey(en, deployId)).toBe("/blog#abc1234@en");
-      expect(generateCacheKey(hu, deployId)).toBe("/blog#abc1234@hu");
+      expect(generateCacheKey(en, deployId)).toBe("https://jiki.io/blog?__deploy=abc1234&__lang=en");
+      expect(generateCacheKey(hu, deployId)).toBe("https://jiki.io/blog?__deploy=abc1234&__lang=hu");
     });
 
     it("separates crawler (no Accept-Language) from browser buckets on the same path", () => {
@@ -129,15 +129,15 @@ describe("cache-key-generator", () => {
 
       // Crawler gets a banner-free page, an English browser gets the "view in
       // English" banner: distinct HTML, so they must be distinct cache entries.
-      expect(generateCacheKey(crawler, deployId)).toBe("/hu/blog#abc1234@none");
-      expect(generateCacheKey(enBrowser, deployId)).toBe("/hu/blog#abc1234@en");
+      expect(generateCacheKey(crawler, deployId)).toBe("https://jiki.io/hu/blog?__deploy=abc1234&__lang=none");
+      expect(generateCacheKey(enBrowser, deployId)).toBe("https://jiki.io/hu/blog?__deploy=abc1234&__lang=en");
     });
 
     // "xx" rather than a real language tag: this asserts the unsupported path, and a
     // real tag makes it fail the day that language launches. "fr" sat here until fr did.
     it("buckets unsupported languages into the default locale", () => {
       const unsupported = new Request("https://jiki.io/blog", { headers: { "accept-language": "xx-XX,xx;q=0.9" } });
-      expect(generateCacheKey(unsupported, deployId)).toBe("/blog#abc1234@en");
+      expect(generateCacheKey(unsupported, deployId)).toBe("https://jiki.io/blog?__deploy=abc1234&__lang=en");
     });
 
     it("generates same key regardless of disallowed param order", () => {
@@ -155,8 +155,8 @@ describe("cache-key-generator", () => {
       const key1 = generateCacheKey(request, "abc1234");
       const key2 = generateCacheKey(request, "def5678");
 
-      expect(key1).toBe("/blog#abc1234@none");
-      expect(key2).toBe("/blog#def5678@none");
+      expect(key1).toBe("https://jiki.io/blog?__deploy=abc1234&__lang=none");
+      expect(key2).toBe("https://jiki.io/blog?__deploy=def5678&__lang=none");
       expect(key1).not.toBe(key2);
     });
 
@@ -175,13 +175,44 @@ describe("cache-key-generator", () => {
         "https://jiki.io/de/help?criteria=top&page=3&utm_source=google&utm_medium=cpc&ref=home"
       );
       const result = generateCacheKey(request, deployId);
-      expect(result).toBe("/de/help?criteria=top&page=3#abc1234@none");
+      expect(result).toBe("https://jiki.io/de/help?criteria=top&page=3&__deploy=abc1234&__lang=none");
     });
 
     it("strips _rsc param from cache key", () => {
       const request = new Request("https://jiki.io/blog?_rsc=1mj2u&page=2");
       const result = generateCacheKey(request, deployId);
-      expect(result).toBe("/blog?page=2#abc1234@none");
+      expect(result).toBe("https://jiki.io/blog?page=2&__deploy=abc1234&__lang=none");
+    });
+
+    // The Cache API resolves a string key via `new Request(key)`, which throws on a
+    // relative URL. A key that throws is swallowed by the wrapper's try/catch and
+    // silently disables the edge cache, so this asserts the key is usable as one.
+    it("produces a key the Cache API can resolve", () => {
+      const request = new Request("https://jiki.io/blog?page=2");
+      const key = generateCacheKey(request, deployId);
+
+      expect(() => new Request(key)).not.toThrow();
+      expect(new URL(key).origin).toBe("https://jiki.io");
+    });
+
+    // The dimensions used to sit in a `#deployId@bucket` fragment, which a URL drops:
+    // every deploy and every language bucket collapsed onto one entry.
+    it("keeps the deploy ID and locale bucket in the resolved request URL", () => {
+      const request = new Request("https://jiki.io/blog", { headers: { "accept-language": "hu-HU" } });
+      const key = generateCacheKey(request, deployId);
+
+      const resolved = new URL(new Request(key).url);
+      expect(resolved.searchParams.get("__deploy")).toBe("abc1234");
+      expect(resolved.searchParams.get("__lang")).toBe("hu");
+    });
+
+    // Otherwise a visitor could pin themselves to another bucket's HTML, or to an
+    // entry from a deploy that has been superseded.
+    it("ignores forged __deploy and __lang params from the visitor", () => {
+      const forged = new Request("https://jiki.io/blog?__deploy=evil&__lang=hu");
+      const clean = new Request("https://jiki.io/blog");
+
+      expect(generateCacheKey(forged, deployId)).toBe(generateCacheKey(clean, deployId));
     });
   });
 });

--- a/app/tests/unit/middleware.test.ts
+++ b/app/tests/unit/middleware.test.ts
@@ -9,8 +9,8 @@ jest.mock("@/lib/env");
 
 const mockIsStaging = isStaging as jest.MockedFunction<typeof isStaging>;
 
-function requestFor(path: string) {
-  return new NextRequest(new URL(`https://staging.jiki.io${path}`));
+function requestFor(path: string, headers?: Record<string, string>) {
+  return new NextRequest(new URL(`https://staging.jiki.io${path}`), { headers });
 }
 
 describe("middleware staging behaviour", () => {
@@ -43,5 +43,51 @@ describe("middleware staging behaviour", () => {
 
     expect(res.headers.get("X-Robots-Tag")).toBeNull();
     expect(res.headers.get("Cache-Control")).toBe("public, max-age=600, s-maxage=600");
+  });
+});
+
+describe("middleware RSC cache headers", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  //
+  // An RSC response is flight data served from the document's own URL, told apart
+  // only by a request header Cloudflare doesn't vary on. If it is ever publicly
+  // cacheable, an edge node can serve raw flight text to a browser asking for HTML.
+  // These assert the header is set explicitly, not merely left unset.
+  //
+  it("marks an RSC response uncacheable on a cacheable public route", () => {
+    mockIsStaging.mockReturnValue(false);
+
+    const res = middleware(requestFor("/", { rsc: "1" }));
+
+    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+
+  it("marks an RSC response uncacheable with no `_rsc` cache-buster in the URL", () => {
+    mockIsStaging.mockReturnValue(false);
+
+    // The buster is what normally keeps prefetches off the document's cache key.
+    // Its absence is exactly the case this guard exists for.
+    const res = middleware(requestFor("/blog", { rsc: "1" }));
+
+    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+
+  it("still serves the public cache header to a document request on the same route", () => {
+    mockIsStaging.mockReturnValue(false);
+
+    const res = middleware(requestFor("/"));
+
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600, s-maxage=600");
+  });
+
+  it("keeps staging's no-store for RSC requests", () => {
+    mockIsStaging.mockReturnValue(true);
+
+    const res = middleware(requestFor("/", { rsc: "1" }));
+
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
   });
 });


### PR DESCRIPTION
## Why

A visitor hit `https://jiki.io/fr` and got the raw RSC flight payload as text instead of the page. It resolved on refresh and has not reproduced since, which is the signature of a poisoned edge-cache entry rather than a bug in the page: per-PoP, and gone once the 600s TTL expired.

An RSC response is flight data served from the document's own URL. The two are distinguished only by the `RSC` request header, and Cloudflare varies on nothing but `Accept-Encoding`. So if flight data is ever marked publicly cacheable, one edge node can store it under the document's key and serve it to every browser asking for HTML until it expires.

`middleware.ts` only ever *skipped* RSC requests when setting cache headers, never marked them uncacheable, so an RSC response shipped whatever Next emitted, which for a prerendered public route can be `public`. The one thing keeping those off the document's key is the `_rsc=<hash>` cache-buster Next appends to prefetch URLs, but that is an implementation detail of the client router, not a guarantee: an RSC request that reaches the bare URL lands on the document's key.

`/fr` being freshly launched is the aggravating factor. Its first RSC traffic and its first cache fill happened at roughly the same moment, which is when that race is winnable.

## What

**The fix:** set `Cache-Control: private, no-store` on RSC responses explicitly, with or without the buster.

**Two adjacent bugs in the edge cache key**, found while tracing the layers:

- The key put the deploy ID and locale bucket in a `#deployId@bucket` suffix. The Cache API parses the key as a URL, and a fragment is not part of a request's identity, so both were discarded before the lookup. Entries outlived the deploy that produced them, and the locale bucketing that exists to stop one language's banner poisoning another's HTML did nothing. They are now query params.
- The key was relative. The Cache API resolves a string key via `new Request(key)`, which rejects a relative URL; the throw was swallowed by the wrapper's `try`/`catch`, silently falling through to the origin on every request. It is now absolute, built on the incoming request's own origin.

The two new params are double-underscored and absent from `ALLOWED_PARAMS`, so a visitor cannot forge one to pin themselves to another bucket's HTML or to a superseded deploy.

## Testing

Full suite green via the pre-commit hook (2376 tests, 199 suites). New cases cover:

- an RSC request on a cacheable public route gets `private, no-store`
- the same with no `_rsc` buster in the URL, which is the case the guard exists for
- a document request on the same route still gets the public cache header
- staging's `no-store` still wins for RSC
- the cache key resolves through `new Request(key)`
- the deploy ID and locale bucket survive into the resolved request URL
- forged `__deploy` / `__lang` params are ignored

**Not verified against production:** the failure is per-edge-node and could not be reproduced on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhefeEkMsnvx87boCj3UVe